### PR TITLE
Windows compatibility

### DIFF
--- a/nimcuda.nimble
+++ b/nimcuda.nimble
@@ -13,9 +13,13 @@ requires "nim >= 0.16.0"
 import ospaths, strutils
 
 proc patch(libName: string): string =
+  when defined(windows):
+    let libpath = getEnv("CUDA_PATH") / "include" / libName
+  else:
+    let libpath = "/usr/local/cuda/include" / libName
+
   let
     simpleLibPath = "include" / libName
-    libPath = "/usr/local/cuda/include" / libName
     patchPath = "c2nim" / libName
     outPath = "headers" / libName
     libContent =

--- a/nimcuda.nimble
+++ b/nimcuda.nimble
@@ -90,8 +90,12 @@ proc exampleConfig() =
   --stacktrace: on
   --linetrace: on
   --debuginfo
-  --cincludes: "/usr/local/cuda/include"
-  --clibdir: "/usr/local/cuda/lib64"
+  when defined(windows):
+    switch("cincludes", getenv("CUDA_PATH") / "include")
+    switch("clibdir", getenv("CUDA_PATH") / "lib/x64")
+  else:
+    --cincludes: "/usr/local/cuda/include"
+    --clibdir: "/usr/local/cuda/lib64"
   --path: "."
   --run
 

--- a/nimcuda/cublas_api.nim
+++ b/nimcuda/cublas_api.nim
@@ -1,13 +1,16 @@
  {.deadCodeElim: on.}
 when defined(windows):
-  const
-    libName = "cublas.dll"
+  import os
+  {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cublas.lib" & "\"".}
+  {.pragma: dyn.}
 elif defined(macosx):
   const
     libName = "libcublas.dylib"
+  {.pragma: dyn, dynlib: libName.}
 else:
   const
     libName = "libcublas.so"
+  {.pragma: dyn, dynlib: libName.}
 type
   half* = object
     x*: cushort
@@ -114,26 +117,26 @@ when not defined(CUBLAS_API_H):
   type
     cublasHandle_t* = ptr cublasContext
   proc cublasCreate_v2*(handle: ptr cublasHandle_t): cublasStatus_t {.cdecl,
-      importc: "cublasCreate_v2", dynlib: libName.}
+      importc: "cublasCreate_v2", dyn.}
   proc cublasDestroy_v2*(handle: cublasHandle_t): cublasStatus_t {.cdecl,
-      importc: "cublasDestroy_v2", dynlib: libName.}
+      importc: "cublasDestroy_v2", dyn.}
   proc cublasGetVersion_v2*(handle: cublasHandle_t; version: ptr cint): cublasStatus_t {.
-      cdecl, importc: "cublasGetVersion_v2", dynlib: libName.}
+      cdecl, importc: "cublasGetVersion_v2", dyn.}
   proc cublasGetProperty*(`type`: libraryPropertyType; value: ptr cint): cublasStatus_t {.
-      cdecl, importc: "cublasGetProperty", dynlib: libName.}
+      cdecl, importc: "cublasGetProperty", dyn.}
   proc cublasSetStream_v2*(handle: cublasHandle_t; streamId: cudaStream_t): cublasStatus_t {.
-      cdecl, importc: "cublasSetStream_v2", dynlib: libName.}
+      cdecl, importc: "cublasSetStream_v2", dyn.}
   proc cublasGetStream_v2*(handle: cublasHandle_t; streamId: ptr cudaStream_t): cublasStatus_t {.
-      cdecl, importc: "cublasGetStream_v2", dynlib: libName.}
+      cdecl, importc: "cublasGetStream_v2", dyn.}
   proc cublasGetPointerMode_v2*(handle: cublasHandle_t;
                                mode: ptr cublasPointerMode_t): cublasStatus_t {.
-      cdecl, importc: "cublasGetPointerMode_v2", dynlib: libName.}
+      cdecl, importc: "cublasGetPointerMode_v2", dyn.}
   proc cublasSetPointerMode_v2*(handle: cublasHandle_t; mode: cublasPointerMode_t): cublasStatus_t {.
-      cdecl, importc: "cublasSetPointerMode_v2", dynlib: libName.}
+      cdecl, importc: "cublasSetPointerMode_v2", dyn.}
   proc cublasGetAtomicsMode*(handle: cublasHandle_t; mode: ptr cublasAtomicsMode_t): cublasStatus_t {.
-      cdecl, importc: "cublasGetAtomicsMode", dynlib: libName.}
+      cdecl, importc: "cublasGetAtomicsMode", dyn.}
   proc cublasSetAtomicsMode*(handle: cublasHandle_t; mode: cublasAtomicsMode_t): cublasStatus_t {.
-      cdecl, importc: "cublasSetAtomicsMode", dynlib: libName.}
+      cdecl, importc: "cublasSetAtomicsMode", dyn.}
   ##  
   ##  cublasStatus_t 
   ##  cublasSetVector (int n, int elemSize, const void *x, int incx, 
@@ -159,7 +162,7 @@ when not defined(CUBLAS_API_H):
   ## 
   proc cublasSetVector*(n: cint; elemSize: cint; x: pointer; incx: cint;
                        devicePtr: pointer; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasSetVector", dynlib: libName.}
+      importc: "cublasSetVector", dyn.}
   ##  
   ##  cublasStatus_t 
   ##  cublasGetVector (int n, int elemSize, const void *x, int incx, 
@@ -185,7 +188,7 @@ when not defined(CUBLAS_API_H):
   ## 
   proc cublasGetVector*(n: cint; elemSize: cint; x: pointer; incx: cint; y: pointer;
                        incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasGetVector", dynlib: libName.}
+      importc: "cublasGetVector", dyn.}
   ## 
   ##  cublasStatus_t 
   ##  cublasSetMatrix (int rows, int cols, int elemSize, const void *A, 
@@ -209,7 +212,7 @@ when not defined(CUBLAS_API_H):
   ## 
   proc cublasSetMatrix*(rows: cint; cols: cint; elemSize: cint; A: pointer; lda: cint;
                        B: pointer; ldb: cint): cublasStatus_t {.cdecl,
-      importc: "cublasSetMatrix", dynlib: libName.}
+      importc: "cublasSetMatrix", dyn.}
   ## 
   ##  cublasStatus_t 
   ##  cublasGetMatrix (int rows, int cols, int elemSize, const void *A, 
@@ -232,7 +235,7 @@ when not defined(CUBLAS_API_H):
   ## 
   proc cublasGetMatrix*(rows: cint; cols: cint; elemSize: cint; A: pointer; lda: cint;
                        B: pointer; ldb: cint): cublasStatus_t {.cdecl,
-      importc: "cublasGetMatrix", dynlib: libName.}
+      importc: "cublasGetMatrix", dyn.}
   ##  
   ##  cublasStatus 
   ##  cublasSetVectorAsync ( int n, int elemSize, const void *x, int incx, 
@@ -251,7 +254,7 @@ when not defined(CUBLAS_API_H):
   ## 
   proc cublasSetVectorAsync*(n: cint; elemSize: cint; hostPtr: pointer; incx: cint;
                             devicePtr: pointer; incy: cint; stream: cudaStream_t): cublasStatus_t {.
-      cdecl, importc: "cublasSetVectorAsync", dynlib: libName.}
+      cdecl, importc: "cublasSetVectorAsync", dyn.}
   ##  
   ##  cublasStatus 
   ##  cublasGetVectorAsync( int n, int elemSize, const void *x, int incx, 
@@ -270,7 +273,7 @@ when not defined(CUBLAS_API_H):
   ## 
   proc cublasGetVectorAsync*(n: cint; elemSize: cint; devicePtr: pointer; incx: cint;
                             hostPtr: pointer; incy: cint; stream: cudaStream_t): cublasStatus_t {.
-      cdecl, importc: "cublasGetVectorAsync", dynlib: libName.}
+      cdecl, importc: "cublasGetVectorAsync", dyn.}
   ## 
   ##  cublasStatus_t 
   ##  cublasSetMatrixAsync (int rows, int cols, int elemSize, const void *A, 
@@ -290,7 +293,7 @@ when not defined(CUBLAS_API_H):
   ## 
   proc cublasSetMatrixAsync*(rows: cint; cols: cint; elemSize: cint; A: pointer;
                             lda: cint; B: pointer; ldb: cint; stream: cudaStream_t): cublasStatus_t {.
-      cdecl, importc: "cublasSetMatrixAsync", dynlib: libName.}
+      cdecl, importc: "cublasSetMatrixAsync", dyn.}
   ## 
   ##  cublasStatus_t 
   ##  cublasGetMatrixAsync (int rows, int cols, int elemSize, const void *A, 
@@ -309,262 +312,262 @@ when not defined(CUBLAS_API_H):
   ## 
   proc cublasGetMatrixAsync*(rows: cint; cols: cint; elemSize: cint; A: pointer;
                             lda: cint; B: pointer; ldb: cint; stream: cudaStream_t): cublasStatus_t {.
-      cdecl, importc: "cublasGetMatrixAsync", dynlib: libName.}
+      cdecl, importc: "cublasGetMatrixAsync", dyn.}
   proc cublasXerbla*(srName: cstring; info: cint) {.cdecl, importc: "cublasXerbla",
-      dynlib: libName.}
+      dyn.}
   ##  ---------------- CUBLAS BLAS1 functions ----------------
   proc cublasNrm2Ex*(handle: cublasHandle_t; n: cint; x: pointer; xType: cudaDataType;
                     incx: cint; result: pointer; resultType: cudaDataType;
                     executionType: cudaDataType): cublasStatus_t {.cdecl,
-      importc: "cublasNrm2Ex", dynlib: libName.}
+      importc: "cublasNrm2Ex", dyn.}
   ##  host or device pointer
   proc cublasSnrm2_v2*(handle: cublasHandle_t; n: cint; x: ptr cfloat; incx: cint;
                       result: ptr cfloat): cublasStatus_t {.cdecl,
-      importc: "cublasSnrm2_v2", dynlib: libName.}
+      importc: "cublasSnrm2_v2", dyn.}
   ##  host or device pointer
   proc cublasDnrm2_v2*(handle: cublasHandle_t; n: cint; x: ptr cdouble; incx: cint;
                       result: ptr cdouble): cublasStatus_t {.cdecl,
-      importc: "cublasDnrm2_v2", dynlib: libName.}
+      importc: "cublasDnrm2_v2", dyn.}
   ##  host or device pointer
   proc cublasScnrm2_v2*(handle: cublasHandle_t; n: cint; x: ptr cuComplex; incx: cint;
                        result: ptr cfloat): cublasStatus_t {.cdecl,
-      importc: "cublasScnrm2_v2", dynlib: libName.}
+      importc: "cublasScnrm2_v2", dyn.}
   ##  host or device pointer
   proc cublasDznrm2_v2*(handle: cublasHandle_t; n: cint; x: ptr cuDoubleComplex;
                        incx: cint; result: ptr cdouble): cublasStatus_t {.cdecl,
-      importc: "cublasDznrm2_v2", dynlib: libName.}
+      importc: "cublasDznrm2_v2", dyn.}
   ##  host or device pointer
   proc cublasDotEx*(handle: cublasHandle_t; n: cint; x: pointer; xType: cudaDataType;
                    incx: cint; y: pointer; yType: cudaDataType; incy: cint;
                    result: pointer; resultType: cudaDataType;
                    executionType: cudaDataType): cublasStatus_t {.cdecl,
-      importc: "cublasDotEx", dynlib: libName.}
+      importc: "cublasDotEx", dyn.}
   proc cublasDotcEx*(handle: cublasHandle_t; n: cint; x: pointer; xType: cudaDataType;
                     incx: cint; y: pointer; yType: cudaDataType; incy: cint;
                     result: pointer; resultType: cudaDataType;
                     executionType: cudaDataType): cublasStatus_t {.cdecl,
-      importc: "cublasDotcEx", dynlib: libName.}
+      importc: "cublasDotcEx", dyn.}
   proc cublasSdot_v2*(handle: cublasHandle_t; n: cint; x: ptr cfloat; incx: cint;
                      y: ptr cfloat; incy: cint; result: ptr cfloat): cublasStatus_t {.
-      cdecl, importc: "cublasSdot_v2", dynlib: libName.}
+      cdecl, importc: "cublasSdot_v2", dyn.}
   ##  host or device pointer
   proc cublasDdot_v2*(handle: cublasHandle_t; n: cint; x: ptr cdouble; incx: cint;
                      y: ptr cdouble; incy: cint; result: ptr cdouble): cublasStatus_t {.
-      cdecl, importc: "cublasDdot_v2", dynlib: libName.}
+      cdecl, importc: "cublasDdot_v2", dyn.}
   ##  host or device pointer
   proc cublasCdotu_v2*(handle: cublasHandle_t; n: cint; x: ptr cuComplex; incx: cint;
                       y: ptr cuComplex; incy: cint; result: ptr cuComplex): cublasStatus_t {.
-      cdecl, importc: "cublasCdotu_v2", dynlib: libName.}
+      cdecl, importc: "cublasCdotu_v2", dyn.}
   ##  host or device pointer
   proc cublasCdotc_v2*(handle: cublasHandle_t; n: cint; x: ptr cuComplex; incx: cint;
                       y: ptr cuComplex; incy: cint; result: ptr cuComplex): cublasStatus_t {.
-      cdecl, importc: "cublasCdotc_v2", dynlib: libName.}
+      cdecl, importc: "cublasCdotc_v2", dyn.}
   ##  host or device pointer
   proc cublasZdotu_v2*(handle: cublasHandle_t; n: cint; x: ptr cuDoubleComplex;
                       incx: cint; y: ptr cuDoubleComplex; incy: cint;
                       result: ptr cuDoubleComplex): cublasStatus_t {.cdecl,
-      importc: "cublasZdotu_v2", dynlib: libName.}
+      importc: "cublasZdotu_v2", dyn.}
   ##  host or device pointer
   proc cublasZdotc_v2*(handle: cublasHandle_t; n: cint; x: ptr cuDoubleComplex;
                       incx: cint; y: ptr cuDoubleComplex; incy: cint;
                       result: ptr cuDoubleComplex): cublasStatus_t {.cdecl,
-      importc: "cublasZdotc_v2", dynlib: libName.}
+      importc: "cublasZdotc_v2", dyn.}
   ##  host or device pointer
   proc cublasScalEx*(handle: cublasHandle_t; n: cint; alpha: pointer;
                     alphaType: cudaDataType; x: pointer; xType: cudaDataType;
                     incx: cint; executionType: cudaDataType): cublasStatus_t {.cdecl,
-      importc: "cublasScalEx", dynlib: libName.}
+      importc: "cublasScalEx", dyn.}
     ##  host or device pointer
   proc cublasSscal_v2*(handle: cublasHandle_t; n: cint; alpha: ptr cfloat;
                       x: ptr cfloat; incx: cint): cublasStatus_t {.cdecl,
-      importc: "cublasSscal_v2", dynlib: libName.}
+      importc: "cublasSscal_v2", dyn.}
     ##  host or device pointer
   proc cublasDscal_v2*(handle: cublasHandle_t; n: cint; alpha: ptr cdouble;
                       x: ptr cdouble; incx: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDscal_v2", dynlib: libName.}
+      importc: "cublasDscal_v2", dyn.}
     ##  host or device pointer
   proc cublasCscal_v2*(handle: cublasHandle_t; n: cint; alpha: ptr cuComplex;
                       x: ptr cuComplex; incx: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCscal_v2", dynlib: libName.}
+      importc: "cublasCscal_v2", dyn.}
     ##  host or device pointer
   proc cublasCsscal_v2*(handle: cublasHandle_t; n: cint; alpha: ptr cfloat;
                        x: ptr cuComplex; incx: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCsscal_v2", dynlib: libName.}
+      importc: "cublasCsscal_v2", dyn.}
     ##  host or device pointer
   proc cublasZscal_v2*(handle: cublasHandle_t; n: cint; alpha: ptr cuDoubleComplex;
                       x: ptr cuDoubleComplex; incx: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZscal_v2", dynlib: libName.}
+      importc: "cublasZscal_v2", dyn.}
     ##  host or device pointer
   proc cublasZdscal_v2*(handle: cublasHandle_t; n: cint; alpha: ptr cdouble;
                        x: ptr cuDoubleComplex; incx: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZdscal_v2", dynlib: libName.}
+      importc: "cublasZdscal_v2", dyn.}
     ##  host or device pointer
   proc cublasAxpyEx*(handle: cublasHandle_t; n: cint; alpha: pointer;
                     alphaType: cudaDataType; x: pointer; xType: cudaDataType;
                     incx: cint; y: pointer; yType: cudaDataType; incy: cint;
                     executiontype: cudaDataType): cublasStatus_t {.cdecl,
-      importc: "cublasAxpyEx", dynlib: libName.}
+      importc: "cublasAxpyEx", dyn.}
     ##  host or device pointer
   proc cublasSaxpy_v2*(handle: cublasHandle_t; n: cint; alpha: ptr cfloat;
                       x: ptr cfloat; incx: cint; y: ptr cfloat; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSaxpy_v2", dynlib: libName.}
+      cdecl, importc: "cublasSaxpy_v2", dyn.}
     ##  host or device pointer
   proc cublasDaxpy_v2*(handle: cublasHandle_t; n: cint; alpha: ptr cdouble;
                       x: ptr cdouble; incx: cint; y: ptr cdouble; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDaxpy_v2", dynlib: libName.}
+      cdecl, importc: "cublasDaxpy_v2", dyn.}
     ##  host or device pointer
   proc cublasCaxpy_v2*(handle: cublasHandle_t; n: cint; alpha: ptr cuComplex;
                       x: ptr cuComplex; incx: cint; y: ptr cuComplex; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCaxpy_v2", dynlib: libName.}
+      cdecl, importc: "cublasCaxpy_v2", dyn.}
     ##  host or device pointer
   proc cublasZaxpy_v2*(handle: cublasHandle_t; n: cint; alpha: ptr cuDoubleComplex;
                       x: ptr cuDoubleComplex; incx: cint; y: ptr cuDoubleComplex;
                       incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZaxpy_v2", dynlib: libName.}
+      importc: "cublasZaxpy_v2", dyn.}
     ##  host or device pointer
   proc cublasScopy_v2*(handle: cublasHandle_t; n: cint; x: ptr cfloat; incx: cint;
                       y: ptr cfloat; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasScopy_v2", dynlib: libName.}
+      importc: "cublasScopy_v2", dyn.}
   proc cublasDcopy_v2*(handle: cublasHandle_t; n: cint; x: ptr cdouble; incx: cint;
                       y: ptr cdouble; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDcopy_v2", dynlib: libName.}
+      importc: "cublasDcopy_v2", dyn.}
   proc cublasCcopy_v2*(handle: cublasHandle_t; n: cint; x: ptr cuComplex; incx: cint;
                       y: ptr cuComplex; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCcopy_v2", dynlib: libName.}
+      importc: "cublasCcopy_v2", dyn.}
   proc cublasZcopy_v2*(handle: cublasHandle_t; n: cint; x: ptr cuDoubleComplex;
                       incx: cint; y: ptr cuDoubleComplex; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasZcopy_v2", dynlib: libName.}
+      cdecl, importc: "cublasZcopy_v2", dyn.}
   proc cublasSswap_v2*(handle: cublasHandle_t; n: cint; x: ptr cfloat; incx: cint;
                       y: ptr cfloat; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasSswap_v2", dynlib: libName.}
+      importc: "cublasSswap_v2", dyn.}
   proc cublasDswap_v2*(handle: cublasHandle_t; n: cint; x: ptr cdouble; incx: cint;
                       y: ptr cdouble; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDswap_v2", dynlib: libName.}
+      importc: "cublasDswap_v2", dyn.}
   proc cublasCswap_v2*(handle: cublasHandle_t; n: cint; x: ptr cuComplex; incx: cint;
                       y: ptr cuComplex; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCswap_v2", dynlib: libName.}
+      importc: "cublasCswap_v2", dyn.}
   proc cublasZswap_v2*(handle: cublasHandle_t; n: cint; x: ptr cuDoubleComplex;
                       incx: cint; y: ptr cuDoubleComplex; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasZswap_v2", dynlib: libName.}
+      cdecl, importc: "cublasZswap_v2", dyn.}
   proc cublasIsamax_v2*(handle: cublasHandle_t; n: cint; x: ptr cfloat; incx: cint;
                        result: ptr cint): cublasStatus_t {.cdecl,
-      importc: "cublasIsamax_v2", dynlib: libName.}
+      importc: "cublasIsamax_v2", dyn.}
   ##  host or device pointer
   proc cublasIdamax_v2*(handle: cublasHandle_t; n: cint; x: ptr cdouble; incx: cint;
                        result: ptr cint): cublasStatus_t {.cdecl,
-      importc: "cublasIdamax_v2", dynlib: libName.}
+      importc: "cublasIdamax_v2", dyn.}
   ##  host or device pointer
   proc cublasIcamax_v2*(handle: cublasHandle_t; n: cint; x: ptr cuComplex; incx: cint;
                        result: ptr cint): cublasStatus_t {.cdecl,
-      importc: "cublasIcamax_v2", dynlib: libName.}
+      importc: "cublasIcamax_v2", dyn.}
   ##  host or device pointer
   proc cublasIzamax_v2*(handle: cublasHandle_t; n: cint; x: ptr cuDoubleComplex;
                        incx: cint; result: ptr cint): cublasStatus_t {.cdecl,
-      importc: "cublasIzamax_v2", dynlib: libName.}
+      importc: "cublasIzamax_v2", dyn.}
   ##  host or device pointer
   proc cublasIsamin_v2*(handle: cublasHandle_t; n: cint; x: ptr cfloat; incx: cint;
                        result: ptr cint): cublasStatus_t {.cdecl,
-      importc: "cublasIsamin_v2", dynlib: libName.}
+      importc: "cublasIsamin_v2", dyn.}
   ##  host or device pointer
   proc cublasIdamin_v2*(handle: cublasHandle_t; n: cint; x: ptr cdouble; incx: cint;
                        result: ptr cint): cublasStatus_t {.cdecl,
-      importc: "cublasIdamin_v2", dynlib: libName.}
+      importc: "cublasIdamin_v2", dyn.}
   ##  host or device pointer
   proc cublasIcamin_v2*(handle: cublasHandle_t; n: cint; x: ptr cuComplex; incx: cint;
                        result: ptr cint): cublasStatus_t {.cdecl,
-      importc: "cublasIcamin_v2", dynlib: libName.}
+      importc: "cublasIcamin_v2", dyn.}
   ##  host or device pointer
   proc cublasIzamin_v2*(handle: cublasHandle_t; n: cint; x: ptr cuDoubleComplex;
                        incx: cint; result: ptr cint): cublasStatus_t {.cdecl,
-      importc: "cublasIzamin_v2", dynlib: libName.}
+      importc: "cublasIzamin_v2", dyn.}
   ##  host or device pointer
   proc cublasSasum_v2*(handle: cublasHandle_t; n: cint; x: ptr cfloat; incx: cint;
                       result: ptr cfloat): cublasStatus_t {.cdecl,
-      importc: "cublasSasum_v2", dynlib: libName.}
+      importc: "cublasSasum_v2", dyn.}
   ##  host or device pointer
   proc cublasDasum_v2*(handle: cublasHandle_t; n: cint; x: ptr cdouble; incx: cint;
                       result: ptr cdouble): cublasStatus_t {.cdecl,
-      importc: "cublasDasum_v2", dynlib: libName.}
+      importc: "cublasDasum_v2", dyn.}
   ##  host or device pointer
   proc cublasScasum_v2*(handle: cublasHandle_t; n: cint; x: ptr cuComplex; incx: cint;
                        result: ptr cfloat): cublasStatus_t {.cdecl,
-      importc: "cublasScasum_v2", dynlib: libName.}
+      importc: "cublasScasum_v2", dyn.}
   ##  host or device pointer
   proc cublasDzasum_v2*(handle: cublasHandle_t; n: cint; x: ptr cuDoubleComplex;
                        incx: cint; result: ptr cdouble): cublasStatus_t {.cdecl,
-      importc: "cublasDzasum_v2", dynlib: libName.}
+      importc: "cublasDzasum_v2", dyn.}
   ##  host or device pointer
   proc cublasSrot_v2*(handle: cublasHandle_t; n: cint; x: ptr cfloat; incx: cint;
                      y: ptr cfloat; incy: cint; c: ptr cfloat; s: ptr cfloat): cublasStatus_t {.
-      cdecl, importc: "cublasSrot_v2", dynlib: libName.}
+      cdecl, importc: "cublasSrot_v2", dyn.}
     ##  host or device pointer
   ##  host or device pointer
   proc cublasDrot_v2*(handle: cublasHandle_t; n: cint; x: ptr cdouble; incx: cint;
                      y: ptr cdouble; incy: cint; c: ptr cdouble; s: ptr cdouble): cublasStatus_t {.
-      cdecl, importc: "cublasDrot_v2", dynlib: libName.}
+      cdecl, importc: "cublasDrot_v2", dyn.}
     ##  host or device pointer
   ##  host or device pointer
   proc cublasCrot_v2*(handle: cublasHandle_t; n: cint; x: ptr cuComplex; incx: cint;
                      y: ptr cuComplex; incy: cint; c: ptr cfloat; s: ptr cuComplex): cublasStatus_t {.
-      cdecl, importc: "cublasCrot_v2", dynlib: libName.}
+      cdecl, importc: "cublasCrot_v2", dyn.}
     ##  host or device pointer
   ##  host or device pointer
   proc cublasCsrot_v2*(handle: cublasHandle_t; n: cint; x: ptr cuComplex; incx: cint;
                       y: ptr cuComplex; incy: cint; c: ptr cfloat; s: ptr cfloat): cublasStatus_t {.
-      cdecl, importc: "cublasCsrot_v2", dynlib: libName.}
+      cdecl, importc: "cublasCsrot_v2", dyn.}
     ##  host or device pointer
   ##  host or device pointer
   proc cublasZrot_v2*(handle: cublasHandle_t; n: cint; x: ptr cuDoubleComplex;
                      incx: cint; y: ptr cuDoubleComplex; incy: cint; c: ptr cdouble;
                      s: ptr cuDoubleComplex): cublasStatus_t {.cdecl,
-      importc: "cublasZrot_v2", dynlib: libName.}
+      importc: "cublasZrot_v2", dyn.}
     ##  host or device pointer
   ##  host or device pointer
   proc cublasZdrot_v2*(handle: cublasHandle_t; n: cint; x: ptr cuDoubleComplex;
                       incx: cint; y: ptr cuDoubleComplex; incy: cint; c: ptr cdouble;
                       s: ptr cdouble): cublasStatus_t {.cdecl,
-      importc: "cublasZdrot_v2", dynlib: libName.}
+      importc: "cublasZdrot_v2", dyn.}
     ##  host or device pointer
   ##  host or device pointer
   proc cublasSrotg_v2*(handle: cublasHandle_t; a: ptr cfloat; b: ptr cfloat;
                       c: ptr cfloat; s: ptr cfloat): cublasStatus_t {.cdecl,
-      importc: "cublasSrotg_v2", dynlib: libName.}
+      importc: "cublasSrotg_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
     ##  host or device pointer
   ##  host or device pointer
   proc cublasDrotg_v2*(handle: cublasHandle_t; a: ptr cdouble; b: ptr cdouble;
                       c: ptr cdouble; s: ptr cdouble): cublasStatus_t {.cdecl,
-      importc: "cublasDrotg_v2", dynlib: libName.}
+      importc: "cublasDrotg_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
     ##  host or device pointer
   ##  host or device pointer
   proc cublasCrotg_v2*(handle: cublasHandle_t; a: ptr cuComplex; b: ptr cuComplex;
                       c: ptr cfloat; s: ptr cuComplex): cublasStatus_t {.cdecl,
-      importc: "cublasCrotg_v2", dynlib: libName.}
+      importc: "cublasCrotg_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
     ##  host or device pointer
   ##  host or device pointer
   proc cublasZrotg_v2*(handle: cublasHandle_t; a: ptr cuDoubleComplex;
                       b: ptr cuDoubleComplex; c: ptr cdouble; s: ptr cuDoubleComplex): cublasStatus_t {.
-      cdecl, importc: "cublasZrotg_v2", dynlib: libName.}
+      cdecl, importc: "cublasZrotg_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
     ##  host or device pointer
   ##  host or device pointer
   proc cublasSrotm_v2*(handle: cublasHandle_t; n: cint; x: ptr cfloat; incx: cint;
                       y: ptr cfloat; incy: cint; param: ptr cfloat): cublasStatus_t {.
-      cdecl, importc: "cublasSrotm_v2", dynlib: libName.}
+      cdecl, importc: "cublasSrotm_v2", dyn.}
   ##  host or device pointer
   proc cublasDrotm_v2*(handle: cublasHandle_t; n: cint; x: ptr cdouble; incx: cint;
                       y: ptr cdouble; incy: cint; param: ptr cdouble): cublasStatus_t {.
-      cdecl, importc: "cublasDrotm_v2", dynlib: libName.}
+      cdecl, importc: "cublasDrotm_v2", dyn.}
   ##  host or device pointer
   proc cublasSrotmg_v2*(handle: cublasHandle_t; d1: ptr cfloat; d2: ptr cfloat;
                        x1: ptr cfloat; y1: ptr cfloat; param: ptr cfloat): cublasStatus_t {.
-      cdecl, importc: "cublasSrotmg_v2", dynlib: libName.}
+      cdecl, importc: "cublasSrotmg_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
     ##  host or device pointer
@@ -572,7 +575,7 @@ when not defined(CUBLAS_API_H):
   ##  host or device pointer
   proc cublasDrotmg_v2*(handle: cublasHandle_t; d1: ptr cdouble; d2: ptr cdouble;
                        x1: ptr cdouble; y1: ptr cdouble; param: ptr cdouble): cublasStatus_t {.
-      cdecl, importc: "cublasDrotmg_v2", dynlib: libName.}
+      cdecl, importc: "cublasDrotmg_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
     ##  host or device pointer
@@ -583,28 +586,28 @@ when not defined(CUBLAS_API_H):
   proc cublasSgemv_v2*(handle: cublasHandle_t; trans: cublasOperation_t; m: cint;
                       n: cint; alpha: ptr cfloat; A: ptr cfloat; lda: cint; x: ptr cfloat;
                       incx: cint; beta: ptr cfloat; y: ptr cfloat; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSgemv_v2", dynlib: libName.}
+      cdecl, importc: "cublasSgemv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasDgemv_v2*(handle: cublasHandle_t; trans: cublasOperation_t; m: cint;
                       n: cint; alpha: ptr cdouble; A: ptr cdouble; lda: cint;
                       x: ptr cdouble; incx: cint; beta: ptr cdouble; y: ptr cdouble;
                       incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDgemv_v2", dynlib: libName.}
+      importc: "cublasDgemv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasCgemv_v2*(handle: cublasHandle_t; trans: cublasOperation_t; m: cint;
                       n: cint; alpha: ptr cuComplex; A: ptr cuComplex; lda: cint;
                       x: ptr cuComplex; incx: cint; beta: ptr cuComplex;
                       y: ptr cuComplex; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCgemv_v2", dynlib: libName.}
+      importc: "cublasCgemv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZgemv_v2*(handle: cublasHandle_t; trans: cublasOperation_t; m: cint;
                       n: cint; alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex;
                       lda: cint; x: ptr cuDoubleComplex; incx: cint;
                       beta: ptr cuDoubleComplex; y: ptr cuDoubleComplex; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasZgemv_v2", dynlib: libName.}
+      cdecl, importc: "cublasZgemv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  GBMV
@@ -612,21 +615,21 @@ when not defined(CUBLAS_API_H):
                       n: cint; kl: cint; ku: cint; alpha: ptr cfloat; A: ptr cfloat;
                       lda: cint; x: ptr cfloat; incx: cint; beta: ptr cfloat;
                       y: ptr cfloat; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasSgbmv_v2", dynlib: libName.}
+      importc: "cublasSgbmv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasDgbmv_v2*(handle: cublasHandle_t; trans: cublasOperation_t; m: cint;
                       n: cint; kl: cint; ku: cint; alpha: ptr cdouble; A: ptr cdouble;
                       lda: cint; x: ptr cdouble; incx: cint; beta: ptr cdouble;
                       y: ptr cdouble; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDgbmv_v2", dynlib: libName.}
+      importc: "cublasDgbmv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasCgbmv_v2*(handle: cublasHandle_t; trans: cublasOperation_t; m: cint;
                       n: cint; kl: cint; ku: cint; alpha: ptr cuComplex;
                       A: ptr cuComplex; lda: cint; x: ptr cuComplex; incx: cint;
                       beta: ptr cuComplex; y: ptr cuComplex; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCgbmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasCgbmv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZgbmv_v2*(handle: cublasHandle_t; trans: cublasOperation_t; m: cint;
@@ -634,344 +637,344 @@ when not defined(CUBLAS_API_H):
                       A: ptr cuDoubleComplex; lda: cint; x: ptr cuDoubleComplex;
                       incx: cint; beta: ptr cuDoubleComplex; y: ptr cuDoubleComplex;
                       incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZgbmv_v2", dynlib: libName.}
+      importc: "cublasZgbmv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  TRMV
   proc cublasStrmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       A: ptr cfloat; lda: cint; x: ptr cfloat; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasStrmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasStrmv_v2", dyn.}
   proc cublasDtrmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       A: ptr cdouble; lda: cint; x: ptr cdouble; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDtrmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasDtrmv_v2", dyn.}
   proc cublasCtrmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       A: ptr cuComplex; lda: cint; x: ptr cuComplex; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCtrmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasCtrmv_v2", dyn.}
   proc cublasZtrmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       A: ptr cuDoubleComplex; lda: cint; x: ptr cuDoubleComplex;
                       incx: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZtrmv_v2", dynlib: libName.}
+      importc: "cublasZtrmv_v2", dyn.}
   ##  TBMV
   proc cublasStbmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       k: cint; A: ptr cfloat; lda: cint; x: ptr cfloat; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasStbmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasStbmv_v2", dyn.}
   proc cublasDtbmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       k: cint; A: ptr cdouble; lda: cint; x: ptr cdouble; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDtbmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasDtbmv_v2", dyn.}
   proc cublasCtbmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       k: cint; A: ptr cuComplex; lda: cint; x: ptr cuComplex; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCtbmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasCtbmv_v2", dyn.}
   proc cublasZtbmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       k: cint; A: ptr cuDoubleComplex; lda: cint;
                       x: ptr cuDoubleComplex; incx: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZtbmv_v2", dynlib: libName.}
+      importc: "cublasZtbmv_v2", dyn.}
   ##  TPMV
   proc cublasStpmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       AP: ptr cfloat; x: ptr cfloat; incx: cint): cublasStatus_t {.cdecl,
-      importc: "cublasStpmv_v2", dynlib: libName.}
+      importc: "cublasStpmv_v2", dyn.}
   proc cublasDtpmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       AP: ptr cdouble; x: ptr cdouble; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDtpmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasDtpmv_v2", dyn.}
   proc cublasCtpmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       AP: ptr cuComplex; x: ptr cuComplex; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCtpmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasCtpmv_v2", dyn.}
   proc cublasZtpmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       AP: ptr cuDoubleComplex; x: ptr cuDoubleComplex; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasZtpmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasZtpmv_v2", dyn.}
   ##  TRSV
   proc cublasStrsv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       A: ptr cfloat; lda: cint; x: ptr cfloat; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasStrsv_v2", dynlib: libName.}
+      cdecl, importc: "cublasStrsv_v2", dyn.}
   proc cublasDtrsv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       A: ptr cdouble; lda: cint; x: ptr cdouble; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDtrsv_v2", dynlib: libName.}
+      cdecl, importc: "cublasDtrsv_v2", dyn.}
   proc cublasCtrsv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       A: ptr cuComplex; lda: cint; x: ptr cuComplex; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCtrsv_v2", dynlib: libName.}
+      cdecl, importc: "cublasCtrsv_v2", dyn.}
   proc cublasZtrsv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       A: ptr cuDoubleComplex; lda: cint; x: ptr cuDoubleComplex;
                       incx: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZtrsv_v2", dynlib: libName.}
+      importc: "cublasZtrsv_v2", dyn.}
   ##  TPSV
   proc cublasStpsv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       AP: ptr cfloat; x: ptr cfloat; incx: cint): cublasStatus_t {.cdecl,
-      importc: "cublasStpsv_v2", dynlib: libName.}
+      importc: "cublasStpsv_v2", dyn.}
   proc cublasDtpsv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       AP: ptr cdouble; x: ptr cdouble; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDtpsv_v2", dynlib: libName.}
+      cdecl, importc: "cublasDtpsv_v2", dyn.}
   proc cublasCtpsv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       AP: ptr cuComplex; x: ptr cuComplex; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCtpsv_v2", dynlib: libName.}
+      cdecl, importc: "cublasCtpsv_v2", dyn.}
   proc cublasZtpsv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       AP: ptr cuDoubleComplex; x: ptr cuDoubleComplex; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasZtpsv_v2", dynlib: libName.}
+      cdecl, importc: "cublasZtpsv_v2", dyn.}
   ##  TBSV
   proc cublasStbsv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       k: cint; A: ptr cfloat; lda: cint; x: ptr cfloat; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasStbsv_v2", dynlib: libName.}
+      cdecl, importc: "cublasStbsv_v2", dyn.}
   proc cublasDtbsv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       k: cint; A: ptr cdouble; lda: cint; x: ptr cdouble; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDtbsv_v2", dynlib: libName.}
+      cdecl, importc: "cublasDtbsv_v2", dyn.}
   proc cublasCtbsv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       k: cint; A: ptr cuComplex; lda: cint; x: ptr cuComplex; incx: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCtbsv_v2", dynlib: libName.}
+      cdecl, importc: "cublasCtbsv_v2", dyn.}
   proc cublasZtbsv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; diag: cublasDiagType_t; n: cint;
                       k: cint; A: ptr cuDoubleComplex; lda: cint;
                       x: ptr cuDoubleComplex; incx: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZtbsv_v2", dynlib: libName.}
+      importc: "cublasZtbsv_v2", dyn.}
   ##  SYMV/HEMV
   proc cublasSsymv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cfloat; A: ptr cfloat; lda: cint; x: ptr cfloat;
                       incx: cint; beta: ptr cfloat; y: ptr cfloat; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSsymv_v2", dynlib: libName.}
+      cdecl, importc: "cublasSsymv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasDsymv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cdouble; A: ptr cdouble; lda: cint; x: ptr cdouble;
                       incx: cint; beta: ptr cdouble; y: ptr cdouble; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDsymv_v2", dynlib: libName.}
+      cdecl, importc: "cublasDsymv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasCsymv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cuComplex; A: ptr cuComplex; lda: cint;
                       x: ptr cuComplex; incx: cint; beta: ptr cuComplex;
                       y: ptr cuComplex; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCsymv_v2", dynlib: libName.}
+      importc: "cublasCsymv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZsymv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                       x: ptr cuDoubleComplex; incx: cint; beta: ptr cuDoubleComplex;
                       y: ptr cuDoubleComplex; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZsymv_v2", dynlib: libName.}
+      importc: "cublasZsymv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasChemv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cuComplex; A: ptr cuComplex; lda: cint;
                       x: ptr cuComplex; incx: cint; beta: ptr cuComplex;
                       y: ptr cuComplex; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasChemv_v2", dynlib: libName.}
+      importc: "cublasChemv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZhemv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                       x: ptr cuDoubleComplex; incx: cint; beta: ptr cuDoubleComplex;
                       y: ptr cuDoubleComplex; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZhemv_v2", dynlib: libName.}
+      importc: "cublasZhemv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  SBMV/HBMV
   proc cublasSsbmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       k: cint; alpha: ptr cfloat; A: ptr cfloat; lda: cint; x: ptr cfloat;
                       incx: cint; beta: ptr cfloat; y: ptr cfloat; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSsbmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasSsbmv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasDsbmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       k: cint; alpha: ptr cdouble; A: ptr cdouble; lda: cint;
                       x: ptr cdouble; incx: cint; beta: ptr cdouble; y: ptr cdouble;
                       incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDsbmv_v2", dynlib: libName.}
+      importc: "cublasDsbmv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasChbmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       k: cint; alpha: ptr cuComplex; A: ptr cuComplex; lda: cint;
                       x: ptr cuComplex; incx: cint; beta: ptr cuComplex;
                       y: ptr cuComplex; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasChbmv_v2", dynlib: libName.}
+      importc: "cublasChbmv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZhbmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       k: cint; alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex;
                       lda: cint; x: ptr cuDoubleComplex; incx: cint;
                       beta: ptr cuDoubleComplex; y: ptr cuDoubleComplex; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasZhbmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasZhbmv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  SPMV/HPMV
   proc cublasSspmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cfloat; AP: ptr cfloat; x: ptr cfloat; incx: cint;
                       beta: ptr cfloat; y: ptr cfloat; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSspmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasSspmv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasDspmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cdouble; AP: ptr cdouble; x: ptr cdouble; incx: cint;
                       beta: ptr cdouble; y: ptr cdouble; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDspmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasDspmv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasChpmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cuComplex; AP: ptr cuComplex; x: ptr cuComplex;
                       incx: cint; beta: ptr cuComplex; y: ptr cuComplex; incy: cint): cublasStatus_t {.
-      cdecl, importc: "cublasChpmv_v2", dynlib: libName.}
+      cdecl, importc: "cublasChpmv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZhpmv_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cuDoubleComplex; AP: ptr cuDoubleComplex;
                       x: ptr cuDoubleComplex; incx: cint; beta: ptr cuDoubleComplex;
                       y: ptr cuDoubleComplex; incy: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZhpmv_v2", dynlib: libName.}
+      importc: "cublasZhpmv_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  GER
   proc cublasSger_v2*(handle: cublasHandle_t; m: cint; n: cint; alpha: ptr cfloat;
                      x: ptr cfloat; incx: cint; y: ptr cfloat; incy: cint; A: ptr cfloat;
                      lda: cint): cublasStatus_t {.cdecl, importc: "cublasSger_v2",
-      dynlib: libName.}
+      dyn.}
     ##  host or device pointer
   proc cublasDger_v2*(handle: cublasHandle_t; m: cint; n: cint; alpha: ptr cdouble;
                      x: ptr cdouble; incx: cint; y: ptr cdouble; incy: cint;
                      A: ptr cdouble; lda: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDger_v2", dynlib: libName.}
+      importc: "cublasDger_v2", dyn.}
     ##  host or device pointer
   proc cublasCgeru_v2*(handle: cublasHandle_t; m: cint; n: cint; alpha: ptr cuComplex;
                       x: ptr cuComplex; incx: cint; y: ptr cuComplex; incy: cint;
                       A: ptr cuComplex; lda: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCgeru_v2", dynlib: libName.}
+      importc: "cublasCgeru_v2", dyn.}
     ##  host or device pointer
   proc cublasCgerc_v2*(handle: cublasHandle_t; m: cint; n: cint; alpha: ptr cuComplex;
                       x: ptr cuComplex; incx: cint; y: ptr cuComplex; incy: cint;
                       A: ptr cuComplex; lda: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCgerc_v2", dynlib: libName.}
+      importc: "cublasCgerc_v2", dyn.}
     ##  host or device pointer
   proc cublasZgeru_v2*(handle: cublasHandle_t; m: cint; n: cint;
                       alpha: ptr cuDoubleComplex; x: ptr cuDoubleComplex; incx: cint;
                       y: ptr cuDoubleComplex; incy: cint; A: ptr cuDoubleComplex;
                       lda: cint): cublasStatus_t {.cdecl, importc: "cublasZgeru_v2",
-      dynlib: libName.}
+      dyn.}
     ##  host or device pointer
   proc cublasZgerc_v2*(handle: cublasHandle_t; m: cint; n: cint;
                       alpha: ptr cuDoubleComplex; x: ptr cuDoubleComplex; incx: cint;
                       y: ptr cuDoubleComplex; incy: cint; A: ptr cuDoubleComplex;
                       lda: cint): cublasStatus_t {.cdecl, importc: "cublasZgerc_v2",
-      dynlib: libName.}
+      dyn.}
     ##  host or device pointer
   ##  SYR/HER
   proc cublasSsyr_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                      alpha: ptr cfloat; x: ptr cfloat; incx: cint; A: ptr cfloat; lda: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSsyr_v2", dynlib: libName.}
+      cdecl, importc: "cublasSsyr_v2", dyn.}
     ##  host or device pointer
   proc cublasDsyr_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                      alpha: ptr cdouble; x: ptr cdouble; incx: cint; A: ptr cdouble;
                      lda: cint): cublasStatus_t {.cdecl, importc: "cublasDsyr_v2",
-      dynlib: libName.}
+      dyn.}
     ##  host or device pointer
   proc cublasCsyr_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                      alpha: ptr cuComplex; x: ptr cuComplex; incx: cint;
                      A: ptr cuComplex; lda: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCsyr_v2", dynlib: libName.}
+      importc: "cublasCsyr_v2", dyn.}
     ##  host or device pointer
   proc cublasZsyr_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                      alpha: ptr cuDoubleComplex; x: ptr cuDoubleComplex; incx: cint;
                      A: ptr cuDoubleComplex; lda: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZsyr_v2", dynlib: libName.}
+      importc: "cublasZsyr_v2", dyn.}
     ##  host or device pointer
   proc cublasCher_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                      alpha: ptr cfloat; x: ptr cuComplex; incx: cint; A: ptr cuComplex;
                      lda: cint): cublasStatus_t {.cdecl, importc: "cublasCher_v2",
-      dynlib: libName.}
+      dyn.}
     ##  host or device pointer
   proc cublasZher_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                      alpha: ptr cdouble; x: ptr cuDoubleComplex; incx: cint;
                      A: ptr cuDoubleComplex; lda: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZher_v2", dynlib: libName.}
+      importc: "cublasZher_v2", dyn.}
     ##  host or device pointer
   ##  SPR/HPR
   proc cublasSspr_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                      alpha: ptr cfloat; x: ptr cfloat; incx: cint; AP: ptr cfloat): cublasStatus_t {.
-      cdecl, importc: "cublasSspr_v2", dynlib: libName.}
+      cdecl, importc: "cublasSspr_v2", dyn.}
     ##  host or device pointer
   proc cublasDspr_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                      alpha: ptr cdouble; x: ptr cdouble; incx: cint; AP: ptr cdouble): cublasStatus_t {.
-      cdecl, importc: "cublasDspr_v2", dynlib: libName.}
+      cdecl, importc: "cublasDspr_v2", dyn.}
     ##  host or device pointer
   proc cublasChpr_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                      alpha: ptr cfloat; x: ptr cuComplex; incx: cint; AP: ptr cuComplex): cublasStatus_t {.
-      cdecl, importc: "cublasChpr_v2", dynlib: libName.}
+      cdecl, importc: "cublasChpr_v2", dyn.}
     ##  host or device pointer
   proc cublasZhpr_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                      alpha: ptr cdouble; x: ptr cuDoubleComplex; incx: cint;
                      AP: ptr cuDoubleComplex): cublasStatus_t {.cdecl,
-      importc: "cublasZhpr_v2", dynlib: libName.}
+      importc: "cublasZhpr_v2", dyn.}
     ##  host or device pointer
   ##  SYR2/HER2
   proc cublasSsyr2_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cfloat; x: ptr cfloat; incx: cint; y: ptr cfloat;
                       incy: cint; A: ptr cfloat; lda: cint): cublasStatus_t {.cdecl,
-      importc: "cublasSsyr2_v2", dynlib: libName.}
+      importc: "cublasSsyr2_v2", dyn.}
     ##  host or device pointer
   proc cublasDsyr2_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cdouble; x: ptr cdouble; incx: cint; y: ptr cdouble;
                       incy: cint; A: ptr cdouble; lda: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDsyr2_v2", dynlib: libName.}
+      importc: "cublasDsyr2_v2", dyn.}
     ##  host or device pointer
   proc cublasCsyr2_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cuComplex; x: ptr cuComplex; incx: cint;
                       y: ptr cuComplex; incy: cint; A: ptr cuComplex; lda: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCsyr2_v2", dynlib: libName.}
+      cdecl, importc: "cublasCsyr2_v2", dyn.}
     ##  host or device pointer
   proc cublasZsyr2_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cuDoubleComplex; x: ptr cuDoubleComplex; incx: cint;
                       y: ptr cuDoubleComplex; incy: cint; A: ptr cuDoubleComplex;
                       lda: cint): cublasStatus_t {.cdecl, importc: "cublasZsyr2_v2",
-      dynlib: libName.}
+      dyn.}
     ##  host or device pointer
   proc cublasCher2_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cuComplex; x: ptr cuComplex; incx: cint;
                       y: ptr cuComplex; incy: cint; A: ptr cuComplex; lda: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCher2_v2", dynlib: libName.}
+      cdecl, importc: "cublasCher2_v2", dyn.}
     ##  host or device pointer
   proc cublasZher2_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cuDoubleComplex; x: ptr cuDoubleComplex; incx: cint;
                       y: ptr cuDoubleComplex; incy: cint; A: ptr cuDoubleComplex;
                       lda: cint): cublasStatus_t {.cdecl, importc: "cublasZher2_v2",
-      dynlib: libName.}
+      dyn.}
     ##  host or device pointer
   ##  SPR2/HPR2
   proc cublasSspr2_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cfloat; x: ptr cfloat; incx: cint; y: ptr cfloat;
                       incy: cint; AP: ptr cfloat): cublasStatus_t {.cdecl,
-      importc: "cublasSspr2_v2", dynlib: libName.}
+      importc: "cublasSspr2_v2", dyn.}
     ##  host or device pointer
   proc cublasDspr2_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cdouble; x: ptr cdouble; incx: cint; y: ptr cdouble;
                       incy: cint; AP: ptr cdouble): cublasStatus_t {.cdecl,
-      importc: "cublasDspr2_v2", dynlib: libName.}
+      importc: "cublasDspr2_v2", dyn.}
     ##  host or device pointer
   proc cublasChpr2_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cuComplex; x: ptr cuComplex; incx: cint;
                       y: ptr cuComplex; incy: cint; AP: ptr cuComplex): cublasStatus_t {.
-      cdecl, importc: "cublasChpr2_v2", dynlib: libName.}
+      cdecl, importc: "cublasChpr2_v2", dyn.}
     ##  host or device pointer
   proc cublasZhpr2_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                       alpha: ptr cuDoubleComplex; x: ptr cuDoubleComplex; incx: cint;
                       y: ptr cuDoubleComplex; incy: cint; AP: ptr cuDoubleComplex): cublasStatus_t {.
-      cdecl, importc: "cublasZhpr2_v2", dynlib: libName.}
+      cdecl, importc: "cublasZhpr2_v2", dyn.}
     ##  host or device pointer
   ##  ---------------- CUBLAS BLAS3 functions ----------------
   ##  GEMM
@@ -979,14 +982,14 @@ when not defined(CUBLAS_API_H):
                       transb: cublasOperation_t; m: cint; n: cint; k: cint;
                       alpha: ptr cfloat; A: ptr cfloat; lda: cint; B: ptr cfloat;
                       ldb: cint; beta: ptr cfloat; C: ptr cfloat; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSgemm_v2", dynlib: libName.}
+      cdecl, importc: "cublasSgemm_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasDgemm_v2*(handle: cublasHandle_t; transa: cublasOperation_t;
                       transb: cublasOperation_t; m: cint; n: cint; k: cint;
                       alpha: ptr cdouble; A: ptr cdouble; lda: cint; B: ptr cdouble;
                       ldb: cint; beta: ptr cdouble; C: ptr cdouble; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDgemm_v2", dynlib: libName.}
+      cdecl, importc: "cublasDgemm_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasCgemm_v2*(handle: cublasHandle_t; transa: cublasOperation_t;
@@ -994,7 +997,7 @@ when not defined(CUBLAS_API_H):
                       alpha: ptr cuComplex; A: ptr cuComplex; lda: cint;
                       B: ptr cuComplex; ldb: cint; beta: ptr cuComplex;
                       C: ptr cuComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCgemm_v2", dynlib: libName.}
+      importc: "cublasCgemm_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasCgemm3m*(handle: cublasHandle_t; transa: cublasOperation_t;
@@ -1002,7 +1005,7 @@ when not defined(CUBLAS_API_H):
                      alpha: ptr cuComplex; A: ptr cuComplex; lda: cint;
                      B: ptr cuComplex; ldb: cint; beta: ptr cuComplex; C: ptr cuComplex;
                      ldc: cint): cublasStatus_t {.cdecl, importc: "cublasCgemm3m",
-      dynlib: libName.}
+      dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasCgemm3mEx*(handle: cublasHandle_t; transa: cublasOperation_t;
@@ -1010,13 +1013,13 @@ when not defined(CUBLAS_API_H):
                        alpha: ptr cuComplex; A: pointer; Atype: cudaDataType;
                        lda: cint; B: pointer; Btype: cudaDataType; ldb: cint;
                        beta: ptr cuComplex; C: pointer; Ctype: cudaDataType; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCgemm3mEx", dynlib: libName.}
+      cdecl, importc: "cublasCgemm3mEx", dyn.}
   proc cublasZgemm_v2*(handle: cublasHandle_t; transa: cublasOperation_t;
                       transb: cublasOperation_t; m: cint; n: cint; k: cint;
                       alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                       B: ptr cuDoubleComplex; ldb: cint; beta: ptr cuDoubleComplex;
                       C: ptr cuDoubleComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZgemm_v2", dynlib: libName.}
+      importc: "cublasZgemm_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZgemm3m*(handle: cublasHandle_t; transa: cublasOperation_t;
@@ -1024,14 +1027,14 @@ when not defined(CUBLAS_API_H):
                      alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                      B: ptr cuDoubleComplex; ldb: cint; beta: ptr cuDoubleComplex;
                      C: ptr cuDoubleComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZgemm3m", dynlib: libName.}
+      importc: "cublasZgemm3m", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasHgemm*(handle: cublasHandle_t; transa: cublasOperation_t;
                    transb: cublasOperation_t; m: cint; n: cint; k: cint;
                    alpha: ptr half; A: ptr half; lda: cint; B: ptr half; ldb: cint;
                    beta: ptr half; C: ptr half; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasHgemm", dynlib: libName.}
+      importc: "cublasHgemm", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  IO in FP16/FP32, computation in float
@@ -1040,7 +1043,7 @@ when not defined(CUBLAS_API_H):
                      alpha: ptr cfloat; A: pointer; Atype: cudaDataType; lda: cint;
                      B: pointer; Btype: cudaDataType; ldb: cint; beta: ptr cfloat;
                      C: pointer; Ctype: cudaDataType; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSgemmEx", dynlib: libName.}
+      cdecl, importc: "cublasSgemmEx", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasGemmEx*(handle: cublasHandle_t; transa: cublasOperation_t;
@@ -1049,7 +1052,7 @@ when not defined(CUBLAS_API_H):
                     B: pointer; Btype: cudaDataType; ldb: cint; beta: pointer;
                     C: pointer; Ctype: cudaDataType; ldc: cint;
                     computeType: cudaDataType; algo: cublasGemmAlgo_t): cublasStatus_t {.
-      cdecl, importc: "cublasGemmEx", dynlib: libName.}
+      cdecl, importc: "cublasGemmEx", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  IO in Int8 complex/cuComplex, computation in cuComplex
@@ -1058,40 +1061,40 @@ when not defined(CUBLAS_API_H):
                      alpha: ptr cuComplex; A: pointer; Atype: cudaDataType; lda: cint;
                      B: pointer; Btype: cudaDataType; ldb: cint; beta: ptr cuComplex;
                      C: pointer; Ctype: cudaDataType; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCgemmEx", dynlib: libName.}
+      cdecl, importc: "cublasCgemmEx", dyn.}
   proc cublasUint8gemmBias*(handle: cublasHandle_t; transa: cublasOperation_t;
                            transb: cublasOperation_t; transc: cublasOperation_t;
                            m: cint; n: cint; k: cint; A: ptr cuchar; A_bias: cint;
                            lda: cint; B: ptr cuchar; B_bias: cint; ldb: cint;
                            C: ptr cuchar; C_bias: cint; ldc: cint; C_mult: cint;
                            C_shift: cint): cublasStatus_t {.cdecl,
-      importc: "cublasUint8gemmBias", dynlib: libName.}
+      importc: "cublasUint8gemmBias", dyn.}
   ##  SYRK
   proc cublasSsyrk_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; n: cint; k: cint; alpha: ptr cfloat;
                       A: ptr cfloat; lda: cint; beta: ptr cfloat; C: ptr cfloat; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSsyrk_v2", dynlib: libName.}
+      cdecl, importc: "cublasSsyrk_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasDsyrk_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; n: cint; k: cint; alpha: ptr cdouble;
                       A: ptr cdouble; lda: cint; beta: ptr cdouble; C: ptr cdouble;
                       ldc: cint): cublasStatus_t {.cdecl, importc: "cublasDsyrk_v2",
-      dynlib: libName.}
+      dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasCsyrk_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; n: cint; k: cint;
                       alpha: ptr cuComplex; A: ptr cuComplex; lda: cint;
                       beta: ptr cuComplex; C: ptr cuComplex; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCsyrk_v2", dynlib: libName.}
+      cdecl, importc: "cublasCsyrk_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZsyrk_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; n: cint; k: cint;
                       alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                       beta: ptr cuDoubleComplex; C: ptr cuDoubleComplex; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasZsyrk_v2", dynlib: libName.}
+      cdecl, importc: "cublasZsyrk_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  IO in Int8 complex/cuComplex, computation in cuComplex
@@ -1099,7 +1102,7 @@ when not defined(CUBLAS_API_H):
                      trans: cublasOperation_t; n: cint; k: cint; alpha: ptr cuComplex;
                      A: pointer; Atype: cudaDataType; lda: cint; beta: ptr cuComplex;
                      C: pointer; Ctype: cudaDataType; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCsyrkEx", dynlib: libName.}
+      cdecl, importc: "cublasCsyrkEx", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  IO in Int8 complex/cuComplex, computation in cuComplex, Gaussian math
@@ -1108,20 +1111,20 @@ when not defined(CUBLAS_API_H):
                        alpha: ptr cuComplex; A: pointer; Atype: cudaDataType;
                        lda: cint; beta: ptr cuComplex; C: pointer; Ctype: cudaDataType;
                        ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCsyrk3mEx", dynlib: libName.}
+      importc: "cublasCsyrk3mEx", dyn.}
   ##  HERK
   proc cublasCherk_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; n: cint; k: cint; alpha: ptr cfloat;
                       A: ptr cuComplex; lda: cint; beta: ptr cfloat; C: ptr cuComplex;
                       ldc: cint): cublasStatus_t {.cdecl, importc: "cublasCherk_v2",
-      dynlib: libName.}
+      dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZherk_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                       trans: cublasOperation_t; n: cint; k: cint; alpha: ptr cdouble;
                       A: ptr cuDoubleComplex; lda: cint; beta: ptr cdouble;
                       C: ptr cuDoubleComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZherk_v2", dynlib: libName.}
+      importc: "cublasZherk_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  IO in Int8 complex/cuComplex, computation in cuComplex
@@ -1129,7 +1132,7 @@ when not defined(CUBLAS_API_H):
                      trans: cublasOperation_t; n: cint; k: cint; alpha: ptr cfloat;
                      A: pointer; Atype: cudaDataType; lda: cint; beta: ptr cfloat;
                      C: pointer; Ctype: cudaDataType; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCherkEx", dynlib: libName.}
+      cdecl, importc: "cublasCherkEx", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  IO in Int8 complex/cuComplex, computation in cuComplex, Gaussian math
@@ -1137,20 +1140,20 @@ when not defined(CUBLAS_API_H):
                        trans: cublasOperation_t; n: cint; k: cint; alpha: ptr cfloat;
                        A: pointer; Atype: cudaDataType; lda: cint; beta: ptr cfloat;
                        C: pointer; Ctype: cudaDataType; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCherk3mEx", dynlib: libName.}
+      cdecl, importc: "cublasCherk3mEx", dyn.}
   ##  SYR2K
   proc cublasSsyr2k_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                        trans: cublasOperation_t; n: cint; k: cint; alpha: ptr cfloat;
                        A: ptr cfloat; lda: cint; B: ptr cfloat; ldb: cint;
                        beta: ptr cfloat; C: ptr cfloat; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSsyr2k_v2", dynlib: libName.}
+      cdecl, importc: "cublasSsyr2k_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasDsyr2k_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                        trans: cublasOperation_t; n: cint; k: cint; alpha: ptr cdouble;
                        A: ptr cdouble; lda: cint; B: ptr cdouble; ldb: cint;
                        beta: ptr cdouble; C: ptr cdouble; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDsyr2k_v2", dynlib: libName.}
+      cdecl, importc: "cublasDsyr2k_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasCsyr2k_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
@@ -1158,7 +1161,7 @@ when not defined(CUBLAS_API_H):
                        alpha: ptr cuComplex; A: ptr cuComplex; lda: cint;
                        B: ptr cuComplex; ldb: cint; beta: ptr cuComplex;
                        C: ptr cuComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCsyr2k_v2", dynlib: libName.}
+      importc: "cublasCsyr2k_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZsyr2k_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
@@ -1166,7 +1169,7 @@ when not defined(CUBLAS_API_H):
                        alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                        B: ptr cuDoubleComplex; ldb: cint; beta: ptr cuDoubleComplex;
                        C: ptr cuDoubleComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZsyr2k_v2", dynlib: libName.}
+      importc: "cublasZsyr2k_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  HER2K
@@ -1175,7 +1178,7 @@ when not defined(CUBLAS_API_H):
                        alpha: ptr cuComplex; A: ptr cuComplex; lda: cint;
                        B: ptr cuComplex; ldb: cint; beta: ptr cfloat; C: ptr cuComplex;
                        ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCher2k_v2", dynlib: libName.}
+      importc: "cublasCher2k_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZher2k_v2*(handle: cublasHandle_t; uplo: cublasFillMode_t;
@@ -1183,7 +1186,7 @@ when not defined(CUBLAS_API_H):
                        alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                        B: ptr cuDoubleComplex; ldb: cint; beta: ptr cdouble;
                        C: ptr cuDoubleComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZher2k_v2", dynlib: libName.}
+      importc: "cublasZher2k_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  SYRKX : eXtended SYRK
@@ -1191,21 +1194,21 @@ when not defined(CUBLAS_API_H):
                     trans: cublasOperation_t; n: cint; k: cint; alpha: ptr cfloat;
                     A: ptr cfloat; lda: cint; B: ptr cfloat; ldb: cint; beta: ptr cfloat;
                     C: ptr cfloat; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasSsyrkx", dynlib: libName.}
+      importc: "cublasSsyrkx", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasDsyrkx*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                     trans: cublasOperation_t; n: cint; k: cint; alpha: ptr cdouble;
                     A: ptr cdouble; lda: cint; B: ptr cdouble; ldb: cint;
                     beta: ptr cdouble; C: ptr cdouble; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDsyrkx", dynlib: libName.}
+      cdecl, importc: "cublasDsyrkx", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasCsyrkx*(handle: cublasHandle_t; uplo: cublasFillMode_t;
                     trans: cublasOperation_t; n: cint; k: cint; alpha: ptr cuComplex;
                     A: ptr cuComplex; lda: cint; B: ptr cuComplex; ldb: cint;
                     beta: ptr cuComplex; C: ptr cuComplex; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCsyrkx", dynlib: libName.}
+      cdecl, importc: "cublasCsyrkx", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZsyrkx*(handle: cublasHandle_t; uplo: cublasFillMode_t;
@@ -1213,7 +1216,7 @@ when not defined(CUBLAS_API_H):
                     alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                     B: ptr cuDoubleComplex; ldb: cint; beta: ptr cuDoubleComplex;
                     C: ptr cuDoubleComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZsyrkx", dynlib: libName.}
+      importc: "cublasZsyrkx", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  HERKX : eXtended HERK
@@ -1221,7 +1224,7 @@ when not defined(CUBLAS_API_H):
                     trans: cublasOperation_t; n: cint; k: cint; alpha: ptr cuComplex;
                     A: ptr cuComplex; lda: cint; B: ptr cuComplex; ldb: cint;
                     beta: ptr cfloat; C: ptr cuComplex; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCherkx", dynlib: libName.}
+      cdecl, importc: "cublasCherkx", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZherkx*(handle: cublasHandle_t; uplo: cublasFillMode_t;
@@ -1229,7 +1232,7 @@ when not defined(CUBLAS_API_H):
                     alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                     B: ptr cuDoubleComplex; ldb: cint; beta: ptr cdouble;
                     C: ptr cuDoubleComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZherkx", dynlib: libName.}
+      importc: "cublasZherkx", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  SYMM
@@ -1237,21 +1240,21 @@ when not defined(CUBLAS_API_H):
                       uplo: cublasFillMode_t; m: cint; n: cint; alpha: ptr cfloat;
                       A: ptr cfloat; lda: cint; B: ptr cfloat; ldb: cint;
                       beta: ptr cfloat; C: ptr cfloat; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSsymm_v2", dynlib: libName.}
+      cdecl, importc: "cublasSsymm_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasDsymm_v2*(handle: cublasHandle_t; side: cublasSideMode_t;
                       uplo: cublasFillMode_t; m: cint; n: cint; alpha: ptr cdouble;
                       A: ptr cdouble; lda: cint; B: ptr cdouble; ldb: cint;
                       beta: ptr cdouble; C: ptr cdouble; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDsymm_v2", dynlib: libName.}
+      cdecl, importc: "cublasDsymm_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasCsymm_v2*(handle: cublasHandle_t; side: cublasSideMode_t;
                       uplo: cublasFillMode_t; m: cint; n: cint; alpha: ptr cuComplex;
                       A: ptr cuComplex; lda: cint; B: ptr cuComplex; ldb: cint;
                       beta: ptr cuComplex; C: ptr cuComplex; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCsymm_v2", dynlib: libName.}
+      cdecl, importc: "cublasCsymm_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZsymm_v2*(handle: cublasHandle_t; side: cublasSideMode_t;
@@ -1259,7 +1262,7 @@ when not defined(CUBLAS_API_H):
                       alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                       B: ptr cuDoubleComplex; ldb: cint; beta: ptr cuDoubleComplex;
                       C: ptr cuDoubleComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZsymm_v2", dynlib: libName.}
+      importc: "cublasZsymm_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  HEMM
@@ -1267,7 +1270,7 @@ when not defined(CUBLAS_API_H):
                       uplo: cublasFillMode_t; m: cint; n: cint; alpha: ptr cuComplex;
                       A: ptr cuComplex; lda: cint; B: ptr cuComplex; ldb: cint;
                       beta: ptr cuComplex; C: ptr cuComplex; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasChemm_v2", dynlib: libName.}
+      cdecl, importc: "cublasChemm_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZhemm_v2*(handle: cublasHandle_t; side: cublasSideMode_t;
@@ -1275,7 +1278,7 @@ when not defined(CUBLAS_API_H):
                       alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                       B: ptr cuDoubleComplex; ldb: cint; beta: ptr cuDoubleComplex;
                       C: ptr cuDoubleComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZhemm_v2", dynlib: libName.}
+      importc: "cublasZhemm_v2", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  TRSM
@@ -1283,26 +1286,26 @@ when not defined(CUBLAS_API_H):
                       uplo: cublasFillMode_t; trans: cublasOperation_t;
                       diag: cublasDiagType_t; m: cint; n: cint; alpha: ptr cfloat;
                       A: ptr cfloat; lda: cint; B: ptr cfloat; ldb: cint): cublasStatus_t {.
-      cdecl, importc: "cublasStrsm_v2", dynlib: libName.}
+      cdecl, importc: "cublasStrsm_v2", dyn.}
     ##  host or device pointer
   proc cublasDtrsm_v2*(handle: cublasHandle_t; side: cublasSideMode_t;
                       uplo: cublasFillMode_t; trans: cublasOperation_t;
                       diag: cublasDiagType_t; m: cint; n: cint; alpha: ptr cdouble;
                       A: ptr cdouble; lda: cint; B: ptr cdouble; ldb: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDtrsm_v2", dynlib: libName.}
+      cdecl, importc: "cublasDtrsm_v2", dyn.}
     ##  host or device pointer
   proc cublasCtrsm_v2*(handle: cublasHandle_t; side: cublasSideMode_t;
                       uplo: cublasFillMode_t; trans: cublasOperation_t;
                       diag: cublasDiagType_t; m: cint; n: cint; alpha: ptr cuComplex;
                       A: ptr cuComplex; lda: cint; B: ptr cuComplex; ldb: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCtrsm_v2", dynlib: libName.}
+      cdecl, importc: "cublasCtrsm_v2", dyn.}
     ##  host or device pointer
   proc cublasZtrsm_v2*(handle: cublasHandle_t; side: cublasSideMode_t;
                       uplo: cublasFillMode_t; trans: cublasOperation_t;
                       diag: cublasDiagType_t; m: cint; n: cint;
                       alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                       B: ptr cuDoubleComplex; ldb: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZtrsm_v2", dynlib: libName.}
+      importc: "cublasZtrsm_v2", dyn.}
     ##  host or device pointer
   ##  TRMM
   proc cublasStrmm_v2*(handle: cublasHandle_t; side: cublasSideMode_t;
@@ -1310,21 +1313,21 @@ when not defined(CUBLAS_API_H):
                       diag: cublasDiagType_t; m: cint; n: cint; alpha: ptr cfloat;
                       A: ptr cfloat; lda: cint; B: ptr cfloat; ldb: cint; C: ptr cfloat;
                       ldc: cint): cublasStatus_t {.cdecl, importc: "cublasStrmm_v2",
-      dynlib: libName.}
+      dyn.}
     ##  host or device pointer
   proc cublasDtrmm_v2*(handle: cublasHandle_t; side: cublasSideMode_t;
                       uplo: cublasFillMode_t; trans: cublasOperation_t;
                       diag: cublasDiagType_t; m: cint; n: cint; alpha: ptr cdouble;
                       A: ptr cdouble; lda: cint; B: ptr cdouble; ldb: cint;
                       C: ptr cdouble; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDtrmm_v2", dynlib: libName.}
+      importc: "cublasDtrmm_v2", dyn.}
     ##  host or device pointer
   proc cublasCtrmm_v2*(handle: cublasHandle_t; side: cublasSideMode_t;
                       uplo: cublasFillMode_t; trans: cublasOperation_t;
                       diag: cublasDiagType_t; m: cint; n: cint; alpha: ptr cuComplex;
                       A: ptr cuComplex; lda: cint; B: ptr cuComplex; ldb: cint;
                       C: ptr cuComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCtrmm_v2", dynlib: libName.}
+      importc: "cublasCtrmm_v2", dyn.}
     ##  host or device pointer
   proc cublasZtrmm_v2*(handle: cublasHandle_t; side: cublasSideMode_t;
                       uplo: cublasFillMode_t; trans: cublasOperation_t;
@@ -1332,7 +1335,7 @@ when not defined(CUBLAS_API_H):
                       alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                       B: ptr cuDoubleComplex; ldb: cint; C: ptr cuDoubleComplex;
                       ldc: cint): cublasStatus_t {.cdecl, importc: "cublasZtrmm_v2",
-      dynlib: libName.}
+      dyn.}
     ##  host or device pointer
   ##  BATCH GEMM
   proc cublasSgemmBatched*(handle: cublasHandle_t; transa: cublasOperation_t;
@@ -1340,7 +1343,7 @@ when not defined(CUBLAS_API_H):
                           alpha: ptr cfloat; Aarray: ptr ptr cfloat; lda: cint;
                           Barray: ptr ptr cfloat; ldb: cint; beta: ptr cfloat;
                           Carray: ptr ptr cfloat; ldc: cint; batchCount: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSgemmBatched", dynlib: libName.}
+      cdecl, importc: "cublasSgemmBatched", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasDgemmBatched*(handle: cublasHandle_t; transa: cublasOperation_t;
@@ -1348,7 +1351,7 @@ when not defined(CUBLAS_API_H):
                           alpha: ptr cdouble; Aarray: ptr ptr cdouble; lda: cint;
                           Barray: ptr ptr cdouble; ldb: cint; beta: ptr cdouble;
                           Carray: ptr ptr cdouble; ldc: cint; batchCount: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDgemmBatched", dynlib: libName.}
+      cdecl, importc: "cublasDgemmBatched", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasCgemmBatched*(handle: cublasHandle_t; transa: cublasOperation_t;
@@ -1356,7 +1359,7 @@ when not defined(CUBLAS_API_H):
                           alpha: ptr cuComplex; Aarray: ptr ptr cuComplex; lda: cint;
                           Barray: ptr ptr cuComplex; ldb: cint; beta: ptr cuComplex;
                           Carray: ptr ptr cuComplex; ldc: cint; batchCount: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCgemmBatched", dynlib: libName.}
+      cdecl, importc: "cublasCgemmBatched", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasCgemm3mBatched*(handle: cublasHandle_t; transa: cublasOperation_t;
@@ -1364,7 +1367,7 @@ when not defined(CUBLAS_API_H):
                             alpha: ptr cuComplex; Aarray: ptr ptr cuComplex; lda: cint;
                             Barray: ptr ptr cuComplex; ldb: cint; beta: ptr cuComplex;
                             Carray: ptr ptr cuComplex; ldc: cint; batchCount: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCgemm3mBatched", dynlib: libName.}
+      cdecl, importc: "cublasCgemm3mBatched", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZgemmBatched*(handle: cublasHandle_t; transa: cublasOperation_t;
@@ -1374,7 +1377,7 @@ when not defined(CUBLAS_API_H):
                           Barray: ptr ptr cuDoubleComplex; ldb: cint;
                           beta: ptr cuDoubleComplex;
                           Carray: ptr ptr cuDoubleComplex; ldc: cint; batchCount: cint): cublasStatus_t {.
-      cdecl, importc: "cublasZgemmBatched", dynlib: libName.}
+      cdecl, importc: "cublasZgemmBatched", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasSgemmStridedBatched*(handle: cublasHandle_t;
@@ -1384,7 +1387,7 @@ when not defined(CUBLAS_API_H):
                                  strideA: clonglong; B: ptr cfloat; ldb: cint;
                                  strideB: clonglong; beta: ptr cfloat; C: ptr cfloat;
                                  ldc: cint; strideC: clonglong; batchCount: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSgemmStridedBatched", dynlib: libName.}
+      cdecl, importc: "cublasSgemmStridedBatched", dyn.}
     ##  host or device pointer
     ##  purposely signed
     ##  host or device pointer
@@ -1396,7 +1399,7 @@ when not defined(CUBLAS_API_H):
                                  strideB: clonglong; beta: ptr cdouble;
                                  C: ptr cdouble; ldc: cint; strideC: clonglong;
                                  batchCount: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDgemmStridedBatched", dynlib: libName.}
+      importc: "cublasDgemmStridedBatched", dyn.}
     ##  host or device pointer
     ##  purposely signed
     ##  host or device pointer
@@ -1408,7 +1411,7 @@ when not defined(CUBLAS_API_H):
                                  strideB: clonglong; beta: ptr cuComplex;
                                  C: ptr cuComplex; ldc: cint; strideC: clonglong;
                                  batchCount: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCgemmStridedBatched", dynlib: libName.}
+      importc: "cublasCgemmStridedBatched", dyn.}
     ##  host or device pointer
     ##  purposely signed
     ##  host or device pointer
@@ -1420,7 +1423,7 @@ when not defined(CUBLAS_API_H):
                                    ldb: cint; strideB: clonglong;
                                    beta: ptr cuComplex; C: ptr cuComplex; ldc: cint;
                                    strideC: clonglong; batchCount: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCgemm3mStridedBatched", dynlib: libName.}
+      cdecl, importc: "cublasCgemm3mStridedBatched", dyn.}
     ##  host or device pointer
     ##  purposely signed
     ##  host or device pointer
@@ -1433,7 +1436,7 @@ when not defined(CUBLAS_API_H):
                                  ldb: cint; strideB: clonglong;
                                  beta: ptr cuDoubleComplex; C: ptr cuDoubleComplex;
                                  ldc: cint; strideC: clonglong; batchCount: cint): cublasStatus_t {.
-      cdecl, importc: "cublasZgemmStridedBatched", dynlib: libName.}
+      cdecl, importc: "cublasZgemmStridedBatched", dyn.}
     ##  host or device pointer
     ##  purposely signed
     ##  host or device poi
@@ -1444,7 +1447,7 @@ when not defined(CUBLAS_API_H):
                                  strideA: clonglong; B: ptr half; ldb: cint;
                                  strideB: clonglong; beta: ptr half; C: ptr half;
                                  ldc: cint; strideC: clonglong; batchCount: cint): cublasStatus_t {.
-      cdecl, importc: "cublasHgemmStridedBatched", dynlib: libName.}
+      cdecl, importc: "cublasHgemmStridedBatched", dyn.}
     ##  host or device pointer
     ##  purposely signed
     ##  host or device pointer
@@ -1454,21 +1457,21 @@ when not defined(CUBLAS_API_H):
                    transb: cublasOperation_t; m: cint; n: cint; alpha: ptr cfloat;
                    A: ptr cfloat; lda: cint; beta: ptr cfloat; B: ptr cfloat; ldb: cint;
                    C: ptr cfloat; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasSgeam", dynlib: libName.}
+      importc: "cublasSgeam", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasDgeam*(handle: cublasHandle_t; transa: cublasOperation_t;
                    transb: cublasOperation_t; m: cint; n: cint; alpha: ptr cdouble;
                    A: ptr cdouble; lda: cint; beta: ptr cdouble; B: ptr cdouble; ldb: cint;
                    C: ptr cdouble; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDgeam", dynlib: libName.}
+      importc: "cublasDgeam", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasCgeam*(handle: cublasHandle_t; transa: cublasOperation_t;
                    transb: cublasOperation_t; m: cint; n: cint; alpha: ptr cuComplex;
                    A: ptr cuComplex; lda: cint; beta: ptr cuComplex; B: ptr cuComplex;
                    ldb: cint; C: ptr cuComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCgeam", dynlib: libName.}
+      importc: "cublasCgeam", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cublasZgeam*(handle: cublasHandle_t; transa: cublasOperation_t;
@@ -1476,32 +1479,32 @@ when not defined(CUBLAS_API_H):
                    alpha: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint;
                    beta: ptr cuDoubleComplex; B: ptr cuDoubleComplex; ldb: cint;
                    C: ptr cuDoubleComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZgeam", dynlib: libName.}
+      importc: "cublasZgeam", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  Batched LU - GETRF
   proc cublasSgetrfBatched*(handle: cublasHandle_t; n: cint; A: ptr ptr cfloat;
                            lda: cint; P: ptr cint; info: ptr cint; batchSize: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSgetrfBatched", dynlib: libName.}
+      cdecl, importc: "cublasSgetrfBatched", dyn.}
     ## Device pointer
     ## Device Pointer
     ## Device Pointer
   proc cublasDgetrfBatched*(handle: cublasHandle_t; n: cint; A: ptr ptr cdouble;
                            lda: cint; P: ptr cint; info: ptr cint; batchSize: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDgetrfBatched", dynlib: libName.}
+      cdecl, importc: "cublasDgetrfBatched", dyn.}
     ## Device pointer
     ## Device Pointer
     ## Device Pointer
   proc cublasCgetrfBatched*(handle: cublasHandle_t; n: cint; A: ptr ptr cuComplex;
                            lda: cint; P: ptr cint; info: ptr cint; batchSize: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCgetrfBatched", dynlib: libName.}
+      cdecl, importc: "cublasCgetrfBatched", dyn.}
     ## Device pointer
     ## Device Pointer
     ## Device Pointer
   proc cublasZgetrfBatched*(handle: cublasHandle_t; n: cint;
                            A: ptr ptr cuDoubleComplex; lda: cint; P: ptr cint;
                            info: ptr cint; batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZgetrfBatched", dynlib: libName.}
+      importc: "cublasZgetrfBatched", dyn.}
     ## Device pointer
     ## Device Pointer
     ## Device Pointer
@@ -1509,21 +1512,21 @@ when not defined(CUBLAS_API_H):
   proc cublasSgetriBatched*(handle: cublasHandle_t; n: cint; A: ptr ptr cfloat;
                            lda: cint; P: ptr cint; C: ptr ptr cfloat; ldc: cint;
                            info: ptr cint; batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasSgetriBatched", dynlib: libName.}
+      importc: "cublasSgetriBatched", dyn.}
     ## Device pointer
     ## Device pointer
     ## Device pointer
   proc cublasDgetriBatched*(handle: cublasHandle_t; n: cint; A: ptr ptr cdouble;
                            lda: cint; P: ptr cint; C: ptr ptr cdouble; ldc: cint;
                            info: ptr cint; batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDgetriBatched", dynlib: libName.}
+      importc: "cublasDgetriBatched", dyn.}
     ## Device pointer
     ## Device pointer
     ## Device pointer
   proc cublasCgetriBatched*(handle: cublasHandle_t; n: cint; A: ptr ptr cuComplex;
                            lda: cint; P: ptr cint; C: ptr ptr cuComplex; ldc: cint;
                            info: ptr cint; batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCgetriBatched", dynlib: libName.}
+      importc: "cublasCgetriBatched", dyn.}
     ## Device pointer
     ## Device pointer
     ## Device pointer
@@ -1531,7 +1534,7 @@ when not defined(CUBLAS_API_H):
                            A: ptr ptr cuDoubleComplex; lda: cint; P: ptr cint;
                            C: ptr ptr cuDoubleComplex; ldc: cint; info: ptr cint;
                            batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZgetriBatched", dynlib: libName.}
+      importc: "cublasZgetriBatched", dyn.}
     ## Device pointer
     ## Device pointer
     ## Device pointer
@@ -1540,44 +1543,44 @@ when not defined(CUBLAS_API_H):
                            n: cint; nrhs: cint; Aarray: ptr ptr cfloat; lda: cint;
                            devIpiv: ptr cint; Barray: ptr ptr cfloat; ldb: cint;
                            info: ptr cint; batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasSgetrsBatched", dynlib: libName.}
+      importc: "cublasSgetrsBatched", dyn.}
   proc cublasDgetrsBatched*(handle: cublasHandle_t; trans: cublasOperation_t;
                            n: cint; nrhs: cint; Aarray: ptr ptr cdouble; lda: cint;
                            devIpiv: ptr cint; Barray: ptr ptr cdouble; ldb: cint;
                            info: ptr cint; batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDgetrsBatched", dynlib: libName.}
+      importc: "cublasDgetrsBatched", dyn.}
   proc cublasCgetrsBatched*(handle: cublasHandle_t; trans: cublasOperation_t;
                            n: cint; nrhs: cint; Aarray: ptr ptr cuComplex; lda: cint;
                            devIpiv: ptr cint; Barray: ptr ptr cuComplex; ldb: cint;
                            info: ptr cint; batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCgetrsBatched", dynlib: libName.}
+      importc: "cublasCgetrsBatched", dyn.}
   proc cublasZgetrsBatched*(handle: cublasHandle_t; trans: cublasOperation_t;
                            n: cint; nrhs: cint; Aarray: ptr ptr cuDoubleComplex;
                            lda: cint; devIpiv: ptr cint;
                            Barray: ptr ptr cuDoubleComplex; ldb: cint; info: ptr cint;
                            batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZgetrsBatched", dynlib: libName.}
+      importc: "cublasZgetrsBatched", dyn.}
   ##  TRSM - Batched Triangular Solver
   proc cublasStrsmBatched*(handle: cublasHandle_t; side: cublasSideMode_t;
                           uplo: cublasFillMode_t; trans: cublasOperation_t;
                           diag: cublasDiagType_t; m: cint; n: cint; alpha: ptr cfloat;
                           A: ptr ptr cfloat; lda: cint; B: ptr ptr cfloat; ldb: cint;
                           batchCount: cint): cublasStatus_t {.cdecl,
-      importc: "cublasStrsmBatched", dynlib: libName.}
+      importc: "cublasStrsmBatched", dyn.}
     ## Host or Device Pointer
   proc cublasDtrsmBatched*(handle: cublasHandle_t; side: cublasSideMode_t;
                           uplo: cublasFillMode_t; trans: cublasOperation_t;
                           diag: cublasDiagType_t; m: cint; n: cint;
                           alpha: ptr cdouble; A: ptr ptr cdouble; lda: cint;
                           B: ptr ptr cdouble; ldb: cint; batchCount: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDtrsmBatched", dynlib: libName.}
+      cdecl, importc: "cublasDtrsmBatched", dyn.}
     ## Host or Device Pointer
   proc cublasCtrsmBatched*(handle: cublasHandle_t; side: cublasSideMode_t;
                           uplo: cublasFillMode_t; trans: cublasOperation_t;
                           diag: cublasDiagType_t; m: cint; n: cint;
                           alpha: ptr cuComplex; A: ptr ptr cuComplex; lda: cint;
                           B: ptr ptr cuComplex; ldb: cint; batchCount: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCtrsmBatched", dynlib: libName.}
+      cdecl, importc: "cublasCtrsmBatched", dyn.}
     ## Host or Device Pointer
   proc cublasZtrsmBatched*(handle: cublasHandle_t; side: cublasSideMode_t;
                           uplo: cublasFillMode_t; trans: cublasOperation_t;
@@ -1585,27 +1588,27 @@ when not defined(CUBLAS_API_H):
                           alpha: ptr cuDoubleComplex; A: ptr ptr cuDoubleComplex;
                           lda: cint; B: ptr ptr cuDoubleComplex; ldb: cint;
                           batchCount: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZtrsmBatched", dynlib: libName.}
+      importc: "cublasZtrsmBatched", dyn.}
     ## Host or Device Pointer
   ##  Batched - MATINV
   proc cublasSmatinvBatched*(handle: cublasHandle_t; n: cint; A: ptr ptr cfloat;
                             lda: cint; Ainv: ptr ptr cfloat; lda_inv: cint;
                             info: ptr cint; batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasSmatinvBatched", dynlib: libName.}
+      importc: "cublasSmatinvBatched", dyn.}
     ## Device pointer
     ## Device pointer
     ## Device Pointer
   proc cublasDmatinvBatched*(handle: cublasHandle_t; n: cint; A: ptr ptr cdouble;
                             lda: cint; Ainv: ptr ptr cdouble; lda_inv: cint;
                             info: ptr cint; batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDmatinvBatched", dynlib: libName.}
+      importc: "cublasDmatinvBatched", dyn.}
     ## Device pointer
     ## Device pointer
     ## Device Pointer
   proc cublasCmatinvBatched*(handle: cublasHandle_t; n: cint; A: ptr ptr cuComplex;
                             lda: cint; Ainv: ptr ptr cuComplex; lda_inv: cint;
                             info: ptr cint; batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCmatinvBatched", dynlib: libName.}
+      importc: "cublasCmatinvBatched", dyn.}
     ## Device pointer
     ## Device pointer
     ## Device Pointer
@@ -1613,7 +1616,7 @@ when not defined(CUBLAS_API_H):
                             A: ptr ptr cuDoubleComplex; lda: cint;
                             Ainv: ptr ptr cuDoubleComplex; lda_inv: cint;
                             info: ptr cint; batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZmatinvBatched", dynlib: libName.}
+      importc: "cublasZmatinvBatched", dyn.}
     ## Device pointer
     ## Device pointer
     ## Device Pointer
@@ -1621,26 +1624,26 @@ when not defined(CUBLAS_API_H):
   proc cublasSgeqrfBatched*(handle: cublasHandle_t; m: cint; n: cint;
                            Aarray: ptr ptr cfloat; lda: cint;
                            TauArray: ptr ptr cfloat; info: ptr cint; batchSize: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSgeqrfBatched", dynlib: libName.}
+      cdecl, importc: "cublasSgeqrfBatched", dyn.}
     ## Device pointer
     ##  Device pointer
   proc cublasDgeqrfBatched*(handle: cublasHandle_t; m: cint; n: cint;
                            Aarray: ptr ptr cdouble; lda: cint;
                            TauArray: ptr ptr cdouble; info: ptr cint; batchSize: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDgeqrfBatched", dynlib: libName.}
+      cdecl, importc: "cublasDgeqrfBatched", dyn.}
     ## Device pointer
     ##  Device pointer
   proc cublasCgeqrfBatched*(handle: cublasHandle_t; m: cint; n: cint;
                            Aarray: ptr ptr cuComplex; lda: cint;
                            TauArray: ptr ptr cuComplex; info: ptr cint; batchSize: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCgeqrfBatched", dynlib: libName.}
+      cdecl, importc: "cublasCgeqrfBatched", dyn.}
     ## Device pointer
     ##  Device pointer
   proc cublasZgeqrfBatched*(handle: cublasHandle_t; m: cint; n: cint;
                            Aarray: ptr ptr cuDoubleComplex; lda: cint;
                            TauArray: ptr ptr cuDoubleComplex; info: ptr cint;
                            batchSize: cint): cublasStatus_t {.cdecl,
-      importc: "cublasZgeqrfBatched", dynlib: libName.}
+      importc: "cublasZgeqrfBatched", dyn.}
     ## Device pointer
     ##  Device pointer
   ##  Least Square Min only m >= n and Non-transpose supported
@@ -1648,7 +1651,7 @@ when not defined(CUBLAS_API_H):
                           n: cint; nrhs: cint; Aarray: ptr ptr cfloat; lda: cint;
                           Carray: ptr ptr cfloat; ldc: cint; info: ptr cint;
                           devInfoArray: ptr cint; batchSize: cint): cublasStatus_t {.
-      cdecl, importc: "cublasSgelsBatched", dynlib: libName.}
+      cdecl, importc: "cublasSgelsBatched", dyn.}
     ## Device pointer
     ##  Device pointer
     ##  Device pointer
@@ -1656,7 +1659,7 @@ when not defined(CUBLAS_API_H):
                           n: cint; nrhs: cint; Aarray: ptr ptr cdouble; lda: cint;
                           Carray: ptr ptr cdouble; ldc: cint; info: ptr cint;
                           devInfoArray: ptr cint; batchSize: cint): cublasStatus_t {.
-      cdecl, importc: "cublasDgelsBatched", dynlib: libName.}
+      cdecl, importc: "cublasDgelsBatched", dyn.}
     ## Device pointer
     ##  Device pointer
     ##  Device pointer
@@ -1664,56 +1667,56 @@ when not defined(CUBLAS_API_H):
                           n: cint; nrhs: cint; Aarray: ptr ptr cuComplex; lda: cint;
                           Carray: ptr ptr cuComplex; ldc: cint; info: ptr cint;
                           devInfoArray: ptr cint; batchSize: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCgelsBatched", dynlib: libName.}
+      cdecl, importc: "cublasCgelsBatched", dyn.}
     ## Device pointer
     ##  Device pointer
   proc cublasZgelsBatched*(handle: cublasHandle_t; trans: cublasOperation_t; m: cint;
                           n: cint; nrhs: cint; Aarray: ptr ptr cuDoubleComplex;
                           lda: cint; Carray: ptr ptr cuDoubleComplex; ldc: cint;
                           info: ptr cint; devInfoArray: ptr cint; batchSize: cint): cublasStatus_t {.
-      cdecl, importc: "cublasZgelsBatched", dynlib: libName.}
+      cdecl, importc: "cublasZgelsBatched", dyn.}
     ## Device pointer
     ##  Device pointer
   ##  DGMM
   proc cublasSdgmm*(handle: cublasHandle_t; mode: cublasSideMode_t; m: cint; n: cint;
                    A: ptr cfloat; lda: cint; x: ptr cfloat; incx: cint; C: ptr cfloat;
                    ldc: cint): cublasStatus_t {.cdecl, importc: "cublasSdgmm",
-      dynlib: libName.}
+      dyn.}
   proc cublasDdgmm*(handle: cublasHandle_t; mode: cublasSideMode_t; m: cint; n: cint;
                    A: ptr cdouble; lda: cint; x: ptr cdouble; incx: cint; C: ptr cdouble;
                    ldc: cint): cublasStatus_t {.cdecl, importc: "cublasDdgmm",
-      dynlib: libName.}
+      dyn.}
   proc cublasCdgmm*(handle: cublasHandle_t; mode: cublasSideMode_t; m: cint; n: cint;
                    A: ptr cuComplex; lda: cint; x: ptr cuComplex; incx: cint;
                    C: ptr cuComplex; ldc: cint): cublasStatus_t {.cdecl,
-      importc: "cublasCdgmm", dynlib: libName.}
+      importc: "cublasCdgmm", dyn.}
   proc cublasZdgmm*(handle: cublasHandle_t; mode: cublasSideMode_t; m: cint; n: cint;
                    A: ptr cuDoubleComplex; lda: cint; x: ptr cuDoubleComplex;
                    incx: cint; C: ptr cuDoubleComplex; ldc: cint): cublasStatus_t {.
-      cdecl, importc: "cublasZdgmm", dynlib: libName.}
+      cdecl, importc: "cublasZdgmm", dyn.}
   ##  TPTTR : Triangular Pack format to Triangular format
   proc cublasStpttr*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                     AP: ptr cfloat; A: ptr cfloat; lda: cint): cublasStatus_t {.cdecl,
-      importc: "cublasStpttr", dynlib: libName.}
+      importc: "cublasStpttr", dyn.}
   proc cublasDtpttr*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                     AP: ptr cdouble; A: ptr cdouble; lda: cint): cublasStatus_t {.cdecl,
-      importc: "cublasDtpttr", dynlib: libName.}
+      importc: "cublasDtpttr", dyn.}
   proc cublasCtpttr*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                     AP: ptr cuComplex; A: ptr cuComplex; lda: cint): cublasStatus_t {.
-      cdecl, importc: "cublasCtpttr", dynlib: libName.}
+      cdecl, importc: "cublasCtpttr", dyn.}
   proc cublasZtpttr*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                     AP: ptr cuDoubleComplex; A: ptr cuDoubleComplex; lda: cint): cublasStatus_t {.
-      cdecl, importc: "cublasZtpttr", dynlib: libName.}
+      cdecl, importc: "cublasZtpttr", dyn.}
   ##  TRTTP : Triangular format to Triangular Pack format
   proc cublasStrttp*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                     A: ptr cfloat; lda: cint; AP: ptr cfloat): cublasStatus_t {.cdecl,
-      importc: "cublasStrttp", dynlib: libName.}
+      importc: "cublasStrttp", dyn.}
   proc cublasDtrttp*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                     A: ptr cdouble; lda: cint; AP: ptr cdouble): cublasStatus_t {.cdecl,
-      importc: "cublasDtrttp", dynlib: libName.}
+      importc: "cublasDtrttp", dyn.}
   proc cublasCtrttp*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                     A: ptr cuComplex; lda: cint; AP: ptr cuComplex): cublasStatus_t {.
-      cdecl, importc: "cublasCtrttp", dynlib: libName.}
+      cdecl, importc: "cublasCtrttp", dyn.}
   proc cublasZtrttp*(handle: cublasHandle_t; uplo: cublasFillMode_t; n: cint;
                     A: ptr cuDoubleComplex; lda: cint; AP: ptr cuDoubleComplex): cublasStatus_t {.
-      cdecl, importc: "cublasZtrttp", dynlib: libName.}
+      cdecl, importc: "cublasZtrttp", dyn.}

--- a/nimcuda/cuda_runtime_api.nim
+++ b/nimcuda/cuda_runtime_api.nim
@@ -1,13 +1,16 @@
  {.deadCodeElim: on.}
 when defined(windows):
-  const
-    libName = "cudart.dll"
+  import os
+  {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cudart.lib" & "\"".}
+  {.pragma: dyn.}
 elif defined(macosx):
   const
     libName = "libcudart.dylib"
+  {.pragma: dyn, dynlib: libName.}
 else:
   const
     libName = "libcudart.so"
+  {.pragma: dyn, dynlib: libName.}
 import
   vector_types, driver_types, surface_types, texture_types
 
@@ -171,7 +174,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaDeviceSynchronize
   ## 
   proc cudaDeviceReset*(): cudaError_t {.cdecl, importc: "cudaDeviceReset",
-                                      dynlib: libName.}
+                                      dyn.}
   ## *
   ##  \brief Wait for compute device to finish
   ## 
@@ -188,7 +191,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaDeviceReset
   ## 
   proc cudaDeviceSynchronize*(): cudaError_t {.cdecl,
-      importc: "cudaDeviceSynchronize", dynlib: libName.}
+      importc: "cudaDeviceSynchronize", dyn.}
   ## *
   ##  \brief Set resource limits
   ## 
@@ -263,7 +266,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaDeviceGetLimit
   ## 
   proc cudaDeviceSetLimit*(limit: cudaLimit; value: csize): cudaError_t {.cdecl,
-      importc: "cudaDeviceSetLimit", dynlib: libName.}
+      importc: "cudaDeviceSetLimit", dyn.}
   ## *
   ##  \brief Returns resource limits
   ## 
@@ -292,7 +295,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaDeviceSetLimit
   ## 
   proc cudaDeviceGetLimit*(pValue: ptr csize; limit: cudaLimit): cudaError_t {.cdecl,
-      importc: "cudaDeviceGetLimit", dynlib: libName.}
+      importc: "cudaDeviceGetLimit", dyn.}
   ## *
   ##  \brief Returns the preferred cache configuration for the current device.
   ## 
@@ -323,7 +326,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C++ API)"
   ## 
   proc cudaDeviceGetCacheConfig*(pCacheConfig: ptr cudaFuncCache): cudaError_t {.
-      cdecl, importc: "cudaDeviceGetCacheConfig", dynlib: libName.}
+      cdecl, importc: "cudaDeviceGetCacheConfig", dyn.}
   ## *
   ##  \brief Returns numerical values that correspond to the least and
   ##  greatest stream priorities.
@@ -359,7 +362,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaDeviceGetStreamPriorityRange*(leastPriority: ptr cint;
                                         greatestPriority: ptr cint): cudaError_t {.
-      cdecl, importc: "cudaDeviceGetStreamPriorityRange", dynlib: libName.}
+      cdecl, importc: "cudaDeviceGetStreamPriorityRange", dyn.}
   ## *
   ##  \brief Sets the preferred cache configuration for the current device.
   ## 
@@ -401,7 +404,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C++ API)"
   ## 
   proc cudaDeviceSetCacheConfig*(cacheConfig: cudaFuncCache): cudaError_t {.cdecl,
-      importc: "cudaDeviceSetCacheConfig", dynlib: libName.}
+      importc: "cudaDeviceSetCacheConfig", dyn.}
   ## *
   ##  \brief Returns the shared memory configuration for the current device.
   ## 
@@ -430,7 +433,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaFuncSetCacheConfig
   ## 
   proc cudaDeviceGetSharedMemConfig*(pConfig: ptr cudaSharedMemConfig): cudaError_t {.
-      cdecl, importc: "cudaDeviceGetSharedMemConfig", dynlib: libName.}
+      cdecl, importc: "cudaDeviceGetSharedMemConfig", dyn.}
   ## *
   ##  \brief Sets the shared memory configuration for the current device.
   ## 
@@ -472,7 +475,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaFuncSetCacheConfig
   ## 
   proc cudaDeviceSetSharedMemConfig*(config: cudaSharedMemConfig): cudaError_t {.
-      cdecl, importc: "cudaDeviceSetSharedMemConfig", dynlib: libName.}
+      cdecl, importc: "cudaDeviceSetSharedMemConfig", dyn.}
   ## *
   ##  \brief Returns a handle to a compute device
   ## 
@@ -495,7 +498,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaDeviceGetPCIBusId
   ## 
   proc cudaDeviceGetByPCIBusId*(device: ptr cint; pciBusId: cstring): cudaError_t {.
-      cdecl, importc: "cudaDeviceGetByPCIBusId", dynlib: libName.}
+      cdecl, importc: "cudaDeviceGetByPCIBusId", dyn.}
   ## *
   ##  \brief Returns a PCI Bus Id string for the device
   ## 
@@ -522,7 +525,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   ## 
   proc cudaDeviceGetPCIBusId*(pciBusId: cstring; len: cint; device: cint): cudaError_t {.
-      cdecl, importc: "cudaDeviceGetPCIBusId", dynlib: libName.}
+      cdecl, importc: "cudaDeviceGetPCIBusId", dyn.}
   ## *
   ##  \brief Gets an interprocess handle for a previously allocated event
   ## 
@@ -564,7 +567,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaIpcCloseMemHandle
   ## 
   proc cudaIpcGetEventHandle*(handle: ptr cudaIpcEventHandle_t; event: cudaEvent_t): cudaError_t {.
-      cdecl, importc: "cudaIpcGetEventHandle", dynlib: libName.}
+      cdecl, importc: "cudaIpcGetEventHandle", dyn.}
   ## *
   ##  \brief Opens an interprocess event handle for use in the current process
   ## 
@@ -599,7 +602,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaIpcCloseMemHandle
   ## 
   proc cudaIpcOpenEventHandle*(event: ptr cudaEvent_t; handle: cudaIpcEventHandle_t): cudaError_t {.
-      cdecl, importc: "cudaIpcOpenEventHandle", dynlib: libName.}
+      cdecl, importc: "cudaIpcOpenEventHandle", dyn.}
   ## *
   ##  \brief Gets an interprocess memory handle for an existing device memory
   ##           allocation
@@ -636,7 +639,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaIpcCloseMemHandle
   ## 
   proc cudaIpcGetMemHandle*(handle: ptr cudaIpcMemHandle_t; devPtr: pointer): cudaError_t {.
-      cdecl, importc: "cudaIpcGetMemHandle", dynlib: libName.}
+      cdecl, importc: "cudaIpcGetMemHandle", dyn.}
   ## *
   ##  \brief Opens an interprocess memory handle exported from another process
   ##           and returns a device pointer usable in the local process.
@@ -687,7 +690,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaIpcOpenMemHandle*(devPtr: ptr pointer; handle: cudaIpcMemHandle_t;
                             flags: cuint): cudaError_t {.cdecl,
-      importc: "cudaIpcOpenMemHandle", dynlib: libName.}
+      importc: "cudaIpcOpenMemHandle", dyn.}
   ## *
   ##  \brief Close memory mapped with cudaIpcOpenMemHandle
   ## 
@@ -717,7 +720,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaIpcOpenMemHandle,
   ## 
   proc cudaIpcCloseMemHandle*(devPtr: pointer): cudaError_t {.cdecl,
-      importc: "cudaIpcCloseMemHandle", dynlib: libName.}
+      importc: "cudaIpcCloseMemHandle", dyn.}
   ## * @}
   ##  END CUDART_DEVICE
   ## *
@@ -756,7 +759,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaDeviceReset
   ## 
   proc cudaThreadExit*(): cudaError_t {.cdecl, importc: "cudaThreadExit",
-                                     dynlib: libName.}
+                                     dyn.}
   ## *
   ##  \brief Wait for compute device to finish
   ## 
@@ -780,7 +783,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaDeviceSynchronize
   ## 
   proc cudaThreadSynchronize*(): cudaError_t {.cdecl,
-      importc: "cudaThreadSynchronize", dynlib: libName.}
+      importc: "cudaThreadSynchronize", dyn.}
   ## *
   ##  \brief Set resource limits
   ## 
@@ -827,7 +830,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaDeviceSetLimit
   ## 
   proc cudaThreadSetLimit*(limit: cudaLimit; value: csize): cudaError_t {.cdecl,
-      importc: "cudaThreadSetLimit", dynlib: libName.}
+      importc: "cudaThreadSetLimit", dyn.}
   ## *
   ##  \brief Returns resource limits
   ## 
@@ -858,7 +861,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaDeviceGetLimit
   ## 
   proc cudaThreadGetLimit*(pValue: ptr csize; limit: cudaLimit): cudaError_t {.cdecl,
-      importc: "cudaThreadGetLimit", dynlib: libName.}
+      importc: "cudaThreadGetLimit", dyn.}
   ## *
   ##  \brief Returns the preferred cache configuration for the current device.
   ## 
@@ -893,7 +896,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa cudaDeviceGetCacheConfig
   ## 
   proc cudaThreadGetCacheConfig*(pCacheConfig: ptr cudaFuncCache): cudaError_t {.
-      cdecl, importc: "cudaThreadGetCacheConfig", dynlib: libName.}
+      cdecl, importc: "cudaThreadGetCacheConfig", dyn.}
   ## *
   ##  \brief Sets the preferred cache configuration for the current device.
   ## 
@@ -939,7 +942,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaDeviceSetCacheConfig
   ## 
   proc cudaThreadSetCacheConfig*(cacheConfig: cudaFuncCache): cudaError_t {.cdecl,
-      importc: "cudaThreadSetCacheConfig", dynlib: libName.}
+      importc: "cudaThreadSetCacheConfig", dyn.}
   ## * @}
   ##  END CUDART_THREAD_DEPRECATED
   ## *
@@ -992,7 +995,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaPeekAtLastError, ::cudaGetErrorName, ::cudaGetErrorString, ::cudaError
   ## 
   proc cudaGetLastError*(): cudaError_t {.cdecl, importc: "cudaGetLastError",
-                                       dynlib: libName.}
+                                       dyn.}
   ## *
   ##  \brief Returns the last error from a runtime call
   ## 
@@ -1033,7 +1036,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaGetLastError, ::cudaGetErrorName, ::cudaGetErrorString, ::cudaError
   ## 
   proc cudaPeekAtLastError*(): cudaError_t {.cdecl, importc: "cudaPeekAtLastError",
-      dynlib: libName.}
+      dyn.}
   ## *
   ##  \brief Returns the string representation of an error code enum name
   ## 
@@ -1048,7 +1051,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaGetErrorString, ::cudaGetLastError, ::cudaPeekAtLastError, ::cudaError
   ## 
   proc cudaGetErrorName*(error: cudaError_t): cstring {.cdecl,
-      importc: "cudaGetErrorName", dynlib: libName.}
+      importc: "cudaGetErrorName", dyn.}
   ## *
   ##  \brief Returns the description string for an error code
   ## 
@@ -1063,7 +1066,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaGetErrorName, ::cudaGetLastError, ::cudaPeekAtLastError, ::cudaError
   ## 
   proc cudaGetErrorString*(error: cudaError_t): cstring {.cdecl,
-      importc: "cudaGetErrorString", dynlib: libName.}
+      importc: "cudaGetErrorString", dyn.}
   ## * @}
   ##  END CUDART_ERROR
   ## *
@@ -1093,7 +1096,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaChooseDevice
   ## 
   proc cudaGetDeviceCount*(count: ptr cint): cudaError_t {.cdecl,
-      importc: "cudaGetDeviceCount", dynlib: libName.}
+      importc: "cudaGetDeviceCount", dyn.}
   ## *
   ##  \brief Returns information about the compute-device
   ## 
@@ -1339,7 +1342,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaDeviceGetAttribute
   ## 
   proc cudaGetDeviceProperties*(prop: ptr cudaDeviceProp; device: cint): cudaError_t {.
-      cdecl, importc: "cudaGetDeviceProperties", dynlib: libName.}
+      cdecl, importc: "cudaGetDeviceProperties", dyn.}
   ## *
   ##  \brief Returns information about the device
   ## 
@@ -1511,7 +1514,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaGetDeviceProperties
   ## 
   proc cudaDeviceGetAttribute*(value: ptr cint; attr: cudaDeviceAttr; device: cint): cudaError_t {.
-      cdecl, importc: "cudaDeviceGetAttribute", dynlib: libName.}
+      cdecl, importc: "cudaDeviceGetAttribute", dyn.}
   ## *
   ##  \brief Queries attributes of the link between two devices.
   ## 
@@ -1547,7 +1550,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaDeviceGetP2PAttribute*(value: ptr cint; attr: cudaDeviceP2PAttr;
                                  srcDevice: cint; dstDevice: cint): cudaError_t {.
-      cdecl, importc: "cudaDeviceGetP2PAttribute", dynlib: libName.}
+      cdecl, importc: "cudaDeviceGetP2PAttribute", dyn.}
   ## *
   ##  \brief Select compute-device which best matches criteria
   ## 
@@ -1566,7 +1569,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaGetDeviceProperties
   ## 
   proc cudaChooseDevice*(device: ptr cint; prop: ptr cudaDeviceProp): cudaError_t {.
-      cdecl, importc: "cudaChooseDevice", dynlib: libName.}
+      cdecl, importc: "cudaChooseDevice", dyn.}
   ## *
   ##  \brief Set device to be used for GPU executions
   ## 
@@ -1600,7 +1603,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaChooseDevice
   ## 
   proc cudaSetDevice*(device: cint): cudaError_t {.cdecl, importc: "cudaSetDevice",
-      dynlib: libName.}
+      dyn.}
   ## *
   ##  \brief Returns which device is currently being used
   ## 
@@ -1617,7 +1620,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaChooseDevice
   ## 
   proc cudaGetDevice*(device: ptr cint): cudaError_t {.cdecl,
-      importc: "cudaGetDevice", dynlib: libName.}
+      importc: "cudaGetDevice", dyn.}
   ## *
   ##  \brief Set a list of devices that can be used for CUDA
   ## 
@@ -1646,7 +1649,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaChooseDevice
   ## 
   proc cudaSetValidDevices*(device_arr: ptr cint; len: cint): cudaError_t {.cdecl,
-      importc: "cudaSetValidDevices", dynlib: libName.}
+      importc: "cudaSetValidDevices", dyn.}
   ## *
   ##  \brief Sets flags to be used for device executions
   ## 
@@ -1708,7 +1711,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaChooseDevice
   ## 
   proc cudaSetDeviceFlags*(flags: cuint): cudaError_t {.cdecl,
-      importc: "cudaSetDeviceFlags", dynlib: libName.}
+      importc: "cudaSetDeviceFlags", dyn.}
   ## *
   ##  \brief Gets the flags for the current device
   ## 
@@ -1749,7 +1752,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaSetDevice, ::cudaSetDeviceFlags
   ## 
   proc cudaGetDeviceFlags*(flags: ptr cuint): cudaError_t {.cdecl,
-      importc: "cudaGetDeviceFlags", dynlib: libName.}
+      importc: "cudaGetDeviceFlags", dyn.}
   ## * @}
   ##  END CUDART_DEVICE
   ## *
@@ -1786,7 +1789,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaStreamDestroy
   ## 
   proc cudaStreamCreate*(pStream: ptr cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaStreamCreate", dynlib: libName.}
+      importc: "cudaStreamCreate", dyn.}
   ## *
   ##  \brief Create an asynchronous stream
   ## 
@@ -1815,7 +1818,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaStreamDestroy
   ## 
   proc cudaStreamCreateWithFlags*(pStream: ptr cudaStream_t; flags: cuint): cudaError_t {.
-      cdecl, importc: "cudaStreamCreateWithFlags", dynlib: libName.}
+      cdecl, importc: "cudaStreamCreateWithFlags", dyn.}
   ## *
   ##  \brief Create an asynchronous stream with the specified priority
   ## 
@@ -1859,7 +1862,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaStreamCreateWithPriority*(pStream: ptr cudaStream_t; flags: cuint;
                                     priority: cint): cudaError_t {.cdecl,
-      importc: "cudaStreamCreateWithPriority", dynlib: libName.}
+      importc: "cudaStreamCreateWithPriority", dyn.}
   ## *
   ##  \brief Query the priority of a stream
   ## 
@@ -1883,7 +1886,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaStreamGetFlags
   ## 
   proc cudaStreamGetPriority*(hStream: cudaStream_t; priority: ptr cint): cudaError_t {.
-      cdecl, importc: "cudaStreamGetPriority", dynlib: libName.}
+      cdecl, importc: "cudaStreamGetPriority", dyn.}
   ## *
   ##  \brief Query the flags of a stream
   ## 
@@ -1904,7 +1907,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaStreamGetPriority
   ## 
   proc cudaStreamGetFlags*(hStream: cudaStream_t; flags: ptr cuint): cudaError_t {.
-      cdecl, importc: "cudaStreamGetFlags", dynlib: libName.}
+      cdecl, importc: "cudaStreamGetFlags", dyn.}
   ## *
   ##  \brief Destroys and cleans up an asynchronous stream
   ## 
@@ -1925,7 +1928,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaStreamCreate, ::cudaStreamCreateWithFlags, ::cudaStreamQuery, ::cudaStreamWaitEvent, ::cudaStreamSynchronize, ::cudaStreamAddCallback
   ## 
   proc cudaStreamDestroy*(stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaStreamDestroy", dynlib: libName.}
+      importc: "cudaStreamDestroy", dyn.}
   ## *
   ##  \brief Make a compute stream wait on an event
   ## 
@@ -1957,7 +1960,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaStreamCreate, ::cudaStreamCreateWithFlags, ::cudaStreamQuery, ::cudaStreamSynchronize, ::cudaStreamAddCallback, ::cudaStreamDestroy
   ## 
   proc cudaStreamWaitEvent*(stream: cudaStream_t; event: cudaEvent_t; flags: cuint): cudaError_t {.
-      cdecl, importc: "cudaStreamWaitEvent", dynlib: libName.}
+      cdecl, importc: "cudaStreamWaitEvent", dyn.}
   ## *
   ##  Type of stream callback functions.
   ##  \param stream The stream as passed to ::cudaStreamAddCallback, may be NULL.
@@ -2024,7 +2027,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaStreamAddCallback*(stream: cudaStream_t; callback: cudaStreamCallback_t;
                              userData: pointer; flags: cuint): cudaError_t {.cdecl,
-      importc: "cudaStreamAddCallback", dynlib: libName.}
+      importc: "cudaStreamAddCallback", dyn.}
   ## *
   ##  \brief Waits for stream tasks to complete
   ## 
@@ -2043,7 +2046,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaStreamCreate, ::cudaStreamCreateWithFlags, ::cudaStreamQuery, ::cudaStreamWaitEvent, ::cudaStreamAddCallback, ::cudaStreamDestroy
   ## 
   proc cudaStreamSynchronize*(stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaStreamSynchronize", dynlib: libName.}
+      importc: "cudaStreamSynchronize", dyn.}
   ## *
   ##  \brief Queries an asynchronous stream for completion status
   ## 
@@ -2064,7 +2067,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaStreamCreate, ::cudaStreamCreateWithFlags, ::cudaStreamWaitEvent, ::cudaStreamSynchronize, ::cudaStreamAddCallback, ::cudaStreamDestroy
   ## 
   proc cudaStreamQuery*(stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaStreamQuery", dynlib: libName.}
+      importc: "cudaStreamQuery", dyn.}
   ## *
   ##  \brief Attach memory to a stream asynchronously
   ## 
@@ -2136,7 +2139,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaStreamAttachMemAsync*(stream: cudaStream_t; devPtr: pointer;
                                 length: csize; flags: cuint): cudaError_t {.cdecl,
-      importc: "cudaStreamAttachMemAsync", dynlib: libName.}
+      importc: "cudaStreamAttachMemAsync", dyn.}
   ## * @}
   ##  END CUDART_STREAM
   ## *
@@ -2171,7 +2174,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaStreamWaitEvent
   ## 
   proc cudaEventCreate*(event: ptr cudaEvent_t): cudaError_t {.cdecl,
-      importc: "cudaEventCreate", dynlib: libName.}
+      importc: "cudaEventCreate", dyn.}
   ## *
   ##  \brief Creates an event object with the specified flags
   ## 
@@ -2205,7 +2208,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaStreamWaitEvent
   ## 
   proc cudaEventCreateWithFlags*(event: ptr cudaEvent_t; flags: cuint): cudaError_t {.
-      cdecl, importc: "cudaEventCreateWithFlags", dynlib: libName.}
+      cdecl, importc: "cudaEventCreateWithFlags", dyn.}
   ## *
   ##  \brief Records an event
   ## 
@@ -2236,7 +2239,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaStreamWaitEvent
   ## 
   proc cudaEventRecord*(event: cudaEvent_t; stream: cudaStream_t): cudaError_t {.
-      cdecl, importc: "cudaEventRecord", dynlib: libName.}
+      cdecl, importc: "cudaEventRecord", dyn.}
   ## *
   ##  \brief Queries an event's status
   ## 
@@ -2268,7 +2271,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaEventSynchronize, ::cudaEventDestroy, ::cudaEventElapsedTime
   ## 
   proc cudaEventQuery*(event: cudaEvent_t): cudaError_t {.cdecl,
-      importc: "cudaEventQuery", dynlib: libName.}
+      importc: "cudaEventQuery", dyn.}
   ## *
   ##  \brief Waits for an event to complete
   ## 
@@ -2300,7 +2303,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaEventQuery, ::cudaEventDestroy, ::cudaEventElapsedTime
   ## 
   proc cudaEventSynchronize*(event: cudaEvent_t): cudaError_t {.cdecl,
-      importc: "cudaEventSynchronize", dynlib: libName.}
+      importc: "cudaEventSynchronize", dyn.}
   ## *
   ##  \brief Destroys an event object
   ## 
@@ -2325,7 +2328,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaEventSynchronize, ::cudaEventRecord, ::cudaEventElapsedTime
   ## 
   proc cudaEventDestroy*(event: cudaEvent_t): cudaError_t {.cdecl,
-      importc: "cudaEventDestroy", dynlib: libName.}
+      importc: "cudaEventDestroy", dyn.}
   ## *
   ##  \brief Computes the elapsed time between events
   ## 
@@ -2366,7 +2369,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaEventSynchronize, ::cudaEventDestroy, ::cudaEventRecord
   ## 
   proc cudaEventElapsedTime*(ms: ptr cfloat; start: cudaEvent_t; `end`: cudaEvent_t): cudaError_t {.
-      cdecl, importc: "cudaEventElapsedTime", dynlib: libName.}
+      cdecl, importc: "cudaEventElapsedTime", dyn.}
   ## * @}
   ##  END CUDART_EVENT
   ## *
@@ -2425,7 +2428,7 @@ when not defined(CUDA_RUNTIME_API_H):
     ## 
     proc cudaLaunchKernel*(`func`: pointer; gridDim: dim3; blockDim: dim3;
                           args: ptr pointer; sharedMem: csize; stream: cudaStream_t): cudaError_t {.
-        cdecl, importc: "cudaLaunchKernel", dynlib: libName.}
+        cdecl, importc: "cudaLaunchKernel", dyn.}
   ## *
   ##  \brief Sets the preferred cache configuration for a device function
   ## 
@@ -2473,7 +2476,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaThreadSetCacheConfig
   ## 
   proc cudaFuncSetCacheConfig*(`func`: pointer; cacheConfig: cudaFuncCache): cudaError_t {.
-      cdecl, importc: "cudaFuncSetCacheConfig", dynlib: libName.}
+      cdecl, importc: "cudaFuncSetCacheConfig", dyn.}
   ## *
   ##  \brief Sets the shared memory configuration for a device function
   ## 
@@ -2527,7 +2530,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaFuncSetCacheConfig
   ## 
   proc cudaFuncSetSharedMemConfig*(`func`: pointer; config: cudaSharedMemConfig): cudaError_t {.
-      cdecl, importc: "cudaFuncSetSharedMemConfig", dynlib: libName.}
+      cdecl, importc: "cudaFuncSetSharedMemConfig", dyn.}
   ## *
   ##  \brief Find out attributes for a given function
   ## 
@@ -2561,7 +2564,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)"
   ## 
   proc cudaFuncGetAttributes*(attr: ptr cudaFuncAttributes; `func`: pointer): cudaError_t {.
-      cdecl, importc: "cudaFuncGetAttributes", dynlib: libName.}
+      cdecl, importc: "cudaFuncGetAttributes", dyn.}
   ## *
   ##  \brief Converts a double argument to be executed on a device
   ## 
@@ -2584,7 +2587,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)"
   ## 
   proc cudaSetDoubleForDevice*(d: ptr cdouble): cudaError_t {.cdecl,
-      importc: "cudaSetDoubleForDevice", dynlib: libName.}
+      importc: "cudaSetDoubleForDevice", dyn.}
   ## *
   ##  \brief Converts a double argument after execution on a device
   ## 
@@ -2607,7 +2610,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)"
   ## 
   proc cudaSetDoubleForHost*(d: ptr cdouble): cudaError_t {.cdecl,
-      importc: "cudaSetDoubleForHost", dynlib: libName.}
+      importc: "cudaSetDoubleForHost", dyn.}
   ## * @}
   ##  END CUDART_EXECUTION
   when CUDART_VERSION >= 6050:
@@ -2662,7 +2665,7 @@ when not defined(CUDA_RUNTIME_API_H):
     ## 
     proc cudaOccupancyMaxActiveBlocksPerMultiprocessor*(numBlocks: ptr cint;
         `func`: pointer; blockSize: cint; dynamicSMemSize: csize): cudaError_t {.cdecl,
-        importc: "cudaOccupancyMaxActiveBlocksPerMultiprocessor", dynlib: libName.}
+        importc: "cudaOccupancyMaxActiveBlocksPerMultiprocessor", dyn.}
     when CUDART_VERSION >= 7000:
       ## *
       ##  \brief Returns occupancy for a device function with the specified flags
@@ -2709,7 +2712,7 @@ when not defined(CUDA_RUNTIME_API_H):
           numBlocks: ptr cint; `func`: pointer; blockSize: cint;
           dynamicSMemSize: csize; flags: cuint): cudaError_t {.cdecl,
           importc: "cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags",
-          dynlib: libName.}
+          dyn.}
       ## * @}
       ##  END CUDA_OCCUPANCY
   ## *
@@ -2758,7 +2761,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaConfigureCall*(gridDim: dim3; blockDim: dim3; sharedMem: csize;
                          stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaConfigureCall", dynlib: libName.}
+      importc: "cudaConfigureCall", dyn.}
   ## *
   ##  \brief Configure a device launch
   ## 
@@ -2787,7 +2790,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \ref ::cudaSetupArgument(T, size_t) "cudaSetupArgument (C++ API)",
   ## 
   proc cudaSetupArgument*(arg: pointer; size: csize; offset: csize): cudaError_t {.
-      cdecl, importc: "cudaSetupArgument", dynlib: libName.}
+      cdecl, importc: "cudaSetupArgument", dyn.}
   ## *
   ##  \brief Launches a device function
   ## 
@@ -2825,7 +2828,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaThreadSetCacheConfig
   ## 
   proc cudaLaunch*(`func`: pointer): cudaError_t {.cdecl, importc: "cudaLaunch",
-      dynlib: libName.}
+      dyn.}
   ## * @}
   ##  END CUDART_EXECUTION_DEPRECATED
   ## *
@@ -2940,7 +2943,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaFreeHost, ::cudaHostAlloc, ::cudaDeviceGetAttribute, ::cudaStreamAttachMemAsync
   ## 
   proc cudaMallocManaged*(devPtr: ptr pointer; size: csize; flags: cuint): cudaError_t {.
-      cdecl, importc: "cudaMallocManaged", dynlib: libName.}
+      cdecl, importc: "cudaMallocManaged", dyn.}
   ## *
   ##  \brief Allocate memory on the device
   ## 
@@ -2965,7 +2968,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaFreeHost, ::cudaHostAlloc
   ## 
   proc cudaMalloc*(devPtr: ptr pointer; size: csize): cudaError_t {.cdecl,
-      importc: "cudaMalloc", dynlib: libName.}
+      importc: "cudaMalloc", dyn.}
   ## *
   ##  \brief Allocates page-locked memory on the host
   ## 
@@ -2994,7 +2997,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaFreeHost, ::cudaHostAlloc
   ## 
   proc cudaMallocHost*(`ptr`: ptr pointer; size: csize): cudaError_t {.cdecl,
-      importc: "cudaMallocHost", dynlib: libName.}
+      importc: "cudaMallocHost", dyn.}
   ## *
   ##  \brief Allocates pitched memory on the device
   ## 
@@ -3034,7 +3037,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMallocPitch*(devPtr: ptr pointer; pitch: ptr csize; width: csize;
                        height: csize): cudaError_t {.cdecl,
-      importc: "cudaMallocPitch", dynlib: libName.}
+      importc: "cudaMallocPitch", dyn.}
   ## *
   ##  \brief Allocate an array on the device
   ## 
@@ -3077,7 +3080,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMallocArray*(array: ptr cudaArray_t; desc: ptr cudaChannelFormatDesc;
                        width: csize; height: csize; flags: cuint): cudaError_t {.cdecl,
-      importc: "cudaMallocArray", dynlib: libName.}
+      importc: "cudaMallocArray", dyn.}
   ## *
   ##  \brief Frees memory on the device
   ## 
@@ -3104,7 +3107,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaHostAlloc
   ## 
   proc cudaFree*(devPtr: pointer): cudaError_t {.cdecl, importc: "cudaFree",
-      dynlib: libName.}
+      dyn.}
   ## *
   ##  \brief Frees page-locked memory
   ## 
@@ -3124,7 +3127,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMalloc3D, ::cudaMalloc3DArray, ::cudaHostAlloc
   ## 
   proc cudaFreeHost*(`ptr`: pointer): cudaError_t {.cdecl, importc: "cudaFreeHost",
-      dynlib: libName.}
+      dyn.}
   ## *
   ##  \brief Frees an array on the device
   ## 
@@ -3146,7 +3149,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaFreeHost, ::cudaHostAlloc
   ## 
   proc cudaFreeArray*(array: cudaArray_t): cudaError_t {.cdecl,
-      importc: "cudaFreeArray", dynlib: libName.}
+      importc: "cudaFreeArray", dyn.}
   ## *
   ##  \brief Frees a mipmapped array on the device
   ## 
@@ -3168,7 +3171,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaFreeHost, ::cudaHostAlloc
   ## 
   proc cudaFreeMipmappedArray*(mipmappedArray: cudaMipmappedArray_t): cudaError_t {.
-      cdecl, importc: "cudaFreeMipmappedArray", dynlib: libName.}
+      cdecl, importc: "cudaFreeMipmappedArray", dyn.}
   ## *
   ##  \brief Allocates page-locked memory on the host
   ## 
@@ -3226,7 +3229,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaFreeHost
   ## 
   proc cudaHostAlloc*(pHost: ptr pointer; size: csize; flags: cuint): cudaError_t {.
-      cdecl, importc: "cudaHostAlloc", dynlib: libName.}
+      cdecl, importc: "cudaHostAlloc", dyn.}
   ## *
   ##  \brief Registers an existing host memory range for use by CUDA
   ## 
@@ -3303,7 +3306,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaHostUnregister, ::cudaHostGetFlags, ::cudaHostGetDevicePointer
   ## 
   proc cudaHostRegister*(`ptr`: pointer; size: csize; flags: cuint): cudaError_t {.
-      cdecl, importc: "cudaHostRegister", dynlib: libName.}
+      cdecl, importc: "cudaHostRegister", dyn.}
   ## *
   ##  \brief Unregisters a memory range that was registered with cudaHostRegister
   ## 
@@ -3322,7 +3325,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaHostUnregister
   ## 
   proc cudaHostUnregister*(`ptr`: pointer): cudaError_t {.cdecl,
-      importc: "cudaHostUnregister", dynlib: libName.}
+      importc: "cudaHostUnregister", dyn.}
   ## *
   ##  \brief Passes back device pointer of mapped host memory allocated by
   ##  cudaHostAlloc or registered by cudaHostRegister
@@ -3364,7 +3367,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaSetDeviceFlags, ::cudaHostAlloc
   ## 
   proc cudaHostGetDevicePointer*(pDevice: ptr pointer; pHost: pointer; flags: cuint): cudaError_t {.
-      cdecl, importc: "cudaHostGetDevicePointer", dynlib: libName.}
+      cdecl, importc: "cudaHostGetDevicePointer", dyn.}
   ## *
   ##  \brief Passes back flags used to allocate pinned host memory allocated by
   ##  cudaHostAlloc
@@ -3383,7 +3386,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaHostAlloc
   ## 
   proc cudaHostGetFlags*(pFlags: ptr cuint; pHost: pointer): cudaError_t {.cdecl,
-      importc: "cudaHostGetFlags", dynlib: libName.}
+      importc: "cudaHostGetFlags", dyn.}
   ## *
   ##  \brief Allocates logical 1D, 2D, or 3D memory objects on the device
   ## 
@@ -3418,7 +3421,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaFreeHost, ::cudaHostAlloc, ::make_cudaPitchedPtr, ::make_cudaExtent
   ## 
   proc cudaMalloc3D*(pitchedDevPtr: ptr cudaPitchedPtr; extent: cudaExtent): cudaError_t {.
-      cdecl, importc: "cudaMalloc3D", dynlib: libName.}
+      cdecl, importc: "cudaMalloc3D", dyn.}
   ## *
   ##  \brief Allocate an array on the device
   ## 
@@ -3554,7 +3557,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMalloc3DArray*(array: ptr cudaArray_t; desc: ptr cudaChannelFormatDesc;
                          extent: cudaExtent; flags: cuint): cudaError_t {.cdecl,
-      importc: "cudaMalloc3DArray", dynlib: libName.}
+      importc: "cudaMalloc3DArray", dyn.}
   ## *
   ##  \brief Allocate a mipmapped array on the device
   ## 
@@ -3677,7 +3680,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaMallocMipmappedArray*(mipmappedArray: ptr cudaMipmappedArray_t;
                                 desc: ptr cudaChannelFormatDesc;
                                 extent: cudaExtent; numLevels: cuint; flags: cuint): cudaError_t {.
-      cdecl, importc: "cudaMallocMipmappedArray", dynlib: libName.}
+      cdecl, importc: "cudaMallocMipmappedArray", dyn.}
   ## *
   ##  \brief Gets a mipmap level of a CUDA mipmapped array
   ## 
@@ -3705,7 +3708,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaGetMipmappedArrayLevel*(levelArray: ptr cudaArray_t;
                                   mipmappedArray: cudaMipmappedArray_const_t;
                                   level: cuint): cudaError_t {.cdecl,
-      importc: "cudaGetMipmappedArrayLevel", dynlib: libName.}
+      importc: "cudaGetMipmappedArrayLevel", dyn.}
   ## *
   ##  \brief Copies data between 3D objects
   ## 
@@ -3805,7 +3808,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::make_cudaExtent, ::make_cudaPos
   ## 
   proc cudaMemcpy3D*(p: ptr cudaMemcpy3DParms): cudaError_t {.cdecl,
-      importc: "cudaMemcpy3D", dynlib: libName.}
+      importc: "cudaMemcpy3D", dyn.}
   ## *
   ##  \brief Copies memory between devices
   ## 
@@ -3833,7 +3836,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpy3DPeerAsync
   ## 
   proc cudaMemcpy3DPeer*(p: ptr cudaMemcpy3DPeerParms): cudaError_t {.cdecl,
-      importc: "cudaMemcpy3DPeer", dynlib: libName.}
+      importc: "cudaMemcpy3DPeer", dyn.}
   ## *
   ##  \brief Copies data between 3D objects
   ## 
@@ -3944,7 +3947,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::make_cudaExtent, ::make_cudaPos
   ## 
   proc cudaMemcpy3DAsync*(p: ptr cudaMemcpy3DParms; stream: cudaStream_t): cudaError_t {.
-      cdecl, importc: "cudaMemcpy3DAsync", dynlib: libName.}
+      cdecl, importc: "cudaMemcpy3DAsync", dyn.}
   ## *
   ##  \brief Copies memory between devices asynchronously.
   ## 
@@ -3967,7 +3970,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpy3DPeerAsync
   ## 
   proc cudaMemcpy3DPeerAsync*(p: ptr cudaMemcpy3DPeerParms; stream: cudaStream_t): cudaError_t {.
-      cdecl, importc: "cudaMemcpy3DPeerAsync", dynlib: libName.}
+      cdecl, importc: "cudaMemcpy3DPeerAsync", dyn.}
   ## *
   ##  \brief Gets free and total device memory
   ## 
@@ -3986,7 +3989,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   ## 
   proc cudaMemGetInfo*(free: ptr csize; total: ptr csize): cudaError_t {.cdecl,
-      importc: "cudaMemGetInfo", dynlib: libName.}
+      importc: "cudaMemGetInfo", dyn.}
   ## *
   ##  \brief Gets info about the specified cudaArray
   ## 
@@ -4008,7 +4011,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaArrayGetInfo*(desc: ptr cudaChannelFormatDesc; extent: ptr cudaExtent;
                         flags: ptr cuint; array: cudaArray_t): cudaError_t {.cdecl,
-      importc: "cudaArrayGetInfo", dynlib: libName.}
+      importc: "cudaArrayGetInfo", dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4046,7 +4049,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
   ## 
   proc cudaMemcpy*(dst: pointer; src: pointer; count: csize; kind: cudaMemcpyKind): cudaError_t {.
-      cdecl, importc: "cudaMemcpy", dynlib: libName.}
+      cdecl, importc: "cudaMemcpy", dyn.}
   ## *
   ##  \brief Copies memory between two devices
   ## 
@@ -4079,7 +4082,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemcpyPeer*(dst: pointer; dstDevice: cint; src: pointer; srcDevice: cint;
                       count: csize): cudaError_t {.cdecl, importc: "cudaMemcpyPeer",
-      dynlib: libName.}
+      dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4118,7 +4121,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemcpyToArray*(dst: cudaArray_t; wOffset: csize; hOffset: csize;
                          src: pointer; count: csize; kind: cudaMemcpyKind): cudaError_t {.
-      cdecl, importc: "cudaMemcpyToArray", dynlib: libName.}
+      cdecl, importc: "cudaMemcpyToArray", dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4156,7 +4159,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemcpyFromArray*(dst: pointer; src: cudaArray_const_t; wOffset: csize;
                            hOffset: csize; count: csize; kind: cudaMemcpyKind): cudaError_t {.
-      cdecl, importc: "cudaMemcpyFromArray", dynlib: libName.}
+      cdecl, importc: "cudaMemcpyFromArray", dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4197,7 +4200,7 @@ when not defined(CUDA_RUNTIME_API_H):
                               hOffsetDst: csize; src: cudaArray_const_t;
                               wOffsetSrc: csize; hOffsetSrc: csize; count: csize;
                               kind: cudaMemcpyKind): cudaError_t {.cdecl,
-      importc: "cudaMemcpyArrayToArray", dynlib: libName.}
+      importc: "cudaMemcpyArrayToArray", dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4243,7 +4246,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemcpy2D*(dst: pointer; dpitch: csize; src: pointer; spitch: csize;
                     width: csize; height: csize; kind: cudaMemcpyKind): cudaError_t {.
-      cdecl, importc: "cudaMemcpy2D", dynlib: libName.}
+      cdecl, importc: "cudaMemcpy2D", dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4291,7 +4294,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaMemcpy2DToArray*(dst: cudaArray_t; wOffset: csize; hOffset: csize;
                            src: pointer; spitch: csize; width: csize; height: csize;
                            kind: cudaMemcpyKind): cudaError_t {.cdecl,
-      importc: "cudaMemcpy2DToArray", dynlib: libName.}
+      importc: "cudaMemcpy2DToArray", dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4339,7 +4342,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaMemcpy2DFromArray*(dst: pointer; dpitch: csize; src: cudaArray_const_t;
                              wOffset: csize; hOffset: csize; width: csize;
                              height: csize; kind: cudaMemcpyKind): cudaError_t {.
-      cdecl, importc: "cudaMemcpy2DFromArray", dynlib: libName.}
+      cdecl, importc: "cudaMemcpy2DFromArray", dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4385,7 +4388,7 @@ when not defined(CUDA_RUNTIME_API_H):
                                 hOffsetDst: csize; src: cudaArray_const_t;
                                 wOffsetSrc: csize; hOffsetSrc: csize; width: csize;
                                 height: csize; kind: cudaMemcpyKind): cudaError_t {.
-      cdecl, importc: "cudaMemcpy2DArrayToArray", dynlib: libName.}
+      cdecl, importc: "cudaMemcpy2DArrayToArray", dyn.}
   ## *
   ##  \brief Copies data to the given symbol on the device
   ## 
@@ -4424,7 +4427,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemcpyToSymbol*(symbol: pointer; src: pointer; count: csize; offset: csize;
                           kind: cudaMemcpyKind): cudaError_t {.cdecl,
-      importc: "cudaMemcpyToSymbol", dynlib: libName.}
+      importc: "cudaMemcpyToSymbol", dyn.}
   ## *
   ##  \brief Copies data from the given symbol on the device
   ## 
@@ -4463,7 +4466,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemcpyFromSymbol*(dst: pointer; symbol: pointer; count: csize;
                             offset: csize; kind: cudaMemcpyKind): cudaError_t {.
-      cdecl, importc: "cudaMemcpyFromSymbol", dynlib: libName.}
+      cdecl, importc: "cudaMemcpyFromSymbol", dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4514,7 +4517,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemcpyAsync*(dst: pointer; src: pointer; count: csize; kind: cudaMemcpyKind;
                        stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaMemcpyAsync", dynlib: libName.}
+      importc: "cudaMemcpyAsync", dyn.}
   ## *
   ##  \brief Copies memory between two devices asynchronously.
   ## 
@@ -4547,7 +4550,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemcpyPeerAsync*(dst: pointer; dstDevice: cint; src: pointer;
                            srcDevice: cint; count: csize; stream: cudaStream_t): cudaError_t {.
-      cdecl, importc: "cudaMemcpyPeerAsync", dynlib: libName.}
+      cdecl, importc: "cudaMemcpyPeerAsync", dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4595,7 +4598,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaMemcpyToArrayAsync*(dst: cudaArray_t; wOffset: csize; hOffset: csize;
                               src: pointer; count: csize; kind: cudaMemcpyKind;
                               stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaMemcpyToArrayAsync", dynlib: libName.}
+      importc: "cudaMemcpyToArrayAsync", dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4642,7 +4645,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaMemcpyFromArrayAsync*(dst: pointer; src: cudaArray_const_t;
                                 wOffset: csize; hOffset: csize; count: csize;
                                 kind: cudaMemcpyKind; stream: cudaStream_t): cudaError_t {.
-      cdecl, importc: "cudaMemcpyFromArrayAsync", dynlib: libName.}
+      cdecl, importc: "cudaMemcpyFromArrayAsync", dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4704,7 +4707,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaMemcpy2DAsync*(dst: pointer; dpitch: csize; src: pointer; spitch: csize;
                          width: csize; height: csize; kind: cudaMemcpyKind;
                          stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaMemcpy2DAsync", dynlib: libName.}
+      importc: "cudaMemcpy2DAsync", dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4762,7 +4765,7 @@ when not defined(CUDA_RUNTIME_API_H):
                                 src: pointer; spitch: csize; width: csize;
                                 height: csize; kind: cudaMemcpyKind;
                                 stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaMemcpy2DToArrayAsync", dynlib: libName.}
+      importc: "cudaMemcpy2DToArrayAsync", dyn.}
   ## *
   ##  \brief Copies data between host and device
   ## 
@@ -4819,7 +4822,7 @@ when not defined(CUDA_RUNTIME_API_H):
                                   src: cudaArray_const_t; wOffset: csize;
                                   hOffset: csize; width: csize; height: csize;
                                   kind: cudaMemcpyKind; stream: cudaStream_t): cudaError_t {.
-      cdecl, importc: "cudaMemcpy2DFromArrayAsync", dynlib: libName.}
+      cdecl, importc: "cudaMemcpy2DFromArrayAsync", dyn.}
   ## *
   ##  \brief Copies data to the given symbol on the device
   ## 
@@ -4867,7 +4870,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaMemcpyToSymbolAsync*(symbol: pointer; src: pointer; count: csize;
                                offset: csize; kind: cudaMemcpyKind;
                                stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaMemcpyToSymbolAsync", dynlib: libName.}
+      importc: "cudaMemcpyToSymbolAsync", dyn.}
   ## *
   ##  \brief Copies data from the given symbol on the device
   ## 
@@ -4915,7 +4918,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaMemcpyFromSymbolAsync*(dst: pointer; symbol: pointer; count: csize;
                                  offset: csize; kind: cudaMemcpyKind;
                                  stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaMemcpyFromSymbolAsync", dynlib: libName.}
+      importc: "cudaMemcpyFromSymbolAsync", dyn.}
   ## *
   ##  \brief Initializes or sets device memory to a value
   ## 
@@ -4940,7 +4943,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemset2DAsync, ::cudaMemset3DAsync
   ## 
   proc cudaMemset*(devPtr: pointer; value: cint; count: csize): cudaError_t {.cdecl,
-      importc: "cudaMemset", dynlib: libName.}
+      importc: "cudaMemset", dyn.}
   ## *
   ##  \brief Initializes or sets device memory to a value
   ## 
@@ -4971,7 +4974,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemset2D*(devPtr: pointer; pitch: csize; value: cint; width: csize;
                     height: csize): cudaError_t {.cdecl, importc: "cudaMemset2D",
-      dynlib: libName.}
+      dyn.}
   ## *
   ##  \brief Initializes or sets device memory to a value
   ## 
@@ -5014,7 +5017,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::make_cudaExtent
   ## 
   proc cudaMemset3D*(pitchedDevPtr: cudaPitchedPtr; value: cint; extent: cudaExtent): cudaError_t {.
-      cdecl, importc: "cudaMemset3D", dynlib: libName.}
+      cdecl, importc: "cudaMemset3D", dyn.}
   ## *
   ##  \brief Initializes or sets device memory to a value
   ## 
@@ -5047,7 +5050,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemsetAsync*(devPtr: pointer; value: cint; count: csize;
                        stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaMemsetAsync", dynlib: libName.}
+      importc: "cudaMemsetAsync", dyn.}
   ## *
   ##  \brief Initializes or sets device memory to a value
   ## 
@@ -5085,7 +5088,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemset2DAsync*(devPtr: pointer; pitch: csize; value: cint; width: csize;
                          height: csize; stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaMemset2DAsync", dynlib: libName.}
+      importc: "cudaMemset2DAsync", dyn.}
   ## *
   ##  \brief Initializes or sets device memory to a value
   ## 
@@ -5136,7 +5139,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemset3DAsync*(pitchedDevPtr: cudaPitchedPtr; value: cint;
                          extent: cudaExtent; stream: cudaStream_t): cudaError_t {.
-      cdecl, importc: "cudaMemset3DAsync", dynlib: libName.}
+      cdecl, importc: "cudaMemset3DAsync", dyn.}
   ## *
   ##  \brief Finds the address associated with a CUDA symbol
   ## 
@@ -5159,7 +5162,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \ref ::cudaGetSymbolSize(size_t*, const void*) "cudaGetSymbolSize (C API)"
   ## 
   proc cudaGetSymbolAddress*(devPtr: ptr pointer; symbol: pointer): cudaError_t {.
-      cdecl, importc: "cudaGetSymbolAddress", dynlib: libName.}
+      cdecl, importc: "cudaGetSymbolAddress", dyn.}
   ## *
   ##  \brief Finds the size of the object associated with a CUDA symbol
   ## 
@@ -5181,7 +5184,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \ref ::cudaGetSymbolSize(size_t*, const T&) "cudaGetSymbolSize (C++ API)"
   ## 
   proc cudaGetSymbolSize*(size: ptr csize; symbol: pointer): cudaError_t {.cdecl,
-      importc: "cudaGetSymbolSize", dynlib: libName.}
+      importc: "cudaGetSymbolSize", dyn.}
   ## *
   ##  \brief Prefetches memory to the specified destination device
   ## 
@@ -5249,7 +5252,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemPrefetchAsync*(devPtr: pointer; count: csize; dstDevice: cint;
                             stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaMemPrefetchAsync", dynlib: libName.}
+      importc: "cudaMemPrefetchAsync", dyn.}
   ## *
   ##  \brief Advise about the usage of a given memory range
   ## 
@@ -5336,7 +5339,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaMemAdvise*(devPtr: pointer; count: csize; advice: cudaMemoryAdvise;
                      device: cint): cudaError_t {.cdecl, importc: "cudaMemAdvise",
-      dynlib: libName.}
+      dyn.}
   ## *
   ##  \brief Query an attribute of a given memory range
   ## 
@@ -5394,7 +5397,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaMemRangeGetAttribute*(data: pointer; dataSize: csize;
                                 attribute: cudaMemRangeAttribute; devPtr: pointer;
                                 count: csize): cudaError_t {.cdecl,
-      importc: "cudaMemRangeGetAttribute", dynlib: libName.}
+      importc: "cudaMemRangeGetAttribute", dyn.}
   ## *
   ##  \brief Query attributes of a given memory range.
   ## 
@@ -5432,7 +5435,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaMemRangeGetAttributes*(data: ptr pointer; dataSizes: ptr csize;
                                  attributes: ptr cudaMemRangeAttribute;
                                  numAttributes: csize; devPtr: pointer; count: csize): cudaError_t {.
-      cdecl, importc: "cudaMemRangeGetAttributes", dynlib: libName.}
+      cdecl, importc: "cudaMemRangeGetAttributes", dyn.}
   ## * @}
   ##  END CUDART_MEMORY
   ## *
@@ -5585,7 +5588,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaPointerGetAttributes*(attributes: ptr cudaPointerAttributes;
                                 `ptr`: pointer): cudaError_t {.cdecl,
-      importc: "cudaPointerGetAttributes", dynlib: libName.}
+      importc: "cudaPointerGetAttributes", dyn.}
   ## * @}
   ##  END CUDART_UNIFIED
   ## *
@@ -5623,7 +5626,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaDeviceCanAccessPeer*(canAccessPeer: ptr cint; device: cint;
                                peerDevice: cint): cudaError_t {.cdecl,
-      importc: "cudaDeviceCanAccessPeer", dynlib: libName.}
+      importc: "cudaDeviceCanAccessPeer", dyn.}
   ## *
   ##  \brief Enables direct access to memory allocations on a peer device.
   ## 
@@ -5662,7 +5665,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaDeviceDisablePeerAccess
   ## 
   proc cudaDeviceEnablePeerAccess*(peerDevice: cint; flags: cuint): cudaError_t {.
-      cdecl, importc: "cudaDeviceEnablePeerAccess", dynlib: libName.}
+      cdecl, importc: "cudaDeviceEnablePeerAccess", dyn.}
   ## *
   ##  \brief Disables direct access to memory allocations on a peer device.
   ## 
@@ -5681,7 +5684,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaDeviceEnablePeerAccess
   ## 
   proc cudaDeviceDisablePeerAccess*(peerDevice: cint): cudaError_t {.cdecl,
-      importc: "cudaDeviceDisablePeerAccess", dynlib: libName.}
+      importc: "cudaDeviceDisablePeerAccess", dyn.}
   ## * @}
   ##  END CUDART_PEER
   ## * \defgroup CUDART_OPENGL OpenGL Interoperability
@@ -5730,7 +5733,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaGraphicsGLRegisterImage
   ## 
   proc cudaGraphicsUnregisterResource*(resource: cudaGraphicsResource_t): cudaError_t {.
-      cdecl, importc: "cudaGraphicsUnregisterResource", dynlib: libName.}
+      cdecl, importc: "cudaGraphicsUnregisterResource", dyn.}
   ## *
   ##  \brief Set usage flags for mapping a graphics resource
   ## 
@@ -5763,7 +5766,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaGraphicsResourceSetMapFlags*(resource: cudaGraphicsResource_t;
                                        flags: cuint): cudaError_t {.cdecl,
-      importc: "cudaGraphicsResourceSetMapFlags", dynlib: libName.}
+      importc: "cudaGraphicsResourceSetMapFlags", dyn.}
   ## *
   ##  \brief Map graphics resources for access by CUDA
   ## 
@@ -5801,7 +5804,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaGraphicsMapResources*(count: cint;
                                 resources: ptr cudaGraphicsResource_t;
                                 stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaGraphicsMapResources", dynlib: libName.}
+      importc: "cudaGraphicsMapResources", dyn.}
   ## *
   ##  \brief Unmap graphics resources.
   ## 
@@ -5835,7 +5838,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaGraphicsUnmapResources*(count: cint;
                                   resources: ptr cudaGraphicsResource_t;
                                   stream: cudaStream_t): cudaError_t {.cdecl,
-      importc: "cudaGraphicsUnmapResources", dynlib: libName.}
+      importc: "cudaGraphicsUnmapResources", dyn.}
   ## *
   ##  \brief Get an device pointer through which to access a mapped graphics resource.
   ## 
@@ -5865,7 +5868,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaGraphicsResourceGetMappedPointer*(devPtr: ptr pointer; size: ptr csize;
       resource: cudaGraphicsResource_t): cudaError_t {.cdecl,
-      importc: "cudaGraphicsResourceGetMappedPointer", dynlib: libName.}
+      importc: "cudaGraphicsResourceGetMappedPointer", dyn.}
   ## *
   ##  \brief Get an array through which to access a subresource of a mapped graphics resource.
   ## 
@@ -5900,7 +5903,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaGraphicsSubResourceGetMappedArray*(array: ptr cudaArray_t;
       resource: cudaGraphicsResource_t; arrayIndex: cuint; mipLevel: cuint): cudaError_t {.
-      cdecl, importc: "cudaGraphicsSubResourceGetMappedArray", dynlib: libName.}
+      cdecl, importc: "cudaGraphicsSubResourceGetMappedArray", dyn.}
   ## *
   ##  \brief Get a mipmapped array through which to access a mapped graphics resource.
   ## 
@@ -5927,7 +5930,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaGraphicsResourceGetMappedMipmappedArray*(
       mipmappedArray: ptr cudaMipmappedArray_t; resource: cudaGraphicsResource_t): cudaError_t {.
       cdecl, importc: "cudaGraphicsResourceGetMappedMipmappedArray",
-      dynlib: libName.}
+      dyn.}
   ## * @}
   ##  END CUDART_INTEROP
   ## *
@@ -5966,7 +5969,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"
   ## 
   proc cudaGetChannelDesc*(desc: ptr cudaChannelFormatDesc; array: cudaArray_const_t): cudaError_t {.
-      cdecl, importc: "cudaGetChannelDesc", dynlib: libName.}
+      cdecl, importc: "cudaGetChannelDesc", dyn.}
   ## *
   ##  \brief Returns a channel descriptor using the specified format
   ## 
@@ -6002,7 +6005,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaCreateChannelDesc*(x: cint; y: cint; z: cint; w: cint;
                              f: cudaChannelFormatKind): cudaChannelFormatDesc {.
-      cdecl, importc: "cudaCreateChannelDesc", dynlib: libName.}
+      cdecl, importc: "cudaCreateChannelDesc", dyn.}
   ## *
   ##  \brief Binds a memory area to a texture
   ## 
@@ -6049,7 +6052,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaBindTexture*(offset: ptr csize; texref: ptr textureReference;
                        devPtr: pointer; desc: ptr cudaChannelFormatDesc; size: csize): cudaError_t {.
-      cdecl, importc: "cudaBindTexture", dynlib: libName.}
+      cdecl, importc: "cudaBindTexture", dyn.}
   ## *
   ##  \brief Binds a 2D memory area to a texture
   ## 
@@ -6102,7 +6105,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaBindTexture2D*(offset: ptr csize; texref: ptr textureReference;
                          devPtr: pointer; desc: ptr cudaChannelFormatDesc;
                          width: csize; height: csize; pitch: csize): cudaError_t {.
-      cdecl, importc: "cudaBindTexture2D", dynlib: libName.}
+      cdecl, importc: "cudaBindTexture2D", dyn.}
   ## *
   ##  \brief Binds an array to a texture
   ## 
@@ -6132,7 +6135,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaBindTextureToArray*(texref: ptr textureReference;
                               array: cudaArray_const_t;
                               desc: ptr cudaChannelFormatDesc): cudaError_t {.cdecl,
-      importc: "cudaBindTextureToArray", dynlib: libName.}
+      importc: "cudaBindTextureToArray", dyn.}
   ## *
   ##  \brief Binds a mipmapped array to a texture
   ## 
@@ -6161,7 +6164,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaBindTextureToMipmappedArray*(texref: ptr textureReference; mipmappedArray: cudaMipmappedArray_const_t;
                                        desc: ptr cudaChannelFormatDesc): cudaError_t {.
-      cdecl, importc: "cudaBindTextureToMipmappedArray", dynlib: libName.}
+      cdecl, importc: "cudaBindTextureToMipmappedArray", dyn.}
   ## *
   ##  \brief Unbinds a texture
   ## 
@@ -6182,7 +6185,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"
   ## 
   proc cudaUnbindTexture*(texref: ptr textureReference): cudaError_t {.cdecl,
-      importc: "cudaUnbindTexture", dynlib: libName.}
+      importc: "cudaUnbindTexture", dyn.}
   ## *
   ##  \brief Get the alignment offset of a texture
   ## 
@@ -6208,7 +6211,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaGetTextureAlignmentOffset*(offset: ptr csize;
                                      texref: ptr textureReference): cudaError_t {.
-      cdecl, importc: "cudaGetTextureAlignmentOffset", dynlib: libName.}
+      cdecl, importc: "cudaGetTextureAlignmentOffset", dyn.}
   ## *
   ##  \brief Get the texture reference associated with a symbol
   ## 
@@ -6233,7 +6236,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)"
   ## 
   proc cudaGetTextureReference*(texref: ptr ptr textureReference; symbol: pointer): cudaError_t {.
-      cdecl, importc: "cudaGetTextureReference", dynlib: libName.}
+      cdecl, importc: "cudaGetTextureReference", dyn.}
   ## * @}
   ##  END CUDART_TEXTURE
   ## *
@@ -6274,7 +6277,7 @@ when not defined(CUDA_RUNTIME_API_H):
   proc cudaBindSurfaceToArray*(surfref: ptr surfaceReference;
                               array: cudaArray_const_t;
                               desc: ptr cudaChannelFormatDesc): cudaError_t {.cdecl,
-      importc: "cudaBindSurfaceToArray", dynlib: libName.}
+      importc: "cudaBindSurfaceToArray", dyn.}
   ## *
   ##  \brief Get the surface reference associated with a symbol
   ## 
@@ -6293,7 +6296,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa \ref ::cudaBindSurfaceToArray(const struct surfaceReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindSurfaceToArray (C API)"
   ## 
   proc cudaGetSurfaceReference*(surfref: ptr ptr surfaceReference; symbol: pointer): cudaError_t {.
-      cdecl, importc: "cudaGetSurfaceReference", dynlib: libName.}
+      cdecl, importc: "cudaGetSurfaceReference", dyn.}
   ## * @}
   ##  END CUDART_SURFACE
   ## *
@@ -6520,7 +6523,7 @@ when not defined(CUDA_RUNTIME_API_H):
                                pResDesc: ptr cudaResourceDesc;
                                pTexDesc: ptr cudaTextureDesc;
                                pResViewDesc: ptr cudaResourceViewDesc): cudaError_t {.
-      cdecl, importc: "cudaCreateTextureObject", dynlib: libName.}
+      cdecl, importc: "cudaCreateTextureObject", dyn.}
   ## *
   ##  \brief Destroys a texture object
   ## 
@@ -6535,7 +6538,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaCreateTextureObject
   ## 
   proc cudaDestroyTextureObject*(texObject: cudaTextureObject_t): cudaError_t {.
-      cdecl, importc: "cudaDestroyTextureObject", dynlib: libName.}
+      cdecl, importc: "cudaDestroyTextureObject", dyn.}
   ## *
   ##  \brief Returns a texture object's resource descriptor
   ## 
@@ -6552,7 +6555,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaGetTextureObjectResourceDesc*(pResDesc: ptr cudaResourceDesc;
                                         texObject: cudaTextureObject_t): cudaError_t {.
-      cdecl, importc: "cudaGetTextureObjectResourceDesc", dynlib: libName.}
+      cdecl, importc: "cudaGetTextureObjectResourceDesc", dyn.}
   ## *
   ##  \brief Returns a texture object's texture descriptor
   ## 
@@ -6569,7 +6572,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaGetTextureObjectTextureDesc*(pTexDesc: ptr cudaTextureDesc;
                                        texObject: cudaTextureObject_t): cudaError_t {.
-      cdecl, importc: "cudaGetTextureObjectTextureDesc", dynlib: libName.}
+      cdecl, importc: "cudaGetTextureObjectTextureDesc", dyn.}
   ## *
   ##  \brief Returns a texture object's resource view descriptor
   ## 
@@ -6587,7 +6590,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaGetTextureObjectResourceViewDesc*(
       pResViewDesc: ptr cudaResourceViewDesc; texObject: cudaTextureObject_t): cudaError_t {.
-      cdecl, importc: "cudaGetTextureObjectResourceViewDesc", dynlib: libName.}
+      cdecl, importc: "cudaGetTextureObjectResourceViewDesc", dyn.}
   ## * @}
   ##  END CUDART_TEXTURE_OBJECT
   ## *
@@ -6625,7 +6628,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaCreateSurfaceObject*(pSurfObject: ptr cudaSurfaceObject_t;
                                pResDesc: ptr cudaResourceDesc): cudaError_t {.cdecl,
-      importc: "cudaCreateSurfaceObject", dynlib: libName.}
+      importc: "cudaCreateSurfaceObject", dyn.}
   ## *
   ##  \brief Destroys a surface object
   ## 
@@ -6640,7 +6643,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaCreateSurfaceObject
   ## 
   proc cudaDestroySurfaceObject*(surfObject: cudaSurfaceObject_t): cudaError_t {.
-      cdecl, importc: "cudaDestroySurfaceObject", dynlib: libName.}
+      cdecl, importc: "cudaDestroySurfaceObject", dyn.}
   ## *
   ##  \brief Returns a surface object's resource descriptor
   ##  Returns the resource descriptor for the surface object specified by \p surfObject.
@@ -6656,7 +6659,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## 
   proc cudaGetSurfaceObjectResourceDesc*(pResDesc: ptr cudaResourceDesc;
                                         surfObject: cudaSurfaceObject_t): cudaError_t {.
-      cdecl, importc: "cudaGetSurfaceObjectResourceDesc", dynlib: libName.}
+      cdecl, importc: "cudaGetSurfaceObjectResourceDesc", dyn.}
   ## * @}
   ##  END CUDART_SURFACE_OBJECT
   ## *
@@ -6682,7 +6685,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaRuntimeGetVersion
   ## 
   proc cudaDriverGetVersion*(driverVersion: ptr cint): cudaError_t {.cdecl,
-      importc: "cudaDriverGetVersion", dynlib: libName.}
+      importc: "cudaDriverGetVersion", dyn.}
   ## *
   ##  \brief Returns the CUDA Runtime version
   ## 
@@ -6699,13 +6702,13 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \sa ::cudaDriverGetVersion
   ## 
   proc cudaRuntimeGetVersion*(runtimeVersion: ptr cint): cudaError_t {.cdecl,
-      importc: "cudaRuntimeGetVersion", dynlib: libName.}
+      importc: "cudaRuntimeGetVersion", dyn.}
   ## * @}
   ##  END CUDART__VERSION
   ## * \cond impl_private
   proc cudaGetExportTable*(ppExportTable: ptr pointer;
                           pExportTableId: ptr cudaUUID_t): cudaError_t {.cdecl,
-      importc: "cudaGetExportTable", dynlib: libName.}
+      importc: "cudaGetExportTable", dyn.}
   ## * \endcond impl_private
   ## *
   ##  \defgroup CUDART_HIGHLEVEL C++ API Routines

--- a/nimcuda/cufft.nim
+++ b/nimcuda/cufft.nim
@@ -1,13 +1,16 @@
  {.deadCodeElim: on.}
 when defined(windows):
-  const
-    libName = "cufft.dll"
+  import os
+  {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cufft.lib" & "\"".}
+  {.pragma: dyn.}
 elif defined(macosx):
   const
     libName = "libcufft.dylib"
+  {.pragma: dyn, dynlib: libName.}
 else:
   const
     libName = "libcufft.so"
+  {.pragma: dyn, dynlib: libName.}
 type
   cudaStream_t* = pointer
 
@@ -140,97 +143,97 @@ type
   cufftHandle* = cint
 
 proc cufftPlan1d*(plan: ptr cufftHandle; nx: cint; `type`: cufftType; batch: cint): cufftResult {.
-    cdecl, importc: "cufftPlan1d", dynlib: libName.}
+    cdecl, importc: "cufftPlan1d", dyn.}
 proc cufftPlan2d*(plan: ptr cufftHandle; nx: cint; ny: cint; `type`: cufftType): cufftResult {.
-    cdecl, importc: "cufftPlan2d", dynlib: libName.}
+    cdecl, importc: "cufftPlan2d", dyn.}
 proc cufftPlan3d*(plan: ptr cufftHandle; nx: cint; ny: cint; nz: cint; `type`: cufftType): cufftResult {.
-    cdecl, importc: "cufftPlan3d", dynlib: libName.}
+    cdecl, importc: "cufftPlan3d", dyn.}
 proc cufftPlanMany*(plan: ptr cufftHandle; rank: cint; n: ptr cint; inembed: ptr cint;
                    istride: cint; idist: cint; onembed: ptr cint; ostride: cint;
                    odist: cint; `type`: cufftType; batch: cint): cufftResult {.cdecl,
-    importc: "cufftPlanMany", dynlib: libName.}
+    importc: "cufftPlanMany", dyn.}
 proc cufftMakePlan1d*(plan: cufftHandle; nx: cint; `type`: cufftType; batch: cint;
                      workSize: ptr csize): cufftResult {.cdecl,
-    importc: "cufftMakePlan1d", dynlib: libName.}
+    importc: "cufftMakePlan1d", dyn.}
 proc cufftMakePlan2d*(plan: cufftHandle; nx: cint; ny: cint; `type`: cufftType;
                      workSize: ptr csize): cufftResult {.cdecl,
-    importc: "cufftMakePlan2d", dynlib: libName.}
+    importc: "cufftMakePlan2d", dyn.}
 proc cufftMakePlan3d*(plan: cufftHandle; nx: cint; ny: cint; nz: cint; `type`: cufftType;
                      workSize: ptr csize): cufftResult {.cdecl,
-    importc: "cufftMakePlan3d", dynlib: libName.}
+    importc: "cufftMakePlan3d", dyn.}
 proc cufftMakePlanMany*(plan: cufftHandle; rank: cint; n: ptr cint; inembed: ptr cint;
                        istride: cint; idist: cint; onembed: ptr cint; ostride: cint;
                        odist: cint; `type`: cufftType; batch: cint;
                        workSize: ptr csize): cufftResult {.cdecl,
-    importc: "cufftMakePlanMany", dynlib: libName.}
+    importc: "cufftMakePlanMany", dyn.}
 proc cufftMakePlanMany64*(plan: cufftHandle; rank: cint; n: ptr clonglong;
                          inembed: ptr clonglong; istride: clonglong;
                          idist: clonglong; onembed: ptr clonglong;
                          ostride: clonglong; odist: clonglong; `type`: cufftType;
                          batch: clonglong; workSize: ptr csize): cufftResult {.cdecl,
-    importc: "cufftMakePlanMany64", dynlib: libName.}
+    importc: "cufftMakePlanMany64", dyn.}
 proc cufftGetSizeMany64*(plan: cufftHandle; rank: cint; n: ptr clonglong;
                         inembed: ptr clonglong; istride: clonglong; idist: clonglong;
                         onembed: ptr clonglong; ostride: clonglong; odist: clonglong;
                         `type`: cufftType; batch: clonglong; workSize: ptr csize): cufftResult {.
-    cdecl, importc: "cufftGetSizeMany64", dynlib: libName.}
+    cdecl, importc: "cufftGetSizeMany64", dyn.}
 proc cufftEstimate1d*(nx: cint; `type`: cufftType; batch: cint; workSize: ptr csize): cufftResult {.
-    cdecl, importc: "cufftEstimate1d", dynlib: libName.}
+    cdecl, importc: "cufftEstimate1d", dyn.}
 proc cufftEstimate2d*(nx: cint; ny: cint; `type`: cufftType; workSize: ptr csize): cufftResult {.
-    cdecl, importc: "cufftEstimate2d", dynlib: libName.}
+    cdecl, importc: "cufftEstimate2d", dyn.}
 proc cufftEstimate3d*(nx: cint; ny: cint; nz: cint; `type`: cufftType;
                      workSize: ptr csize): cufftResult {.cdecl,
-    importc: "cufftEstimate3d", dynlib: libName.}
+    importc: "cufftEstimate3d", dyn.}
 proc cufftEstimateMany*(rank: cint; n: ptr cint; inembed: ptr cint; istride: cint;
                        idist: cint; onembed: ptr cint; ostride: cint; odist: cint;
                        `type`: cufftType; batch: cint; workSize: ptr csize): cufftResult {.
-    cdecl, importc: "cufftEstimateMany", dynlib: libName.}
+    cdecl, importc: "cufftEstimateMany", dyn.}
 proc cufftCreate*(handle: ptr cufftHandle): cufftResult {.cdecl,
-    importc: "cufftCreate", dynlib: libName.}
+    importc: "cufftCreate", dyn.}
 proc cufftGetSize1d*(handle: cufftHandle; nx: cint; `type`: cufftType; batch: cint;
                     workSize: ptr csize): cufftResult {.cdecl,
-    importc: "cufftGetSize1d", dynlib: libName.}
+    importc: "cufftGetSize1d", dyn.}
 proc cufftGetSize2d*(handle: cufftHandle; nx: cint; ny: cint; `type`: cufftType;
                     workSize: ptr csize): cufftResult {.cdecl,
-    importc: "cufftGetSize2d", dynlib: libName.}
+    importc: "cufftGetSize2d", dyn.}
 proc cufftGetSize3d*(handle: cufftHandle; nx: cint; ny: cint; nz: cint;
                     `type`: cufftType; workSize: ptr csize): cufftResult {.cdecl,
-    importc: "cufftGetSize3d", dynlib: libName.}
+    importc: "cufftGetSize3d", dyn.}
 proc cufftGetSizeMany*(handle: cufftHandle; rank: cint; n: ptr cint; inembed: ptr cint;
                       istride: cint; idist: cint; onembed: ptr cint; ostride: cint;
                       odist: cint; `type`: cufftType; batch: cint; workArea: ptr csize): cufftResult {.
-    cdecl, importc: "cufftGetSizeMany", dynlib: libName.}
+    cdecl, importc: "cufftGetSizeMany", dyn.}
 proc cufftGetSize*(handle: cufftHandle; workSize: ptr csize): cufftResult {.cdecl,
-    importc: "cufftGetSize", dynlib: libName.}
+    importc: "cufftGetSize", dyn.}
 proc cufftSetWorkArea*(plan: cufftHandle; workArea: pointer): cufftResult {.cdecl,
-    importc: "cufftSetWorkArea", dynlib: libName.}
+    importc: "cufftSetWorkArea", dyn.}
 proc cufftSetAutoAllocation*(plan: cufftHandle; autoAllocate: cint): cufftResult {.
-    cdecl, importc: "cufftSetAutoAllocation", dynlib: libName.}
+    cdecl, importc: "cufftSetAutoAllocation", dyn.}
 proc cufftExecC2C*(plan: cufftHandle; idata: ptr cufftComplex;
                   odata: ptr cufftComplex; direction: cint): cufftResult {.cdecl,
-    importc: "cufftExecC2C", dynlib: libName.}
+    importc: "cufftExecC2C", dyn.}
 proc cufftExecR2C*(plan: cufftHandle; idata: ptr cufftReal; odata: ptr cufftComplex): cufftResult {.
-    cdecl, importc: "cufftExecR2C", dynlib: libName.}
+    cdecl, importc: "cufftExecR2C", dyn.}
 proc cufftExecC2R*(plan: cufftHandle; idata: ptr cufftComplex; odata: ptr cufftReal): cufftResult {.
-    cdecl, importc: "cufftExecC2R", dynlib: libName.}
+    cdecl, importc: "cufftExecC2R", dyn.}
 proc cufftExecZ2Z*(plan: cufftHandle; idata: ptr cufftDoubleComplex;
                   odata: ptr cufftDoubleComplex; direction: cint): cufftResult {.
-    cdecl, importc: "cufftExecZ2Z", dynlib: libName.}
+    cdecl, importc: "cufftExecZ2Z", dyn.}
 proc cufftExecD2Z*(plan: cufftHandle; idata: ptr cufftDoubleReal;
                   odata: ptr cufftDoubleComplex): cufftResult {.cdecl,
-    importc: "cufftExecD2Z", dynlib: libName.}
+    importc: "cufftExecD2Z", dyn.}
 proc cufftExecZ2D*(plan: cufftHandle; idata: ptr cufftDoubleComplex;
                   odata: ptr cufftDoubleReal): cufftResult {.cdecl,
-    importc: "cufftExecZ2D", dynlib: libName.}
+    importc: "cufftExecZ2D", dyn.}
 ##  utility functions
 
 proc cufftSetStream*(plan: cufftHandle; stream: cudaStream_t): cufftResult {.cdecl,
-    importc: "cufftSetStream", dynlib: libName.}
+    importc: "cufftSetStream", dyn.}
 proc cufftSetCompatibilityMode*(plan: cufftHandle; mode: cufftCompatibility): cufftResult {.
-    cdecl, importc: "cufftSetCompatibilityMode", dynlib: libName.}
+    cdecl, importc: "cufftSetCompatibilityMode", dyn.}
 proc cufftDestroy*(plan: cufftHandle): cufftResult {.cdecl, importc: "cufftDestroy",
-    dynlib: libName.}
+    dyn.}
 proc cufftGetVersion*(version: ptr cint): cufftResult {.cdecl,
-    importc: "cufftGetVersion", dynlib: libName.}
+    importc: "cufftGetVersion", dyn.}
 proc cufftGetProperty*(`type`: libraryPropertyType; value: ptr cint): cufftResult {.
-    cdecl, importc: "cufftGetProperty", dynlib: libName.}
+    cdecl, importc: "cufftGetProperty", dyn.}

--- a/nimcuda/curand.nim
+++ b/nimcuda/curand.nim
@@ -1,13 +1,16 @@
  {.deadCodeElim: on.}
 when defined(windows):
-  const
-    libName = "curand.dll"
+    import os
+    {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "curand.lib" & "\"".}
+    {.pragma: dyn.}
 elif defined(macosx):
   const
     libName = "libcurand.dylib"
+  {.pragma: dyn, dynlib: libName.}
 else:
   const
     libName = "libcurand.so"
+  {.pragma: dyn, dynlib: libName.}
 type
   curandDistributionShift_st = object
   
@@ -310,7 +313,7 @@ when not defined(CURAND_H):
   ## 
   proc curandCreateGenerator*(generator: ptr curandGenerator_t;
                              rng_type: curandRngType_t): curandStatus_t {.cdecl,
-      importc: "curandCreateGenerator", dynlib: libName.}
+      importc: "curandCreateGenerator", dyn.}
   ## *
   ##  \brief Create new host CPU random number generator.
   ## 
@@ -390,7 +393,7 @@ when not defined(CURAND_H):
   ## 
   proc curandCreateGeneratorHost*(generator: ptr curandGenerator_t;
                                  rng_type: curandRngType_t): curandStatus_t {.
-      cdecl, importc: "curandCreateGeneratorHost", dynlib: libName.}
+      cdecl, importc: "curandCreateGeneratorHost", dyn.}
   ## *
   ##  \brief Destroy an existing generator.
   ## 
@@ -403,7 +406,7 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_SUCCESS if generator was destroyed successfully \n
   ## 
   proc curandDestroyGenerator*(generator: curandGenerator_t): curandStatus_t {.
-      cdecl, importc: "curandDestroyGenerator", dynlib: libName.}
+      cdecl, importc: "curandDestroyGenerator", dyn.}
   ## *
   ##  \brief Return the version number of the library.
   ## 
@@ -418,7 +421,7 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_SUCCESS if the version number was successfully returned \n
   ## 
   proc curandGetVersion*(version: ptr cint): curandStatus_t {.cdecl,
-      importc: "curandGetVersion", dynlib: libName.}
+      importc: "curandGetVersion", dyn.}
   ## *
   ##  \brief Return the value of the curand property.
   ## 
@@ -433,7 +436,7 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_OUT_OF_RANGE if the property type is not recognized \n
   ## 
   proc curandGetProperty*(`type`: libraryPropertyType; value: ptr cint): curandStatus_t {.
-      cdecl, importc: "curandGetProperty", dynlib: libName.}
+      cdecl, importc: "curandGetProperty", dyn.}
   ## *
   ##  \brief Set the current stream for CURAND kernel launches.
   ## 
@@ -448,7 +451,7 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_SUCCESS if stream was set successfully \n
   ## 
   proc curandSetStream*(generator: curandGenerator_t; stream: cudaStream_t): curandStatus_t {.
-      cdecl, importc: "curandSetStream", dynlib: libName.}
+      cdecl, importc: "curandSetStream", dyn.}
   ## *
   ##  \brief Set the seed value of the pseudo-random number generator.  
   ##  
@@ -467,7 +470,7 @@ when not defined(CURAND_H):
   ## 
   proc curandSetPseudoRandomGeneratorSeed*(generator: curandGenerator_t;
       seed: culonglong): curandStatus_t {.cdecl, importc: "curandSetPseudoRandomGeneratorSeed",
-                                       dynlib: libName.}
+                                       dyn.}
   ## *
   ##  \brief Set the absolute offset of the pseudo or quasirandom number generator.
   ## 
@@ -484,7 +487,7 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_SUCCESS if generator offset was set successfully \n
   ## 
   proc curandSetGeneratorOffset*(generator: curandGenerator_t; offset: culonglong): curandStatus_t {.
-      cdecl, importc: "curandSetGeneratorOffset", dynlib: libName.}
+      cdecl, importc: "curandSetGeneratorOffset", dyn.}
   ## *
   ##  \brief Set the ordering of results of the pseudo or quasirandom number generator.
   ## 
@@ -508,7 +511,7 @@ when not defined(CURAND_H):
   ## 
   proc curandSetGeneratorOrdering*(generator: curandGenerator_t;
                                   order: curandOrdering_t): curandStatus_t {.cdecl,
-      importc: "curandSetGeneratorOrdering", dynlib: libName.}
+      importc: "curandSetGeneratorOrdering", dyn.}
   ## *
   ##  \brief Set the number of dimensions.
   ## 
@@ -528,7 +531,7 @@ when not defined(CURAND_H):
   ## 
   proc curandSetQuasiRandomGeneratorDimensions*(generator: curandGenerator_t;
       num_dimensions: cuint): curandStatus_t {.cdecl,
-      importc: "curandSetQuasiRandomGeneratorDimensions", dynlib: libName.}
+      importc: "curandSetQuasiRandomGeneratorDimensions", dyn.}
   ## *
   ##  \brief Generate 32-bit pseudo or quasirandom numbers.
   ## 
@@ -556,7 +559,7 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_SUCCESS if the results were generated successfully \n
   ## 
   proc curandGenerate*(generator: curandGenerator_t; outputPtr: ptr cuint; num: csize): curandStatus_t {.
-      cdecl, importc: "curandGenerate", dynlib: libName.}
+      cdecl, importc: "curandGenerate", dyn.}
   ## *
   ##  \brief Generate 64-bit quasirandom numbers.
   ## 
@@ -584,7 +587,7 @@ when not defined(CURAND_H):
   ## 
   proc curandGenerateLongLong*(generator: curandGenerator_t;
                               outputPtr: ptr culonglong; num: csize): curandStatus_t {.
-      cdecl, importc: "curandGenerateLongLong", dynlib: libName.}
+      cdecl, importc: "curandGenerateLongLong", dyn.}
   ## *
   ##  \brief Generate uniformly distributed floats.
   ## 
@@ -612,7 +615,7 @@ when not defined(CURAND_H):
   ## 
   proc curandGenerateUniform*(generator: curandGenerator_t; outputPtr: ptr cfloat;
                              num: csize): curandStatus_t {.cdecl,
-      importc: "curandGenerateUniform", dynlib: libName.}
+      importc: "curandGenerateUniform", dyn.}
   ## *
   ##  \brief Generate uniformly distributed doubles.
   ## 
@@ -641,7 +644,7 @@ when not defined(CURAND_H):
   ## 
   proc curandGenerateUniformDouble*(generator: curandGenerator_t;
                                    outputPtr: ptr cdouble; num: csize): curandStatus_t {.
-      cdecl, importc: "curandGenerateUniformDouble", dynlib: libName.}
+      cdecl, importc: "curandGenerateUniformDouble", dyn.}
   ## *
   ##  \brief Generate normally distributed doubles.
   ## 
@@ -686,7 +689,7 @@ when not defined(CURAND_H):
   ## 
   proc curandGenerateNormal*(generator: curandGenerator_t; outputPtr: ptr cfloat;
                             n: csize; mean: cfloat; stddev: cfloat): curandStatus_t {.
-      cdecl, importc: "curandGenerateNormal", dynlib: libName.}
+      cdecl, importc: "curandGenerateNormal", dyn.}
   ## *
   ##  \brief Generate normally distributed doubles.
   ## 
@@ -733,7 +736,7 @@ when not defined(CURAND_H):
   proc curandGenerateNormalDouble*(generator: curandGenerator_t;
                                   outputPtr: ptr cdouble; n: csize; mean: cdouble;
                                   stddev: cdouble): curandStatus_t {.cdecl,
-      importc: "curandGenerateNormalDouble", dynlib: libName.}
+      importc: "curandGenerateNormalDouble", dyn.}
   ## *
   ##  \brief Generate log-normally distributed floats.
   ## 
@@ -780,7 +783,7 @@ when not defined(CURAND_H):
   proc curandGenerateLogNormal*(generator: curandGenerator_t;
                                outputPtr: ptr cfloat; n: csize; mean: cfloat;
                                stddev: cfloat): curandStatus_t {.cdecl,
-      importc: "curandGenerateLogNormal", dynlib: libName.}
+      importc: "curandGenerateLogNormal", dyn.}
   ## *
   ##  \brief Generate log-normally distributed doubles.
   ## 
@@ -828,7 +831,7 @@ when not defined(CURAND_H):
   proc curandGenerateLogNormalDouble*(generator: curandGenerator_t;
                                      outputPtr: ptr cdouble; n: csize; mean: cdouble;
                                      stddev: cdouble): curandStatus_t {.cdecl,
-      importc: "curandGenerateLogNormalDouble", dynlib: libName.}
+      importc: "curandGenerateLogNormalDouble", dyn.}
   ## *
   ##  \brief Construct the histogram array for a Poisson distribution.
   ## 
@@ -851,7 +854,7 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_SUCCESS if the histogram was generated successfully \n
   ## 
   proc curandCreatePoissonDistribution*(lambda: cdouble; discrete_distribution: ptr curandDiscreteDistribution_t): curandStatus_t {.
-      cdecl, importc: "curandCreatePoissonDistribution", dynlib: libName.}
+      cdecl, importc: "curandCreatePoissonDistribution", dyn.}
   ## *
   ##  \brief Destroy the histogram array for a discrete distribution (e.g. Poisson).
   ## 
@@ -864,7 +867,7 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_SUCCESS if the histogram was destroyed successfully \n
   ## 
   proc curandDestroyDistribution*(discrete_distribution: curandDiscreteDistribution_t): curandStatus_t {.
-      cdecl, importc: "curandDestroyDistribution", dynlib: libName.}
+      cdecl, importc: "curandDestroyDistribution", dyn.}
   ## *
   ##  \brief Generate Poisson-distributed unsigned ints.
   ## 
@@ -894,20 +897,20 @@ when not defined(CURAND_H):
   ## 
   proc curandGeneratePoisson*(generator: curandGenerator_t; outputPtr: ptr cuint;
                              n: csize; lambda: cdouble): curandStatus_t {.cdecl,
-      importc: "curandGeneratePoisson", dynlib: libName.}
+      importc: "curandGeneratePoisson", dyn.}
   ##  just for internal usage
   proc curandGeneratePoissonMethod*(generator: curandGenerator_t;
                                    outputPtr: ptr cuint; n: csize; lambda: cdouble;
                                    `method`: curandMethod_t): curandStatus_t {.
-      cdecl, importc: "curandGeneratePoissonMethod", dynlib: libName.}
+      cdecl, importc: "curandGeneratePoissonMethod", dyn.}
   proc curandGenerateBinomial*(generator: curandGenerator_t; outputPtr: ptr cuint;
                               num: csize; n: cuint; p: cdouble): curandStatus_t {.
-      cdecl, importc: "curandGenerateBinomial", dynlib: libName.}
+      cdecl, importc: "curandGenerateBinomial", dyn.}
   ##  just for internal usage
   proc curandGenerateBinomialMethod*(generator: curandGenerator_t;
                                     outputPtr: ptr cuint; num: csize; n: cuint;
                                     p: cdouble; `method`: curandMethod_t): curandStatus_t {.
-      cdecl, importc: "curandGenerateBinomialMethod", dynlib: libName.}
+      cdecl, importc: "curandGenerateBinomialMethod", dyn.}
   ## *
   ##  \brief Setup starting states.
   ## 
@@ -927,7 +930,7 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_SUCCESS if the seeds were generated successfully \n
   ## 
   proc curandGenerateSeeds*(generator: curandGenerator_t): curandStatus_t {.cdecl,
-      importc: "curandGenerateSeeds", dynlib: libName.}
+      importc: "curandGenerateSeeds", dyn.}
   ## *
   ##  \brief Get direction vectors for 32-bit quasirandom number generation.
   ## 
@@ -951,7 +954,7 @@ when not defined(CURAND_H):
   ## 
   proc curandGetDirectionVectors32*(vectors: ptr ptr curandDirectionVectors32_t;
                                    set: curandDirectionVectorSet_t): curandStatus_t {.
-      cdecl, importc: "curandGetDirectionVectors32", dynlib: libName.}
+      cdecl, importc: "curandGetDirectionVectors32", dyn.}
   ## *
   ##  \brief Get scramble constants for 32-bit scrambled Sobol' .
   ## 
@@ -968,7 +971,7 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_SUCCESS if the pointer was set successfully \n
   ## 
   proc curandGetScrambleConstants32*(constants: ptr ptr cuint): curandStatus_t {.
-      cdecl, importc: "curandGetScrambleConstants32", dynlib: libName.}
+      cdecl, importc: "curandGetScrambleConstants32", dyn.}
   ## *
   ##  \brief Get direction vectors for 64-bit quasirandom number generation.
   ## 
@@ -992,7 +995,7 @@ when not defined(CURAND_H):
   ## 
   proc curandGetDirectionVectors64*(vectors: ptr ptr curandDirectionVectors64_t;
                                    set: curandDirectionVectorSet_t): curandStatus_t {.
-      cdecl, importc: "curandGetDirectionVectors64", dynlib: libName.}
+      cdecl, importc: "curandGetDirectionVectors64", dyn.}
   ## *
   ##  \brief Get scramble constants for 64-bit scrambled Sobol' .
   ## 
@@ -1009,5 +1012,5 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_SUCCESS if the pointer was set successfully \n
   ## 
   proc curandGetScrambleConstants64*(constants: ptr ptr culonglong): curandStatus_t {.
-      cdecl, importc: "curandGetScrambleConstants64", dynlib: libName.}
+      cdecl, importc: "curandGetScrambleConstants64", dyn.}
   ## * @}

--- a/nimcuda/cusolverDn.nim
+++ b/nimcuda/cusolverDn.nim
@@ -1,13 +1,16 @@
  {.deadCodeElim: on.}
 when defined(windows):
-  const
-    libName = "cusolver.dll"
+  import os
+  {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cusolver.lib" & "\"".}
+  {.pragma: dyn.}
 elif defined(macosx):
   const
     libName = "libcusolver.dylib"
+  {.pragma: dyn, dynlib: libName.}
 else:
   const
     libName = "libcusolver.so"
+  {.pragma: dyn, dynlib: libName.}
 import
   cuComplex, cublas_api, cusolver_common
 
@@ -72,541 +75,541 @@ when not defined(CUSOLVERDN_H):
   type
     cusolverDnHandle_t* = ptr cusolverDnContext
   proc cusolverDnCreate*(handle: ptr cusolverDnHandle_t): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCreate", dynlib: libName.}
+      importc: "cusolverDnCreate", dyn.}
   proc cusolverDnDestroy*(handle: cusolverDnHandle_t): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDestroy", dynlib: libName.}
+      importc: "cusolverDnDestroy", dyn.}
   proc cusolverDnSetStream*(handle: cusolverDnHandle_t; streamId: cudaStream_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSetStream", dynlib: libName.}
+      cdecl, importc: "cusolverDnSetStream", dyn.}
   proc cusolverDnGetStream*(handle: cusolverDnHandle_t; streamId: ptr cudaStream_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnGetStream", dynlib: libName.}
+      cdecl, importc: "cusolverDnGetStream", dyn.}
   ##  Cholesky factorization and its solver
   proc cusolverDnSpotrf_bufferSize*(handle: cusolverDnHandle_t;
                                    uplo: cublasFillMode_t; n: cint; A: ptr cfloat;
                                    lda: cint; Lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSpotrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnSpotrf_bufferSize", dyn.}
   proc cusolverDnDpotrf_bufferSize*(handle: cusolverDnHandle_t;
                                    uplo: cublasFillMode_t; n: cint; A: ptr cdouble;
                                    lda: cint; Lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDpotrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnDpotrf_bufferSize", dyn.}
   proc cusolverDnCpotrf_bufferSize*(handle: cusolverDnHandle_t;
                                    uplo: cublasFillMode_t; n: cint;
                                    A: ptr cuComplex; lda: cint; Lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnCpotrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnCpotrf_bufferSize", dyn.}
   proc cusolverDnZpotrf_bufferSize*(handle: cusolverDnHandle_t;
                                    uplo: cublasFillMode_t; n: cint;
                                    A: ptr cuDoubleComplex; lda: cint; Lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZpotrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnZpotrf_bufferSize", dyn.}
   proc cusolverDnSpotrf*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cfloat; lda: cint; Workspace: ptr cfloat; Lwork: cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnSpotrf", dynlib: libName.}
+      importc: "cusolverDnSpotrf", dyn.}
   proc cusolverDnDpotrf*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cdouble; lda: cint; Workspace: ptr cdouble; Lwork: cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDpotrf", dynlib: libName.}
+      importc: "cusolverDnDpotrf", dyn.}
   proc cusolverDnCpotrf*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cuComplex; lda: cint; Workspace: ptr cuComplex;
                         Lwork: cint; devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCpotrf", dynlib: libName.}
+      importc: "cusolverDnCpotrf", dyn.}
   proc cusolverDnZpotrf*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cuDoubleComplex; lda: cint;
                         Workspace: ptr cuDoubleComplex; Lwork: cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZpotrf", dynlib: libName.}
+      importc: "cusolverDnZpotrf", dyn.}
   proc cusolverDnSpotrs*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         nrhs: cint; A: ptr cfloat; lda: cint; B: ptr cfloat; ldb: cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnSpotrs", dynlib: libName.}
+      importc: "cusolverDnSpotrs", dyn.}
   proc cusolverDnDpotrs*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         nrhs: cint; A: ptr cdouble; lda: cint; B: ptr cdouble; ldb: cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDpotrs", dynlib: libName.}
+      importc: "cusolverDnDpotrs", dyn.}
   proc cusolverDnCpotrs*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         nrhs: cint; A: ptr cuComplex; lda: cint; B: ptr cuComplex;
                         ldb: cint; devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCpotrs", dynlib: libName.}
+      importc: "cusolverDnCpotrs", dyn.}
   proc cusolverDnZpotrs*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         nrhs: cint; A: ptr cuDoubleComplex; lda: cint;
                         B: ptr cuDoubleComplex; ldb: cint; devInfo: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZpotrs", dynlib: libName.}
+      cdecl, importc: "cusolverDnZpotrs", dyn.}
   ##  LU Factorization
   proc cusolverDnSgetrf_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    A: ptr cfloat; lda: cint; Lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSgetrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnSgetrf_bufferSize", dyn.}
   proc cusolverDnDgetrf_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    A: ptr cdouble; lda: cint; Lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDgetrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnDgetrf_bufferSize", dyn.}
   proc cusolverDnCgetrf_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    A: ptr cuComplex; lda: cint; Lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnCgetrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnCgetrf_bufferSize", dyn.}
   proc cusolverDnZgetrf_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    A: ptr cuDoubleComplex; lda: cint; Lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZgetrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnZgetrf_bufferSize", dyn.}
   proc cusolverDnSgetrf*(handle: cusolverDnHandle_t; m: cint; n: cint; A: ptr cfloat;
                         lda: cint; Workspace: ptr cfloat; devIpiv: ptr cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnSgetrf", dynlib: libName.}
+      importc: "cusolverDnSgetrf", dyn.}
   proc cusolverDnDgetrf*(handle: cusolverDnHandle_t; m: cint; n: cint; A: ptr cdouble;
                         lda: cint; Workspace: ptr cdouble; devIpiv: ptr cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDgetrf", dynlib: libName.}
+      importc: "cusolverDnDgetrf", dyn.}
   proc cusolverDnCgetrf*(handle: cusolverDnHandle_t; m: cint; n: cint;
                         A: ptr cuComplex; lda: cint; Workspace: ptr cuComplex;
                         devIpiv: ptr cint; devInfo: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnCgetrf", dynlib: libName.}
+      cdecl, importc: "cusolverDnCgetrf", dyn.}
   proc cusolverDnZgetrf*(handle: cusolverDnHandle_t; m: cint; n: cint;
                         A: ptr cuDoubleComplex; lda: cint;
                         Workspace: ptr cuDoubleComplex; devIpiv: ptr cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZgetrf", dynlib: libName.}
+      importc: "cusolverDnZgetrf", dyn.}
   ##  Row pivoting
   proc cusolverDnSlaswp*(handle: cusolverDnHandle_t; n: cint; A: ptr cfloat; lda: cint;
                         k1: cint; k2: cint; devIpiv: ptr cint; incx: cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSlaswp", dynlib: libName.}
+      cdecl, importc: "cusolverDnSlaswp", dyn.}
   proc cusolverDnDlaswp*(handle: cusolverDnHandle_t; n: cint; A: ptr cdouble; lda: cint;
                         k1: cint; k2: cint; devIpiv: ptr cint; incx: cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDlaswp", dynlib: libName.}
+      cdecl, importc: "cusolverDnDlaswp", dyn.}
   proc cusolverDnClaswp*(handle: cusolverDnHandle_t; n: cint; A: ptr cuComplex;
                         lda: cint; k1: cint; k2: cint; devIpiv: ptr cint; incx: cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnClaswp", dynlib: libName.}
+      cdecl, importc: "cusolverDnClaswp", dyn.}
   proc cusolverDnZlaswp*(handle: cusolverDnHandle_t; n: cint; A: ptr cuDoubleComplex;
                         lda: cint; k1: cint; k2: cint; devIpiv: ptr cint; incx: cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZlaswp", dynlib: libName.}
+      cdecl, importc: "cusolverDnZlaswp", dyn.}
   ##  LU solve
   proc cusolverDnSgetrs*(handle: cusolverDnHandle_t; trans: cublasOperation_t;
                         n: cint; nrhs: cint; A: ptr cfloat; lda: cint; devIpiv: ptr cint;
                         B: ptr cfloat; ldb: cint; devInfo: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSgetrs", dynlib: libName.}
+      cdecl, importc: "cusolverDnSgetrs", dyn.}
   proc cusolverDnDgetrs*(handle: cusolverDnHandle_t; trans: cublasOperation_t;
                         n: cint; nrhs: cint; A: ptr cdouble; lda: cint;
                         devIpiv: ptr cint; B: ptr cdouble; ldb: cint; devInfo: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDgetrs", dynlib: libName.}
+      cdecl, importc: "cusolverDnDgetrs", dyn.}
   proc cusolverDnCgetrs*(handle: cusolverDnHandle_t; trans: cublasOperation_t;
                         n: cint; nrhs: cint; A: ptr cuComplex; lda: cint;
                         devIpiv: ptr cint; B: ptr cuComplex; ldb: cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCgetrs", dynlib: libName.}
+      importc: "cusolverDnCgetrs", dyn.}
   proc cusolverDnZgetrs*(handle: cusolverDnHandle_t; trans: cublasOperation_t;
                         n: cint; nrhs: cint; A: ptr cuDoubleComplex; lda: cint;
                         devIpiv: ptr cint; B: ptr cuDoubleComplex; ldb: cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZgetrs", dynlib: libName.}
+      importc: "cusolverDnZgetrs", dyn.}
   ##  QR factorization
   proc cusolverDnSgeqrf_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    A: ptr cfloat; lda: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSgeqrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnSgeqrf_bufferSize", dyn.}
   proc cusolverDnDgeqrf_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    A: ptr cdouble; lda: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDgeqrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnDgeqrf_bufferSize", dyn.}
   proc cusolverDnCgeqrf_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    A: ptr cuComplex; lda: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnCgeqrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnCgeqrf_bufferSize", dyn.}
   proc cusolverDnZgeqrf_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    A: ptr cuDoubleComplex; lda: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZgeqrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnZgeqrf_bufferSize", dyn.}
   proc cusolverDnSgeqrf*(handle: cusolverDnHandle_t; m: cint; n: cint; A: ptr cfloat;
                         lda: cint; TAU: ptr cfloat; Workspace: ptr cfloat; Lwork: cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnSgeqrf", dynlib: libName.}
+      importc: "cusolverDnSgeqrf", dyn.}
   proc cusolverDnDgeqrf*(handle: cusolverDnHandle_t; m: cint; n: cint; A: ptr cdouble;
                         lda: cint; TAU: ptr cdouble; Workspace: ptr cdouble;
                         Lwork: cint; devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDgeqrf", dynlib: libName.}
+      importc: "cusolverDnDgeqrf", dyn.}
   proc cusolverDnCgeqrf*(handle: cusolverDnHandle_t; m: cint; n: cint;
                         A: ptr cuComplex; lda: cint; TAU: ptr cuComplex;
                         Workspace: ptr cuComplex; Lwork: cint; devInfo: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnCgeqrf", dynlib: libName.}
+      cdecl, importc: "cusolverDnCgeqrf", dyn.}
   proc cusolverDnZgeqrf*(handle: cusolverDnHandle_t; m: cint; n: cint;
                         A: ptr cuDoubleComplex; lda: cint; TAU: ptr cuDoubleComplex;
                         Workspace: ptr cuDoubleComplex; Lwork: cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZgeqrf", dynlib: libName.}
+      importc: "cusolverDnZgeqrf", dyn.}
   ##  generate unitary matrix Q from QR factorization
   proc cusolverDnSorgqr_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    k: cint; A: ptr cfloat; lda: cint; tau: ptr cfloat;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnSorgqr_bufferSize", dynlib: libName.}
+      importc: "cusolverDnSorgqr_bufferSize", dyn.}
   proc cusolverDnDorgqr_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    k: cint; A: ptr cdouble; lda: cint;
                                    tau: ptr cdouble; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDorgqr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnDorgqr_bufferSize", dyn.}
   proc cusolverDnCungqr_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    k: cint; A: ptr cuComplex; lda: cint;
                                    tau: ptr cuComplex; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnCungqr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnCungqr_bufferSize", dyn.}
   proc cusolverDnZungqr_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    k: cint; A: ptr cuDoubleComplex; lda: cint;
                                    tau: ptr cuDoubleComplex; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZungqr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnZungqr_bufferSize", dyn.}
   proc cusolverDnSorgqr*(handle: cusolverDnHandle_t; m: cint; n: cint; k: cint;
                         A: ptr cfloat; lda: cint; tau: ptr cfloat; work: ptr cfloat;
                         lwork: cint; info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnSorgqr", dynlib: libName.}
+      importc: "cusolverDnSorgqr", dyn.}
   proc cusolverDnDorgqr*(handle: cusolverDnHandle_t; m: cint; n: cint; k: cint;
                         A: ptr cdouble; lda: cint; tau: ptr cdouble; work: ptr cdouble;
                         lwork: cint; info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDorgqr", dynlib: libName.}
+      importc: "cusolverDnDorgqr", dyn.}
   proc cusolverDnCungqr*(handle: cusolverDnHandle_t; m: cint; n: cint; k: cint;
                         A: ptr cuComplex; lda: cint; tau: ptr cuComplex;
                         work: ptr cuComplex; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnCungqr", dynlib: libName.}
+      cdecl, importc: "cusolverDnCungqr", dyn.}
   proc cusolverDnZungqr*(handle: cusolverDnHandle_t; m: cint; n: cint; k: cint;
                         A: ptr cuDoubleComplex; lda: cint; tau: ptr cuDoubleComplex;
                         work: ptr cuDoubleComplex; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZungqr", dynlib: libName.}
+      cdecl, importc: "cusolverDnZungqr", dyn.}
   ##  compute Q**T*b in solve min||A*x = b||
   proc cusolverDnSormqr_bufferSize*(handle: cusolverDnHandle_t;
                                    side: cublasSideMode_t;
                                    trans: cublasOperation_t; m: cint; n: cint;
                                    k: cint; A: ptr cfloat; lda: cint; tau: ptr cfloat;
                                    C: ptr cfloat; ldc: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSormqr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnSormqr_bufferSize", dyn.}
   proc cusolverDnDormqr_bufferSize*(handle: cusolverDnHandle_t;
                                    side: cublasSideMode_t;
                                    trans: cublasOperation_t; m: cint; n: cint;
                                    k: cint; A: ptr cdouble; lda: cint;
                                    tau: ptr cdouble; C: ptr cdouble; ldc: cint;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDormqr_bufferSize", dynlib: libName.}
+      importc: "cusolverDnDormqr_bufferSize", dyn.}
   proc cusolverDnCunmqr_bufferSize*(handle: cusolverDnHandle_t;
                                    side: cublasSideMode_t;
                                    trans: cublasOperation_t; m: cint; n: cint;
                                    k: cint; A: ptr cuComplex; lda: cint;
                                    tau: ptr cuComplex; C: ptr cuComplex; ldc: cint;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCunmqr_bufferSize", dynlib: libName.}
+      importc: "cusolverDnCunmqr_bufferSize", dyn.}
   proc cusolverDnZunmqr_bufferSize*(handle: cusolverDnHandle_t;
                                    side: cublasSideMode_t;
                                    trans: cublasOperation_t; m: cint; n: cint;
                                    k: cint; A: ptr cuDoubleComplex; lda: cint;
                                    tau: ptr cuDoubleComplex;
                                    C: ptr cuDoubleComplex; ldc: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZunmqr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnZunmqr_bufferSize", dyn.}
   proc cusolverDnSormqr*(handle: cusolverDnHandle_t; side: cublasSideMode_t;
                         trans: cublasOperation_t; m: cint; n: cint; k: cint;
                         A: ptr cfloat; lda: cint; tau: ptr cfloat; C: ptr cfloat;
                         ldc: cint; work: ptr cfloat; lwork: cint; devInfo: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSormqr", dynlib: libName.}
+      cdecl, importc: "cusolverDnSormqr", dyn.}
   proc cusolverDnDormqr*(handle: cusolverDnHandle_t; side: cublasSideMode_t;
                         trans: cublasOperation_t; m: cint; n: cint; k: cint;
                         A: ptr cdouble; lda: cint; tau: ptr cdouble; C: ptr cdouble;
                         ldc: cint; work: ptr cdouble; lwork: cint; devInfo: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDormqr", dynlib: libName.}
+      cdecl, importc: "cusolverDnDormqr", dyn.}
   proc cusolverDnCunmqr*(handle: cusolverDnHandle_t; side: cublasSideMode_t;
                         trans: cublasOperation_t; m: cint; n: cint; k: cint;
                         A: ptr cuComplex; lda: cint; tau: ptr cuComplex;
                         C: ptr cuComplex; ldc: cint; work: ptr cuComplex; lwork: cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCunmqr", dynlib: libName.}
+      importc: "cusolverDnCunmqr", dyn.}
   proc cusolverDnZunmqr*(handle: cusolverDnHandle_t; side: cublasSideMode_t;
                         trans: cublasOperation_t; m: cint; n: cint; k: cint;
                         A: ptr cuDoubleComplex; lda: cint; tau: ptr cuDoubleComplex;
                         C: ptr cuDoubleComplex; ldc: cint; work: ptr cuDoubleComplex;
                         lwork: cint; devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZunmqr", dynlib: libName.}
+      importc: "cusolverDnZunmqr", dyn.}
   ##  L*D*L**T,U*D*U**T factorization
   proc cusolverDnSsytrf_bufferSize*(handle: cusolverDnHandle_t; n: cint;
                                    A: ptr cfloat; lda: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSsytrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnSsytrf_bufferSize", dyn.}
   proc cusolverDnDsytrf_bufferSize*(handle: cusolverDnHandle_t; n: cint;
                                    A: ptr cdouble; lda: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDsytrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnDsytrf_bufferSize", dyn.}
   proc cusolverDnCsytrf_bufferSize*(handle: cusolverDnHandle_t; n: cint;
                                    A: ptr cuComplex; lda: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnCsytrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnCsytrf_bufferSize", dyn.}
   proc cusolverDnZsytrf_bufferSize*(handle: cusolverDnHandle_t; n: cint;
                                    A: ptr cuDoubleComplex; lda: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZsytrf_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnZsytrf_bufferSize", dyn.}
   proc cusolverDnSsytrf*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cfloat; lda: cint; ipiv: ptr cint; work: ptr cfloat;
                         lwork: cint; info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnSsytrf", dynlib: libName.}
+      importc: "cusolverDnSsytrf", dyn.}
   proc cusolverDnDsytrf*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cdouble; lda: cint; ipiv: ptr cint; work: ptr cdouble;
                         lwork: cint; info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDsytrf", dynlib: libName.}
+      importc: "cusolverDnDsytrf", dyn.}
   proc cusolverDnCsytrf*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cuComplex; lda: cint; ipiv: ptr cint;
                         work: ptr cuComplex; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnCsytrf", dynlib: libName.}
+      cdecl, importc: "cusolverDnCsytrf", dyn.}
   proc cusolverDnZsytrf*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cuDoubleComplex; lda: cint; ipiv: ptr cint;
                         work: ptr cuDoubleComplex; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZsytrf", dynlib: libName.}
+      cdecl, importc: "cusolverDnZsytrf", dyn.}
   ##  bidiagonal factorization
   proc cusolverDnSgebrd_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    Lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnSgebrd_bufferSize", dynlib: libName.}
+      importc: "cusolverDnSgebrd_bufferSize", dyn.}
   proc cusolverDnDgebrd_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    Lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDgebrd_bufferSize", dynlib: libName.}
+      importc: "cusolverDnDgebrd_bufferSize", dyn.}
   proc cusolverDnCgebrd_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    Lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCgebrd_bufferSize", dynlib: libName.}
+      importc: "cusolverDnCgebrd_bufferSize", dyn.}
   proc cusolverDnZgebrd_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    Lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZgebrd_bufferSize", dynlib: libName.}
+      importc: "cusolverDnZgebrd_bufferSize", dyn.}
   proc cusolverDnSgebrd*(handle: cusolverDnHandle_t; m: cint; n: cint; A: ptr cfloat;
                         lda: cint; D: ptr cfloat; E: ptr cfloat; TAUQ: ptr cfloat;
                         TAUP: ptr cfloat; Work: ptr cfloat; Lwork: cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnSgebrd", dynlib: libName.}
+      importc: "cusolverDnSgebrd", dyn.}
   proc cusolverDnDgebrd*(handle: cusolverDnHandle_t; m: cint; n: cint; A: ptr cdouble;
                         lda: cint; D: ptr cdouble; E: ptr cdouble; TAUQ: ptr cdouble;
                         TAUP: ptr cdouble; Work: ptr cdouble; Lwork: cint;
                         devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDgebrd", dynlib: libName.}
+      importc: "cusolverDnDgebrd", dyn.}
   proc cusolverDnCgebrd*(handle: cusolverDnHandle_t; m: cint; n: cint;
                         A: ptr cuComplex; lda: cint; D: ptr cfloat; E: ptr cfloat;
                         TAUQ: ptr cuComplex; TAUP: ptr cuComplex; Work: ptr cuComplex;
                         Lwork: cint; devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCgebrd", dynlib: libName.}
+      importc: "cusolverDnCgebrd", dyn.}
   proc cusolverDnZgebrd*(handle: cusolverDnHandle_t; m: cint; n: cint;
                         A: ptr cuDoubleComplex; lda: cint; D: ptr cdouble;
                         E: ptr cdouble; TAUQ: ptr cuDoubleComplex;
                         TAUP: ptr cuDoubleComplex; Work: ptr cuDoubleComplex;
                         Lwork: cint; devInfo: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZgebrd", dynlib: libName.}
+      importc: "cusolverDnZgebrd", dyn.}
   ##  generates one of the unitary matrices Q or P**T determined by GEBRD
   proc cusolverDnSorgbr_bufferSize*(handle: cusolverDnHandle_t;
                                    side: cublasSideMode_t; m: cint; n: cint; k: cint;
                                    A: ptr cfloat; lda: cint; tau: ptr cfloat;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnSorgbr_bufferSize", dynlib: libName.}
+      importc: "cusolverDnSorgbr_bufferSize", dyn.}
   proc cusolverDnDorgbr_bufferSize*(handle: cusolverDnHandle_t;
                                    side: cublasSideMode_t; m: cint; n: cint; k: cint;
                                    A: ptr cdouble; lda: cint; tau: ptr cdouble;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDorgbr_bufferSize", dynlib: libName.}
+      importc: "cusolverDnDorgbr_bufferSize", dyn.}
   proc cusolverDnCungbr_bufferSize*(handle: cusolverDnHandle_t;
                                    side: cublasSideMode_t; m: cint; n: cint; k: cint;
                                    A: ptr cuComplex; lda: cint; tau: ptr cuComplex;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCungbr_bufferSize", dynlib: libName.}
+      importc: "cusolverDnCungbr_bufferSize", dyn.}
   proc cusolverDnZungbr_bufferSize*(handle: cusolverDnHandle_t;
                                    side: cublasSideMode_t; m: cint; n: cint; k: cint;
                                    A: ptr cuDoubleComplex; lda: cint;
                                    tau: ptr cuDoubleComplex; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZungbr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnZungbr_bufferSize", dyn.}
   proc cusolverDnSorgbr*(handle: cusolverDnHandle_t; side: cublasSideMode_t; m: cint;
                         n: cint; k: cint; A: ptr cfloat; lda: cint; tau: ptr cfloat;
                         work: ptr cfloat; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSorgbr", dynlib: libName.}
+      cdecl, importc: "cusolverDnSorgbr", dyn.}
   proc cusolverDnDorgbr*(handle: cusolverDnHandle_t; side: cublasSideMode_t; m: cint;
                         n: cint; k: cint; A: ptr cdouble; lda: cint; tau: ptr cdouble;
                         work: ptr cdouble; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDorgbr", dynlib: libName.}
+      cdecl, importc: "cusolverDnDorgbr", dyn.}
   proc cusolverDnCungbr*(handle: cusolverDnHandle_t; side: cublasSideMode_t; m: cint;
                         n: cint; k: cint; A: ptr cuComplex; lda: cint;
                         tau: ptr cuComplex; work: ptr cuComplex; lwork: cint;
                         info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCungbr", dynlib: libName.}
+      importc: "cusolverDnCungbr", dyn.}
   proc cusolverDnZungbr*(handle: cusolverDnHandle_t; side: cublasSideMode_t; m: cint;
                         n: cint; k: cint; A: ptr cuDoubleComplex; lda: cint;
                         tau: ptr cuDoubleComplex; work: ptr cuDoubleComplex;
                         lwork: cint; info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZungbr", dynlib: libName.}
+      importc: "cusolverDnZungbr", dyn.}
   ##  tridiagonal factorization
   proc cusolverDnSsytrd_bufferSize*(handle: cusolverDnHandle_t;
                                    uplo: cublasFillMode_t; n: cint; A: ptr cfloat;
                                    lda: cint; d: ptr cfloat; e: ptr cfloat;
                                    tau: ptr cfloat; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSsytrd_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnSsytrd_bufferSize", dyn.}
   proc cusolverDnDsytrd_bufferSize*(handle: cusolverDnHandle_t;
                                    uplo: cublasFillMode_t; n: cint; A: ptr cdouble;
                                    lda: cint; d: ptr cdouble; e: ptr cdouble;
                                    tau: ptr cdouble; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDsytrd_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnDsytrd_bufferSize", dyn.}
   proc cusolverDnChetrd_bufferSize*(handle: cusolverDnHandle_t;
                                    uplo: cublasFillMode_t; n: cint;
                                    A: ptr cuComplex; lda: cint; d: ptr cfloat;
                                    e: ptr cfloat; tau: ptr cuComplex; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnChetrd_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnChetrd_bufferSize", dyn.}
   proc cusolverDnZhetrd_bufferSize*(handle: cusolverDnHandle_t;
                                    uplo: cublasFillMode_t; n: cint;
                                    A: ptr cuDoubleComplex; lda: cint; d: ptr cdouble;
                                    e: ptr cdouble; tau: ptr cuDoubleComplex;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZhetrd_bufferSize", dynlib: libName.}
+      importc: "cusolverDnZhetrd_bufferSize", dyn.}
   proc cusolverDnSsytrd*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cfloat; lda: cint; d: ptr cfloat; e: ptr cfloat;
                         tau: ptr cfloat; work: ptr cfloat; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSsytrd", dynlib: libName.}
+      cdecl, importc: "cusolverDnSsytrd", dyn.}
   proc cusolverDnDsytrd*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cdouble; lda: cint; d: ptr cdouble; e: ptr cdouble;
                         tau: ptr cdouble; work: ptr cdouble; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDsytrd", dynlib: libName.}
+      cdecl, importc: "cusolverDnDsytrd", dyn.}
   proc cusolverDnChetrd*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cuComplex; lda: cint; d: ptr cfloat; e: ptr cfloat;
                         tau: ptr cuComplex; work: ptr cuComplex; lwork: cint;
                         info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnChetrd", dynlib: libName.}
+      importc: "cusolverDnChetrd", dyn.}
   proc cusolverDnZhetrd*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cuDoubleComplex; lda: cint; d: ptr cdouble;
                         e: ptr cdouble; tau: ptr cuDoubleComplex;
                         work: ptr cuDoubleComplex; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZhetrd", dynlib: libName.}
+      cdecl, importc: "cusolverDnZhetrd", dyn.}
   ##  generate unitary Q comes from sytrd
   proc cusolverDnSorgtr_bufferSize*(handle: cusolverDnHandle_t;
                                    uplo: cublasFillMode_t; n: cint; A: ptr cfloat;
                                    lda: cint; tau: ptr cfloat; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSorgtr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnSorgtr_bufferSize", dyn.}
   proc cusolverDnDorgtr_bufferSize*(handle: cusolverDnHandle_t;
                                    uplo: cublasFillMode_t; n: cint; A: ptr cdouble;
                                    lda: cint; tau: ptr cdouble; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDorgtr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnDorgtr_bufferSize", dyn.}
   proc cusolverDnCungtr_bufferSize*(handle: cusolverDnHandle_t;
                                    uplo: cublasFillMode_t; n: cint;
                                    A: ptr cuComplex; lda: cint; tau: ptr cuComplex;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCungtr_bufferSize", dynlib: libName.}
+      importc: "cusolverDnCungtr_bufferSize", dyn.}
   proc cusolverDnZungtr_bufferSize*(handle: cusolverDnHandle_t;
                                    uplo: cublasFillMode_t; n: cint;
                                    A: ptr cuDoubleComplex; lda: cint;
                                    tau: ptr cuDoubleComplex; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZungtr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnZungtr_bufferSize", dyn.}
   proc cusolverDnSorgtr*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cfloat; lda: cint; tau: ptr cfloat; work: ptr cfloat;
                         lwork: cint; info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnSorgtr", dynlib: libName.}
+      importc: "cusolverDnSorgtr", dyn.}
   proc cusolverDnDorgtr*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cdouble; lda: cint; tau: ptr cdouble; work: ptr cdouble;
                         lwork: cint; info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDorgtr", dynlib: libName.}
+      importc: "cusolverDnDorgtr", dyn.}
   proc cusolverDnCungtr*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cuComplex; lda: cint; tau: ptr cuComplex;
                         work: ptr cuComplex; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnCungtr", dynlib: libName.}
+      cdecl, importc: "cusolverDnCungtr", dyn.}
   proc cusolverDnZungtr*(handle: cusolverDnHandle_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cuDoubleComplex; lda: cint; tau: ptr cuDoubleComplex;
                         work: ptr cuDoubleComplex; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZungtr", dynlib: libName.}
+      cdecl, importc: "cusolverDnZungtr", dyn.}
   ##  compute op(Q)*C or C*op(Q) where Q comes from sytrd
   proc cusolverDnSormtr_bufferSize*(handle: cusolverDnHandle_t;
                                    side: cublasSideMode_t; uplo: cublasFillMode_t;
                                    trans: cublasOperation_t; m: cint; n: cint;
                                    A: ptr cfloat; lda: cint; tau: ptr cfloat;
                                    C: ptr cfloat; ldc: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSormtr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnSormtr_bufferSize", dyn.}
   proc cusolverDnDormtr_bufferSize*(handle: cusolverDnHandle_t;
                                    side: cublasSideMode_t; uplo: cublasFillMode_t;
                                    trans: cublasOperation_t; m: cint; n: cint;
                                    A: ptr cdouble; lda: cint; tau: ptr cdouble;
                                    C: ptr cdouble; ldc: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDormtr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnDormtr_bufferSize", dyn.}
   proc cusolverDnCunmtr_bufferSize*(handle: cusolverDnHandle_t;
                                    side: cublasSideMode_t; uplo: cublasFillMode_t;
                                    trans: cublasOperation_t; m: cint; n: cint;
                                    A: ptr cuComplex; lda: cint; tau: ptr cuComplex;
                                    C: ptr cuComplex; ldc: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnCunmtr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnCunmtr_bufferSize", dyn.}
   proc cusolverDnZunmtr_bufferSize*(handle: cusolverDnHandle_t;
                                    side: cublasSideMode_t; uplo: cublasFillMode_t;
                                    trans: cublasOperation_t; m: cint; n: cint;
                                    A: ptr cuDoubleComplex; lda: cint;
                                    tau: ptr cuDoubleComplex;
                                    C: ptr cuDoubleComplex; ldc: cint; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZunmtr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnZunmtr_bufferSize", dyn.}
   proc cusolverDnSormtr*(handle: cusolverDnHandle_t; side: cublasSideMode_t;
                         uplo: cublasFillMode_t; trans: cublasOperation_t; m: cint;
                         n: cint; A: ptr cfloat; lda: cint; tau: ptr cfloat; C: ptr cfloat;
                         ldc: cint; work: ptr cfloat; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSormtr", dynlib: libName.}
+      cdecl, importc: "cusolverDnSormtr", dyn.}
   proc cusolverDnDormtr*(handle: cusolverDnHandle_t; side: cublasSideMode_t;
                         uplo: cublasFillMode_t; trans: cublasOperation_t; m: cint;
                         n: cint; A: ptr cdouble; lda: cint; tau: ptr cdouble;
                         C: ptr cdouble; ldc: cint; work: ptr cdouble; lwork: cint;
                         info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDormtr", dynlib: libName.}
+      importc: "cusolverDnDormtr", dyn.}
   proc cusolverDnCunmtr*(handle: cusolverDnHandle_t; side: cublasSideMode_t;
                         uplo: cublasFillMode_t; trans: cublasOperation_t; m: cint;
                         n: cint; A: ptr cuComplex; lda: cint; tau: ptr cuComplex;
                         C: ptr cuComplex; ldc: cint; work: ptr cuComplex; lwork: cint;
                         info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCunmtr", dynlib: libName.}
+      importc: "cusolverDnCunmtr", dyn.}
   proc cusolverDnZunmtr*(handle: cusolverDnHandle_t; side: cublasSideMode_t;
                         uplo: cublasFillMode_t; trans: cublasOperation_t; m: cint;
                         n: cint; A: ptr cuDoubleComplex; lda: cint;
                         tau: ptr cuDoubleComplex; C: ptr cuDoubleComplex; ldc: cint;
                         work: ptr cuDoubleComplex; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnZunmtr", dynlib: libName.}
+      cdecl, importc: "cusolverDnZunmtr", dyn.}
   ##  singular value decomposition, A = U * Sigma * V^H
   proc cusolverDnSgesvd_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnSgesvd_bufferSize", dynlib: libName.}
+      importc: "cusolverDnSgesvd_bufferSize", dyn.}
   proc cusolverDnDgesvd_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDgesvd_bufferSize", dynlib: libName.}
+      importc: "cusolverDnDgesvd_bufferSize", dyn.}
   proc cusolverDnCgesvd_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCgesvd_bufferSize", dynlib: libName.}
+      importc: "cusolverDnCgesvd_bufferSize", dyn.}
   proc cusolverDnZgesvd_bufferSize*(handle: cusolverDnHandle_t; m: cint; n: cint;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZgesvd_bufferSize", dynlib: libName.}
+      importc: "cusolverDnZgesvd_bufferSize", dyn.}
   proc cusolverDnSgesvd*(handle: cusolverDnHandle_t; jobu: cchar; jobvt: cchar;
                         m: cint; n: cint; A: ptr cfloat; lda: cint; S: ptr cfloat;
                         U: ptr cfloat; ldu: cint; VT: ptr cfloat; ldvt: cint;
                         work: ptr cfloat; lwork: cint; rwork: ptr cfloat; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSgesvd", dynlib: libName.}
+      cdecl, importc: "cusolverDnSgesvd", dyn.}
   proc cusolverDnDgesvd*(handle: cusolverDnHandle_t; jobu: cchar; jobvt: cchar;
                         m: cint; n: cint; A: ptr cdouble; lda: cint; S: ptr cdouble;
                         U: ptr cdouble; ldu: cint; VT: ptr cdouble; ldvt: cint;
                         work: ptr cdouble; lwork: cint; rwork: ptr cdouble;
                         info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnDgesvd", dynlib: libName.}
+      importc: "cusolverDnDgesvd", dyn.}
   proc cusolverDnCgesvd*(handle: cusolverDnHandle_t; jobu: cchar; jobvt: cchar;
                         m: cint; n: cint; A: ptr cuComplex; lda: cint; S: ptr cfloat;
                         U: ptr cuComplex; ldu: cint; VT: ptr cuComplex; ldvt: cint;
                         work: ptr cuComplex; lwork: cint; rwork: ptr cfloat;
                         info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCgesvd", dynlib: libName.}
+      importc: "cusolverDnCgesvd", dyn.}
   proc cusolverDnZgesvd*(handle: cusolverDnHandle_t; jobu: cchar; jobvt: cchar;
                         m: cint; n: cint; A: ptr cuDoubleComplex; lda: cint;
                         S: ptr cdouble; U: ptr cuDoubleComplex; ldu: cint;
                         VT: ptr cuDoubleComplex; ldvt: cint;
                         work: ptr cuDoubleComplex; lwork: cint; rwork: ptr cdouble;
                         info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZgesvd", dynlib: libName.}
+      importc: "cusolverDnZgesvd", dyn.}
   ##  standard symmetric eigenvalue solver, A*x = lambda*x, by divide-and-conquer
   proc cusolverDnSsyevd_bufferSize*(handle: cusolverDnHandle_t;
                                    jobz: cusolverEigMode_t;
                                    uplo: cublasFillMode_t; n: cint; A: ptr cfloat;
                                    lda: cint; W: ptr cfloat; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSsyevd_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnSsyevd_bufferSize", dyn.}
   proc cusolverDnDsyevd_bufferSize*(handle: cusolverDnHandle_t;
                                    jobz: cusolverEigMode_t;
                                    uplo: cublasFillMode_t; n: cint; A: ptr cdouble;
                                    lda: cint; W: ptr cdouble; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDsyevd_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnDsyevd_bufferSize", dyn.}
   proc cusolverDnCheevd_bufferSize*(handle: cusolverDnHandle_t;
                                    jobz: cusolverEigMode_t;
                                    uplo: cublasFillMode_t; n: cint;
                                    A: ptr cuComplex; lda: cint; W: ptr cfloat;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnCheevd_bufferSize", dynlib: libName.}
+      importc: "cusolverDnCheevd_bufferSize", dyn.}
   proc cusolverDnZheevd_bufferSize*(handle: cusolverDnHandle_t;
                                    jobz: cusolverEigMode_t;
                                    uplo: cublasFillMode_t; n: cint;
                                    A: ptr cuDoubleComplex; lda: cint; W: ptr cdouble;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZheevd_bufferSize", dynlib: libName.}
+      importc: "cusolverDnZheevd_bufferSize", dyn.}
   proc cusolverDnSsyevd*(handle: cusolverDnHandle_t; jobz: cusolverEigMode_t;
                         uplo: cublasFillMode_t; n: cint; A: ptr cfloat; lda: cint;
                         W: ptr cfloat; work: ptr cfloat; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSsyevd", dynlib: libName.}
+      cdecl, importc: "cusolverDnSsyevd", dyn.}
   proc cusolverDnDsyevd*(handle: cusolverDnHandle_t; jobz: cusolverEigMode_t;
                         uplo: cublasFillMode_t; n: cint; A: ptr cdouble; lda: cint;
                         W: ptr cdouble; work: ptr cdouble; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDsyevd", dynlib: libName.}
+      cdecl, importc: "cusolverDnDsyevd", dyn.}
   proc cusolverDnCheevd*(handle: cusolverDnHandle_t; jobz: cusolverEigMode_t;
                         uplo: cublasFillMode_t; n: cint; A: ptr cuComplex; lda: cint;
                         W: ptr cfloat; work: ptr cuComplex; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnCheevd", dynlib: libName.}
+      cdecl, importc: "cusolverDnCheevd", dyn.}
   proc cusolverDnZheevd*(handle: cusolverDnHandle_t; jobz: cusolverEigMode_t;
                         uplo: cublasFillMode_t; n: cint; A: ptr cuDoubleComplex;
                         lda: cint; W: ptr cdouble; work: ptr cuDoubleComplex;
                         lwork: cint; info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZheevd", dynlib: libName.}
+      importc: "cusolverDnZheevd", dyn.}
   ##  generalized symmetric eigenvalue solver, A*x = lambda*B*x, by divide-and-conquer
   proc cusolverDnSsygvd_bufferSize*(handle: cusolverDnHandle_t;
                                    itype: cusolverEigType_t;
@@ -614,21 +617,21 @@ when not defined(CUSOLVERDN_H):
                                    uplo: cublasFillMode_t; n: cint; A: ptr cfloat;
                                    lda: cint; B: ptr cfloat; ldb: cint; W: ptr cfloat;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnSsygvd_bufferSize", dynlib: libName.}
+      importc: "cusolverDnSsygvd_bufferSize", dyn.}
   proc cusolverDnDsygvd_bufferSize*(handle: cusolverDnHandle_t;
                                    itype: cusolverEigType_t;
                                    jobz: cusolverEigMode_t;
                                    uplo: cublasFillMode_t; n: cint; A: ptr cdouble;
                                    lda: cint; B: ptr cdouble; ldb: cint;
                                    W: ptr cdouble; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDsygvd_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnDsygvd_bufferSize", dyn.}
   proc cusolverDnChegvd_bufferSize*(handle: cusolverDnHandle_t;
                                    itype: cusolverEigType_t;
                                    jobz: cusolverEigMode_t;
                                    uplo: cublasFillMode_t; n: cint;
                                    A: ptr cuComplex; lda: cint; B: ptr cuComplex;
                                    ldb: cint; W: ptr cfloat; lwork: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnChegvd_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusolverDnChegvd_bufferSize", dyn.}
   proc cusolverDnZhegvd_bufferSize*(handle: cusolverDnHandle_t;
                                    itype: cusolverEigType_t;
                                    jobz: cusolverEigMode_t;
@@ -636,25 +639,25 @@ when not defined(CUSOLVERDN_H):
                                    A: ptr cuDoubleComplex; lda: cint;
                                    B: ptr cuDoubleComplex; ldb: cint; W: ptr cdouble;
                                    lwork: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZhegvd_bufferSize", dynlib: libName.}
+      importc: "cusolverDnZhegvd_bufferSize", dyn.}
   proc cusolverDnSsygvd*(handle: cusolverDnHandle_t; itype: cusolverEigType_t;
                         jobz: cusolverEigMode_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cfloat; lda: cint; B: ptr cfloat; ldb: cint; W: ptr cfloat;
                         work: ptr cfloat; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnSsygvd", dynlib: libName.}
+      cdecl, importc: "cusolverDnSsygvd", dyn.}
   proc cusolverDnDsygvd*(handle: cusolverDnHandle_t; itype: cusolverEigType_t;
                         jobz: cusolverEigMode_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cdouble; lda: cint; B: ptr cdouble; ldb: cint;
                         W: ptr cdouble; work: ptr cdouble; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnDsygvd", dynlib: libName.}
+      cdecl, importc: "cusolverDnDsygvd", dyn.}
   proc cusolverDnChegvd*(handle: cusolverDnHandle_t; itype: cusolverEigType_t;
                         jobz: cusolverEigMode_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cuComplex; lda: cint; B: ptr cuComplex; ldb: cint;
                         W: ptr cfloat; work: ptr cuComplex; lwork: cint; info: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverDnChegvd", dynlib: libName.}
+      cdecl, importc: "cusolverDnChegvd", dyn.}
   proc cusolverDnZhegvd*(handle: cusolverDnHandle_t; itype: cusolverEigType_t;
                         jobz: cusolverEigMode_t; uplo: cublasFillMode_t; n: cint;
                         A: ptr cuDoubleComplex; lda: cint; B: ptr cuDoubleComplex;
                         ldb: cint; W: ptr cdouble; work: ptr cuDoubleComplex;
                         lwork: cint; info: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverDnZhegvd", dynlib: libName.}
+      importc: "cusolverDnZhegvd", dyn.}

--- a/nimcuda/cusolverRf.nim
+++ b/nimcuda/cusolverRf.nim
@@ -1,13 +1,16 @@
  {.deadCodeElim: on.}
 when defined(windows):
-  const
-    libName = "cusolver.dll"
+  import os
+  {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cusolver.lib" & "\"".}
+  {.pragma: dyn.}
 elif defined(macosx):
   const
     libName = "libcusolver.dylib"
+  {.pragma: dyn, dynlib: libName.}
 else:
   const
     libName = "libcusolver.so"
+  {.pragma: dyn, dynlib: libName.}
 import
   cuComplex, cusolver_common
 
@@ -103,41 +106,41 @@ when not defined(CUSOLVERRF_H):
     cusolverRfHandle_t* = ptr cusolverRfCommon
   ##  CUSOLVERRF create (allocate memory) and destroy (free memory) in the handle
   proc cusolverRfCreate*(handle: ptr cusolverRfHandle_t): cusolverStatus_t {.cdecl,
-      importc: "cusolverRfCreate", dynlib: libName.}
+      importc: "cusolverRfCreate", dyn.}
   proc cusolverRfDestroy*(handle: cusolverRfHandle_t): cusolverStatus_t {.cdecl,
-      importc: "cusolverRfDestroy", dynlib: libName.}
+      importc: "cusolverRfDestroy", dyn.}
   ##  CUSOLVERRF set and get input format
   proc cusolverRfGetMatrixFormat*(handle: cusolverRfHandle_t;
                                  format: ptr cusolverRfMatrixFormat_t;
                                  diag: ptr cusolverRfUnitDiagonal_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfGetMatrixFormat", dynlib: libName.}
+      cdecl, importc: "cusolverRfGetMatrixFormat", dyn.}
   proc cusolverRfSetMatrixFormat*(handle: cusolverRfHandle_t;
                                  format: cusolverRfMatrixFormat_t;
                                  diag: cusolverRfUnitDiagonal_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfSetMatrixFormat", dynlib: libName.}
+      cdecl, importc: "cusolverRfSetMatrixFormat", dyn.}
   ##  CUSOLVERRF set and get numeric properties
   proc cusolverRfSetNumericProperties*(handle: cusolverRfHandle_t; zero: cdouble;
                                       boost: cdouble): cusolverStatus_t {.cdecl,
-      importc: "cusolverRfSetNumericProperties", dynlib: libName.}
+      importc: "cusolverRfSetNumericProperties", dyn.}
   proc cusolverRfGetNumericProperties*(handle: cusolverRfHandle_t;
                                       zero: ptr cdouble; boost: ptr cdouble): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfGetNumericProperties", dynlib: libName.}
+      cdecl, importc: "cusolverRfGetNumericProperties", dyn.}
   proc cusolverRfGetNumericBoostReport*(handle: cusolverRfHandle_t; report: ptr cusolverRfNumericBoostReport_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfGetNumericBoostReport", dynlib: libName.}
+      cdecl, importc: "cusolverRfGetNumericBoostReport", dyn.}
   ##  CUSOLVERRF choose the triangular solve algorithm
   proc cusolverRfSetAlgs*(handle: cusolverRfHandle_t;
                          factAlg: cusolverRfFactorization_t;
                          solveAlg: cusolverRfTriangularSolve_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfSetAlgs", dynlib: libName.}
+      cdecl, importc: "cusolverRfSetAlgs", dyn.}
   proc cusolverRfGetAlgs*(handle: cusolverRfHandle_t;
                          factAlg: ptr cusolverRfFactorization_t;
                          solveAlg: ptr cusolverRfTriangularSolve_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfGetAlgs", dynlib: libName.}
+      cdecl, importc: "cusolverRfGetAlgs", dyn.}
   ##  CUSOLVERRF set and get fast mode
   proc cusolverRfGetResetValuesFastMode*(handle: cusolverRfHandle_t; fastMode: ptr cusolverRfResetValuesFastMode_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfGetResetValuesFastMode", dynlib: libName.}
+      cdecl, importc: "cusolverRfGetResetValuesFastMode", dyn.}
   proc cusolverRfSetResetValuesFastMode*(handle: cusolverRfHandle_t; fastMode: cusolverRfResetValuesFastMode_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfSetResetValuesFastMode", dynlib: libName.}
+      cdecl, importc: "cusolverRfSetResetValuesFastMode", dyn.}
   ## ** Non-Batched Routines **
   ##  CUSOLVERRF setup of internal structures from host or device memory
   proc cusolverRfSetupHost*(n: cint; nnzA: cint; h_csrRowPtrA: ptr cint;
@@ -147,7 +150,7 @@ when not defined(CUSOLVERRF_H):
                            h_csrRowPtrU: ptr cint; h_csrColIndU: ptr cint;
                            h_csrValU: ptr cdouble; h_P: ptr cint; h_Q: ptr cint;
                            handle: cusolverRfHandle_t): cusolverStatus_t {.cdecl,
-      importc: "cusolverRfSetupHost", dynlib: libName.}
+      importc: "cusolverRfSetupHost", dyn.}
     ##  Input (in the host memory)
     ##  Output
   proc cusolverRfSetupDevice*(n: cint; nnzA: cint; csrRowPtrA: ptr cint;
@@ -156,7 +159,7 @@ when not defined(CUSOLVERRF_H):
                              csrValL: ptr cdouble; nnzU: cint; csrRowPtrU: ptr cint;
                              csrColIndU: ptr cint; csrValU: ptr cdouble; P: ptr cint;
                              Q: ptr cint; handle: cusolverRfHandle_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfSetupDevice", dynlib: libName.}
+      cdecl, importc: "cusolverRfSetupDevice", dyn.}
     ##  Input (in the device memory)
     ##  Output
   ##  CUSOLVERRF update the matrix values (assuming the reordering, pivoting 
@@ -165,25 +168,25 @@ when not defined(CUSOLVERRF_H):
   proc cusolverRfResetValues*(n: cint; nnzA: cint; csrRowPtrA: ptr cint;
                              csrColIndA: ptr cint; csrValA: ptr cdouble; P: ptr cint;
                              Q: ptr cint; handle: cusolverRfHandle_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfResetValues", dynlib: libName.}
+      cdecl, importc: "cusolverRfResetValues", dyn.}
     ##  Input (in the device memory)
     ##  Output
   ##  CUSOLVERRF analysis (for parallelism)
   proc cusolverRfAnalyze*(handle: cusolverRfHandle_t): cusolverStatus_t {.cdecl,
-      importc: "cusolverRfAnalyze", dynlib: libName.}
+      importc: "cusolverRfAnalyze", dyn.}
   ##  CUSOLVERRF re-factorization (for parallelism)
   proc cusolverRfRefactor*(handle: cusolverRfHandle_t): cusolverStatus_t {.cdecl,
-      importc: "cusolverRfRefactor", dynlib: libName.}
+      importc: "cusolverRfRefactor", dyn.}
   ##  CUSOLVERRF extraction: Get L & U packed into a single matrix M
   proc cusolverRfAccessBundledFactorsDevice*(handle: cusolverRfHandle_t;
       nnzM: ptr cint; Mp: ptr ptr cint; Mi: ptr ptr cint; Mx: ptr ptr cdouble): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfAccessBundledFactorsDevice", dynlib: libName.}
+      cdecl, importc: "cusolverRfAccessBundledFactorsDevice", dyn.}
     ##  Input
     ##  Output (in the host memory)
     ##  Output (in the device memory)
   proc cusolverRfExtractBundledFactorsHost*(handle: cusolverRfHandle_t;
       h_nnzM: ptr cint; h_Mp: ptr ptr cint; h_Mi: ptr ptr cint; h_Mx: ptr ptr cdouble): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfExtractBundledFactorsHost", dynlib: libName.}
+      cdecl, importc: "cusolverRfExtractBundledFactorsHost", dyn.}
     ##  Input
     ##  Output (in the host memory)
   ##  CUSOLVERRF extraction: Get L & U individually
@@ -191,13 +194,13 @@ when not defined(CUSOLVERRF_H):
       h_nnzL: ptr cint; h_csrRowPtrL: ptr ptr cint; h_csrColIndL: ptr ptr cint;
       h_csrValL: ptr ptr cdouble; h_nnzU: ptr cint; h_csrRowPtrU: ptr ptr cint;
       h_csrColIndU: ptr ptr cint; h_csrValU: ptr ptr cdouble): cusolverStatus_t {.cdecl,
-      importc: "cusolverRfExtractSplitFactorsHost", dynlib: libName.}
+      importc: "cusolverRfExtractSplitFactorsHost", dyn.}
     ##  Input
     ##  Output (in the host memory)
   ##  CUSOLVERRF (forward and backward triangular) solves
   proc cusolverRfSolve*(handle: cusolverRfHandle_t; P: ptr cint; Q: ptr cint; nrhs: cint;
                        Temp: ptr cdouble; ldt: cint; XF: ptr cdouble; ldxf: cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfSolve", dynlib: libName.}
+      cdecl, importc: "cusolverRfSolve", dyn.}
     ##  Input (in the device memory)
     ## only nrhs=1 is supported
     ## of size ldt*nrhs (ldt>=n)
@@ -213,7 +216,7 @@ when not defined(CUSOLVERRF_H):
                                 h_csrRowPtrU: ptr cint; h_csrColIndU: ptr cint;
                                 h_csrValU: ptr cdouble; h_P: ptr cint; h_Q: ptr cint;
                                 handle: cusolverRfHandle_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfBatchSetupHost", dynlib: libName.}
+      cdecl, importc: "cusolverRfBatchSetupHost", dyn.}
     ##  Input (in the host memory)
     ##  Output (in the device memory)
   ##  CUSOLVERRF-batch update the matrix values (assuming the reordering, pivoting 
@@ -223,20 +226,20 @@ when not defined(CUSOLVERRF_H):
                                   csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                                   csrValA_array: ptr ptr cdouble; P: ptr cint;
                                   Q: ptr cint; handle: cusolverRfHandle_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfBatchResetValues", dynlib: libName.}
+      cdecl, importc: "cusolverRfBatchResetValues", dyn.}
     ##  Input (in the device memory)
     ##  Output
   ##  CUSOLVERRF-batch analysis (for parallelism)
   proc cusolverRfBatchAnalyze*(handle: cusolverRfHandle_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfBatchAnalyze", dynlib: libName.}
+      cdecl, importc: "cusolverRfBatchAnalyze", dyn.}
   ##  CUSOLVERRF-batch re-factorization (for parallelism)
   proc cusolverRfBatchRefactor*(handle: cusolverRfHandle_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfBatchRefactor", dynlib: libName.}
+      cdecl, importc: "cusolverRfBatchRefactor", dyn.}
   ##  CUSOLVERRF-batch (forward and backward triangular) solves
   proc cusolverRfBatchSolve*(handle: cusolverRfHandle_t; P: ptr cint; Q: ptr cint;
                             nrhs: cint; Temp: ptr cdouble; ldt: cint;
                             XF_array: ptr ptr cdouble; ldxf: cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfBatchSolve", dynlib: libName.}
+      cdecl, importc: "cusolverRfBatchSolve", dyn.}
     ##  Input (in the device memory)
     ## only nrhs=1 is supported
     ## of size 2*batchSize*(n*nrhs)
@@ -245,6 +248,6 @@ when not defined(CUSOLVERRF_H):
     ##  Input
   ##  CUSOLVERRF-batch obtain the position of zero pivot
   proc cusolverRfBatchZeroPivot*(handle: cusolverRfHandle_t; position: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverRfBatchZeroPivot", dynlib: libName.}
+      cdecl, importc: "cusolverRfBatchZeroPivot", dyn.}
     ##  Input
     ##  Output (in the host memory)

--- a/nimcuda/cusolverSp.nim
+++ b/nimcuda/cusolverSp.nim
@@ -1,13 +1,16 @@
  {.deadCodeElim: on.}
 when defined(windows):
-  const
-    libName = "cusolver.dll"
+  import os
+  {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cusolver.lib" & "\"".}
+  {.pragma: dyn.}
 elif defined(macosx):
   const
     libName = "libcusolver.dylib"
+  {.pragma: dyn, dynlib: libName.}
 else:
   const
     libName = "libcusolver.so"
+  {.pragma: dyn, dynlib: libName.}
 import
   cuComplex
 
@@ -77,18 +80,18 @@ when not defined(CUSOLVERSP_H):
   type
     csrqrInfo_t* = ptr csrqrInfo
   proc cusolverSpCreate*(handle: ptr cusolverSpHandle_t): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpCreate", dynlib: libName.}
+      importc: "cusolverSpCreate", dyn.}
   proc cusolverSpDestroy*(handle: cusolverSpHandle_t): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpDestroy", dynlib: libName.}
+      importc: "cusolverSpDestroy", dyn.}
   proc cusolverSpSetStream*(handle: cusolverSpHandle_t; streamId: cudaStream_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpSetStream", dynlib: libName.}
+      cdecl, importc: "cusolverSpSetStream", dyn.}
   proc cusolverSpGetStream*(handle: cusolverSpHandle_t; streamId: ptr cudaStream_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpGetStream", dynlib: libName.}
+      cdecl, importc: "cusolverSpGetStream", dyn.}
   proc cusolverSpXcsrissymHost*(handle: cusolverSpHandle_t; m: cint; nnzA: cint;
                                descrA: cusparseMatDescr_t; csrRowPtrA: ptr cint;
                                csrEndPtrA: ptr cint; csrColIndA: ptr cint;
                                issym: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpXcsrissymHost", dynlib: libName.}
+      importc: "cusolverSpXcsrissymHost", dyn.}
   ##  -------- GPU linear solver based on LU factorization
   ##        solve A*x = b, A can be singular 
   ##  [ls] stands for linear solve
@@ -100,26 +103,26 @@ when not defined(CUSOLVERSP_H):
                                csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                                b: ptr cfloat; tol: cfloat; reorder: cint;
                                x: ptr cfloat; singularity: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpScsrlsvluHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpScsrlsvluHost", dyn.}
   proc cusolverSpDcsrlsvluHost*(handle: cusolverSpHandle_t; n: cint; nnzA: cint;
                                descrA: cusparseMatDescr_t; csrValA: ptr cdouble;
                                csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                                b: ptr cdouble; tol: cdouble; reorder: cint;
                                x: ptr cdouble; singularity: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpDcsrlsvluHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpDcsrlsvluHost", dyn.}
   proc cusolverSpCcsrlsvluHost*(handle: cusolverSpHandle_t; n: cint; nnzA: cint;
                                descrA: cusparseMatDescr_t; csrValA: ptr cuComplex;
                                csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                                b: ptr cuComplex; tol: cfloat; reorder: cint;
                                x: ptr cuComplex; singularity: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpCcsrlsvluHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpCcsrlsvluHost", dyn.}
   proc cusolverSpZcsrlsvluHost*(handle: cusolverSpHandle_t; n: cint; nnzA: cint;
                                descrA: cusparseMatDescr_t;
                                csrValA: ptr cuDoubleComplex; csrRowPtrA: ptr cint;
                                csrColIndA: ptr cint; b: ptr cuDoubleComplex;
                                tol: cdouble; reorder: cint; x: ptr cuDoubleComplex;
                                singularity: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpZcsrlsvluHost", dynlib: libName.}
+      importc: "cusolverSpZcsrlsvluHost", dyn.}
   ##  -------- GPU linear solver based on QR factorization
   ##        solve A*x = b, A can be singular 
   ##  [ls] stands for linear solve
@@ -131,26 +134,26 @@ when not defined(CUSOLVERSP_H):
                            csrRowPtr: ptr cint; csrColInd: ptr cint; b: ptr cfloat;
                            tol: cfloat; reorder: cint; x: ptr cfloat;
                            singularity: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpScsrlsvqr", dynlib: libName.}
+      importc: "cusolverSpScsrlsvqr", dyn.}
   proc cusolverSpDcsrlsvqr*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                            descrA: cusparseMatDescr_t; csrVal: ptr cdouble;
                            csrRowPtr: ptr cint; csrColInd: ptr cint; b: ptr cdouble;
                            tol: cdouble; reorder: cint; x: ptr cdouble;
                            singularity: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpDcsrlsvqr", dynlib: libName.}
+      importc: "cusolverSpDcsrlsvqr", dyn.}
   proc cusolverSpCcsrlsvqr*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                            descrA: cusparseMatDescr_t; csrVal: ptr cuComplex;
                            csrRowPtr: ptr cint; csrColInd: ptr cint; b: ptr cuComplex;
                            tol: cfloat; reorder: cint; x: ptr cuComplex;
                            singularity: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpCcsrlsvqr", dynlib: libName.}
+      importc: "cusolverSpCcsrlsvqr", dyn.}
   proc cusolverSpZcsrlsvqr*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                            descrA: cusparseMatDescr_t;
                            csrVal: ptr cuDoubleComplex; csrRowPtr: ptr cint;
                            csrColInd: ptr cint; b: ptr cuDoubleComplex; tol: cdouble;
                            reorder: cint; x: ptr cuDoubleComplex;
                            singularity: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpZcsrlsvqr", dynlib: libName.}
+      importc: "cusolverSpZcsrlsvqr", dyn.}
   ##  -------- CPU linear solver based on QR factorization
   ##        solve A*x = b, A can be singular 
   ##  [ls] stands for linear solve
@@ -162,26 +165,26 @@ when not defined(CUSOLVERSP_H):
                                csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                                b: ptr cfloat; tol: cfloat; reorder: cint;
                                x: ptr cfloat; singularity: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpScsrlsvqrHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpScsrlsvqrHost", dyn.}
   proc cusolverSpDcsrlsvqrHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                                descrA: cusparseMatDescr_t; csrValA: ptr cdouble;
                                csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                                b: ptr cdouble; tol: cdouble; reorder: cint;
                                x: ptr cdouble; singularity: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpDcsrlsvqrHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpDcsrlsvqrHost", dyn.}
   proc cusolverSpCcsrlsvqrHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                                descrA: cusparseMatDescr_t; csrValA: ptr cuComplex;
                                csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                                b: ptr cuComplex; tol: cfloat; reorder: cint;
                                x: ptr cuComplex; singularity: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpCcsrlsvqrHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpCcsrlsvqrHost", dyn.}
   proc cusolverSpZcsrlsvqrHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                                descrA: cusparseMatDescr_t;
                                csrValA: ptr cuDoubleComplex; csrRowPtrA: ptr cint;
                                csrColIndA: ptr cint; b: ptr cuDoubleComplex;
                                tol: cdouble; reorder: cint; x: ptr cuDoubleComplex;
                                singularity: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpZcsrlsvqrHost", dynlib: libName.}
+      importc: "cusolverSpZcsrlsvqrHost", dyn.}
   ##  -------- CPU linear solver based on Cholesky factorization
   ##        solve A*x = b, A can be singular 
   ##  [ls] stands for linear solve
@@ -196,27 +199,27 @@ when not defined(CUSOLVERSP_H):
                                  csrRowPtr: ptr cint; csrColInd: ptr cint;
                                  b: ptr cfloat; tol: cfloat; reorder: cint;
                                  x: ptr cfloat; singularity: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpScsrlsvcholHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpScsrlsvcholHost", dyn.}
   proc cusolverSpDcsrlsvcholHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                                  descrA: cusparseMatDescr_t; csrVal: ptr cdouble;
                                  csrRowPtr: ptr cint; csrColInd: ptr cint;
                                  b: ptr cdouble; tol: cdouble; reorder: cint;
                                  x: ptr cdouble; singularity: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpDcsrlsvcholHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpDcsrlsvcholHost", dyn.}
   proc cusolverSpCcsrlsvcholHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                                  descrA: cusparseMatDescr_t;
                                  csrVal: ptr cuComplex; csrRowPtr: ptr cint;
                                  csrColInd: ptr cint; b: ptr cuComplex; tol: cfloat;
                                  reorder: cint; x: ptr cuComplex;
                                  singularity: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpCcsrlsvcholHost", dynlib: libName.}
+      importc: "cusolverSpCcsrlsvcholHost", dyn.}
   proc cusolverSpZcsrlsvcholHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                                  descrA: cusparseMatDescr_t;
                                  csrVal: ptr cuDoubleComplex; csrRowPtr: ptr cint;
                                  csrColInd: ptr cint; b: ptr cuDoubleComplex;
                                  tol: cdouble; reorder: cint;
                                  x: ptr cuDoubleComplex; singularity: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpZcsrlsvcholHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpZcsrlsvcholHost", dyn.}
   ##  -------- GPU linear solver based on Cholesky factorization
   ##        solve A*x = b, A can be singular 
   ##  [ls] stands for linear solve
@@ -231,21 +234,21 @@ when not defined(CUSOLVERSP_H):
                              csrRowPtr: ptr cint; csrColInd: ptr cint; b: ptr cfloat;
                              tol: cfloat; reorder: cint; x: ptr cfloat;
                              singularity: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpScsrlsvchol", dynlib: libName.}
+      importc: "cusolverSpScsrlsvchol", dyn.}
     ##  output
   proc cusolverSpDcsrlsvchol*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                              descrA: cusparseMatDescr_t; csrVal: ptr cdouble;
                              csrRowPtr: ptr cint; csrColInd: ptr cint; b: ptr cdouble;
                              tol: cdouble; reorder: cint; x: ptr cdouble;
                              singularity: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpDcsrlsvchol", dynlib: libName.}
+      importc: "cusolverSpDcsrlsvchol", dyn.}
     ##  output
   proc cusolverSpCcsrlsvchol*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                              descrA: cusparseMatDescr_t; csrVal: ptr cuComplex;
                              csrRowPtr: ptr cint; csrColInd: ptr cint;
                              b: ptr cuComplex; tol: cfloat; reorder: cint;
                              x: ptr cuComplex; singularity: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpCcsrlsvchol", dynlib: libName.}
+      cdecl, importc: "cusolverSpCcsrlsvchol", dyn.}
     ##  output
   proc cusolverSpZcsrlsvchol*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                              descrA: cusparseMatDescr_t;
@@ -253,7 +256,7 @@ when not defined(CUSOLVERSP_H):
                              csrColInd: ptr cint; b: ptr cuDoubleComplex;
                              tol: cdouble; reorder: cint; x: ptr cuDoubleComplex;
                              singularity: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpZcsrlsvchol", dynlib: libName.}
+      importc: "cusolverSpZcsrlsvchol", dyn.}
     ##  output
   ##  ----------- CPU least square solver based on QR factorization
   ##        solve min|b - A*x| 
@@ -267,21 +270,21 @@ when not defined(CUSOLVERSP_H):
                                 csrColIndA: ptr cint; b: ptr cfloat; tol: cfloat;
                                 rankA: ptr cint; x: ptr cfloat; p: ptr cint;
                                 min_norm: ptr cfloat): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpScsrlsqvqrHost", dynlib: libName.}
+      importc: "cusolverSpScsrlsqvqrHost", dyn.}
   proc cusolverSpDcsrlsqvqrHost*(handle: cusolverSpHandle_t; m: cint; n: cint;
                                 nnz: cint; descrA: cusparseMatDescr_t;
                                 csrValA: ptr cdouble; csrRowPtrA: ptr cint;
                                 csrColIndA: ptr cint; b: ptr cdouble; tol: cdouble;
                                 rankA: ptr cint; x: ptr cdouble; p: ptr cint;
                                 min_norm: ptr cdouble): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpDcsrlsqvqrHost", dynlib: libName.}
+      importc: "cusolverSpDcsrlsqvqrHost", dyn.}
   proc cusolverSpCcsrlsqvqrHost*(handle: cusolverSpHandle_t; m: cint; n: cint;
                                 nnz: cint; descrA: cusparseMatDescr_t;
                                 csrValA: ptr cuComplex; csrRowPtrA: ptr cint;
                                 csrColIndA: ptr cint; b: ptr cuComplex; tol: cfloat;
                                 rankA: ptr cint; x: ptr cuComplex; p: ptr cint;
                                 min_norm: ptr cfloat): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpCcsrlsqvqrHost", dynlib: libName.}
+      importc: "cusolverSpCcsrlsqvqrHost", dyn.}
   proc cusolverSpZcsrlsqvqrHost*(handle: cusolverSpHandle_t; m: cint; n: cint;
                                 nnz: cint; descrA: cusparseMatDescr_t;
                                 csrValA: ptr cuDoubleComplex; csrRowPtrA: ptr cint;
@@ -289,7 +292,7 @@ when not defined(CUSOLVERSP_H):
                                 tol: cdouble; rankA: ptr cint;
                                 x: ptr cuDoubleComplex; p: ptr cint;
                                 min_norm: ptr cdouble): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpZcsrlsqvqrHost", dynlib: libName.}
+      importc: "cusolverSpZcsrlsqvqrHost", dyn.}
   ##  --------- CPU eigenvalue solver based on shift inverse
   ##       solve A*x = lambda * x 
   ##    where lambda is the eigenvalue nearest mu0.
@@ -301,27 +304,27 @@ when not defined(CUSOLVERSP_H):
                                 csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                                 mu0: cfloat; x0: ptr cfloat; maxite: cint; tol: cfloat;
                                 mu: ptr cfloat; x: ptr cfloat): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpScsreigvsiHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpScsreigvsiHost", dyn.}
   proc cusolverSpDcsreigvsiHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                                 descrA: cusparseMatDescr_t; csrValA: ptr cdouble;
                                 csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                                 mu0: cdouble; x0: ptr cdouble; maxite: cint;
                                 tol: cdouble; mu: ptr cdouble; x: ptr cdouble): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpDcsreigvsiHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpDcsreigvsiHost", dyn.}
   proc cusolverSpCcsreigvsiHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                                 descrA: cusparseMatDescr_t;
                                 csrValA: ptr cuComplex; csrRowPtrA: ptr cint;
                                 csrColIndA: ptr cint; mu0: cuComplex;
                                 x0: ptr cuComplex; maxite: cint; tol: cfloat;
                                 mu: ptr cuComplex; x: ptr cuComplex): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpCcsreigvsiHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpCcsreigvsiHost", dyn.}
   proc cusolverSpZcsreigvsiHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                                 descrA: cusparseMatDescr_t;
                                 csrValA: ptr cuDoubleComplex; csrRowPtrA: ptr cint;
                                 csrColIndA: ptr cint; mu0: cuDoubleComplex;
                                 x0: ptr cuDoubleComplex; maxite: cint; tol: cdouble;
                                 mu: ptr cuDoubleComplex; x: ptr cuDoubleComplex): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpZcsreigvsiHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpZcsreigvsiHost", dyn.}
   ##  --------- GPU eigenvalue solver based on shift inverse
   ##       solve A*x = lambda * x 
   ##    where lambda is the eigenvalue nearest mu0.
@@ -333,46 +336,46 @@ when not defined(CUSOLVERSP_H):
                             csrRowPtrA: ptr cint; csrColIndA: ptr cint; mu0: cfloat;
                             x0: ptr cfloat; maxite: cint; eps: cfloat; mu: ptr cfloat;
                             x: ptr cfloat): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpScsreigvsi", dynlib: libName.}
+      importc: "cusolverSpScsreigvsi", dyn.}
   proc cusolverSpDcsreigvsi*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                             descrA: cusparseMatDescr_t; csrValA: ptr cdouble;
                             csrRowPtrA: ptr cint; csrColIndA: ptr cint; mu0: cdouble;
                             x0: ptr cdouble; maxite: cint; eps: cdouble;
                             mu: ptr cdouble; x: ptr cdouble): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpDcsreigvsi", dynlib: libName.}
+      importc: "cusolverSpDcsreigvsi", dyn.}
   proc cusolverSpCcsreigvsi*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                             descrA: cusparseMatDescr_t; csrValA: ptr cuComplex;
                             csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                             mu0: cuComplex; x0: ptr cuComplex; maxite: cint;
                             eps: cfloat; mu: ptr cuComplex; x: ptr cuComplex): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpCcsreigvsi", dynlib: libName.}
+      cdecl, importc: "cusolverSpCcsreigvsi", dyn.}
   proc cusolverSpZcsreigvsi*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                             descrA: cusparseMatDescr_t;
                             csrValA: ptr cuDoubleComplex; csrRowPtrA: ptr cint;
                             csrColIndA: ptr cint; mu0: cuDoubleComplex;
                             x0: ptr cuDoubleComplex; maxite: cint; eps: cdouble;
                             mu: ptr cuDoubleComplex; x: ptr cuDoubleComplex): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpZcsreigvsi", dynlib: libName.}
+      cdecl, importc: "cusolverSpZcsreigvsi", dyn.}
   ##  ----------- enclosed eigenvalues
   proc cusolverSpScsreigsHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                               descrA: cusparseMatDescr_t; csrValA: ptr cfloat;
                               csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                               left_bottom_corner: cuComplex;
                               right_upper_corner: cuComplex; num_eigs: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpScsreigsHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpScsreigsHost", dyn.}
   proc cusolverSpDcsreigsHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                               descrA: cusparseMatDescr_t; csrValA: ptr cdouble;
                               csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                               left_bottom_corner: cuDoubleComplex;
                               right_upper_corner: cuDoubleComplex;
                               num_eigs: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpDcsreigsHost", dynlib: libName.}
+      importc: "cusolverSpDcsreigsHost", dyn.}
   proc cusolverSpCcsreigsHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                               descrA: cusparseMatDescr_t; csrValA: ptr cuComplex;
                               csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                               left_bottom_corner: cuComplex;
                               right_upper_corner: cuComplex; num_eigs: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpCcsreigsHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpCcsreigsHost", dyn.}
   proc cusolverSpZcsreigsHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                               descrA: cusparseMatDescr_t;
                               csrValA: ptr cuDoubleComplex; csrRowPtrA: ptr cint;
@@ -380,7 +383,7 @@ when not defined(CUSOLVERSP_H):
                               left_bottom_corner: cuDoubleComplex;
                               right_upper_corner: cuDoubleComplex;
                               num_eigs: ptr cint): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpZcsreigsHost", dynlib: libName.}
+      importc: "cusolverSpZcsreigsHost", dyn.}
   ##  --------- CPU symrcm
   ##    Symmetric reverse Cuthill McKee permutation         
   ## 
@@ -388,7 +391,7 @@ when not defined(CUSOLVERSP_H):
   proc cusolverSpXcsrsymrcmHost*(handle: cusolverSpHandle_t; n: cint; nnzA: cint;
                                 descrA: cusparseMatDescr_t; csrRowPtrA: ptr cint;
                                 csrColIndA: ptr cint; p: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpXcsrsymrcmHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpXcsrsymrcmHost", dyn.}
   ##  --------- CPU symmdq 
   ##    Symmetric minimum degree algorithm based on quotient graph
   ## 
@@ -396,7 +399,7 @@ when not defined(CUSOLVERSP_H):
   proc cusolverSpXcsrsymmdqHost*(handle: cusolverSpHandle_t; n: cint; nnzA: cint;
                                 descrA: cusparseMatDescr_t; csrRowPtrA: ptr cint;
                                 csrColIndA: ptr cint; p: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpXcsrsymmdqHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpXcsrsymmdqHost", dyn.}
   ##  --------- CPU symmdq 
   ##    Symmetric Approximate minimum degree algorithm based on quotient graph
   ## 
@@ -404,7 +407,7 @@ when not defined(CUSOLVERSP_H):
   proc cusolverSpXcsrsymamdHost*(handle: cusolverSpHandle_t; n: cint; nnzA: cint;
                                 descrA: cusparseMatDescr_t; csrRowPtrA: ptr cint;
                                 csrColIndA: ptr cint; p: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpXcsrsymamdHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpXcsrsymamdHost", dyn.}
   ##  --------- CPU permuation
   ##    P*A*Q^T        
   ## 
@@ -412,66 +415,66 @@ when not defined(CUSOLVERSP_H):
   proc cusolverSpXcsrperm_bufferSizeHost*(handle: cusolverSpHandle_t; m: cint;
       n: cint; nnzA: cint; descrA: cusparseMatDescr_t; csrRowPtrA: ptr cint;
       csrColIndA: ptr cint; p: ptr cint; q: ptr cint; bufferSizeInBytes: ptr csize): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpXcsrperm_bufferSizeHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpXcsrperm_bufferSizeHost", dyn.}
   proc cusolverSpXcsrpermHost*(handle: cusolverSpHandle_t; m: cint; n: cint;
                               nnzA: cint; descrA: cusparseMatDescr_t;
                               csrRowPtrA: ptr cint; csrColIndA: ptr cint; p: ptr cint;
                               q: ptr cint; map: ptr cint; pBuffer: pointer): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpXcsrpermHost", dynlib: libName.}
+      cdecl, importc: "cusolverSpXcsrpermHost", dyn.}
   ## 
   ##   Low-level API: Batched QR
   ## 
   ## 
   proc cusolverSpCreateCsrqrInfo*(info: ptr csrqrInfo_t): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpCreateCsrqrInfo", dynlib: libName.}
+      importc: "cusolverSpCreateCsrqrInfo", dyn.}
   proc cusolverSpDestroyCsrqrInfo*(info: csrqrInfo_t): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpDestroyCsrqrInfo", dynlib: libName.}
+      importc: "cusolverSpDestroyCsrqrInfo", dyn.}
   proc cusolverSpXcsrqrAnalysisBatched*(handle: cusolverSpHandle_t; m: cint; n: cint;
                                        nnzA: cint; descrA: cusparseMatDescr_t;
                                        csrRowPtrA: ptr cint; csrColIndA: ptr cint;
                                        info: csrqrInfo_t): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpXcsrqrAnalysisBatched", dynlib: libName.}
+      cdecl, importc: "cusolverSpXcsrqrAnalysisBatched", dyn.}
   proc cusolverSpScsrqrBufferInfoBatched*(handle: cusolverSpHandle_t; m: cint;
       n: cint; nnz: cint; descrA: cusparseMatDescr_t; csrVal: ptr cfloat;
       csrRowPtr: ptr cint; csrColInd: ptr cint; batchSize: cint; info: csrqrInfo_t;
       internalDataInBytes: ptr csize; workspaceInBytes: ptr csize): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpScsrqrBufferInfoBatched", dynlib: libName.}
+      cdecl, importc: "cusolverSpScsrqrBufferInfoBatched", dyn.}
   proc cusolverSpDcsrqrBufferInfoBatched*(handle: cusolverSpHandle_t; m: cint;
       n: cint; nnz: cint; descrA: cusparseMatDescr_t; csrVal: ptr cdouble;
       csrRowPtr: ptr cint; csrColInd: ptr cint; batchSize: cint; info: csrqrInfo_t;
       internalDataInBytes: ptr csize; workspaceInBytes: ptr csize): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpDcsrqrBufferInfoBatched", dynlib: libName.}
+      cdecl, importc: "cusolverSpDcsrqrBufferInfoBatched", dyn.}
   proc cusolverSpCcsrqrBufferInfoBatched*(handle: cusolverSpHandle_t; m: cint;
       n: cint; nnz: cint; descrA: cusparseMatDescr_t; csrVal: ptr cuComplex;
       csrRowPtr: ptr cint; csrColInd: ptr cint; batchSize: cint; info: csrqrInfo_t;
       internalDataInBytes: ptr csize; workspaceInBytes: ptr csize): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpCcsrqrBufferInfoBatched", dynlib: libName.}
+      cdecl, importc: "cusolverSpCcsrqrBufferInfoBatched", dyn.}
   proc cusolverSpZcsrqrBufferInfoBatched*(handle: cusolverSpHandle_t; m: cint;
       n: cint; nnz: cint; descrA: cusparseMatDescr_t; csrVal: ptr cuDoubleComplex;
       csrRowPtr: ptr cint; csrColInd: ptr cint; batchSize: cint; info: csrqrInfo_t;
       internalDataInBytes: ptr csize; workspaceInBytes: ptr csize): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpZcsrqrBufferInfoBatched", dynlib: libName.}
+      cdecl, importc: "cusolverSpZcsrqrBufferInfoBatched", dyn.}
   proc cusolverSpScsrqrsvBatched*(handle: cusolverSpHandle_t; m: cint; n: cint;
                                  nnz: cint; descrA: cusparseMatDescr_t;
                                  csrValA: ptr cfloat; csrRowPtrA: ptr cint;
                                  csrColIndA: ptr cint; b: ptr cfloat; x: ptr cfloat;
                                  batchSize: cint; info: csrqrInfo_t;
                                  pBuffer: pointer): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpScsrqrsvBatched", dynlib: libName.}
+      importc: "cusolverSpScsrqrsvBatched", dyn.}
   proc cusolverSpDcsrqrsvBatched*(handle: cusolverSpHandle_t; m: cint; n: cint;
                                  nnz: cint; descrA: cusparseMatDescr_t;
                                  csrValA: ptr cdouble; csrRowPtrA: ptr cint;
                                  csrColIndA: ptr cint; b: ptr cdouble; x: ptr cdouble;
                                  batchSize: cint; info: csrqrInfo_t;
                                  pBuffer: pointer): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpDcsrqrsvBatched", dynlib: libName.}
+      importc: "cusolverSpDcsrqrsvBatched", dyn.}
   proc cusolverSpCcsrqrsvBatched*(handle: cusolverSpHandle_t; m: cint; n: cint;
                                  nnz: cint; descrA: cusparseMatDescr_t;
                                  csrValA: ptr cuComplex; csrRowPtrA: ptr cint;
                                  csrColIndA: ptr cint; b: ptr cuComplex;
                                  x: ptr cuComplex; batchSize: cint;
                                  info: csrqrInfo_t; pBuffer: pointer): cusolverStatus_t {.
-      cdecl, importc: "cusolverSpCcsrqrsvBatched", dynlib: libName.}
+      cdecl, importc: "cusolverSpCcsrqrsvBatched", dyn.}
   proc cusolverSpZcsrqrsvBatched*(handle: cusolverSpHandle_t; m: cint; n: cint;
                                  nnz: cint; descrA: cusparseMatDescr_t;
                                  csrValA: ptr cuDoubleComplex;
@@ -479,4 +482,4 @@ when not defined(CUSOLVERSP_H):
                                  b: ptr cuDoubleComplex; x: ptr cuDoubleComplex;
                                  batchSize: cint; info: csrqrInfo_t;
                                  pBuffer: pointer): cusolverStatus_t {.cdecl,
-      importc: "cusolverSpZcsrqrsvBatched", dynlib: libName.}
+      importc: "cusolverSpZcsrqrsvBatched", dyn.}

--- a/nimcuda/cusolver_common.nim
+++ b/nimcuda/cusolver_common.nim
@@ -1,13 +1,16 @@
  {.deadCodeElim: on.}
 when defined(windows):
-  const
-    libName = "cusolver.dll"
+  import os
+  {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cusolver.lib" & "\"".}
+  {.pragma: dyn.}
 elif defined(macosx):
   const
     libName = "libcusolver.dylib"
+  {.pragma: dyn, dynlib: libName.}
 else:
   const
     libName = "libcusolver.so"
+  {.pragma: dyn, dynlib: libName.}
 import
   library_types
 
@@ -77,4 +80,4 @@ when not defined(CUSOLVER_COMMON_H):
     cusolverEigMode_t* {.size: sizeof(cint).} = enum
       CUSOLVER_EIG_MODE_NOVECTOR = 0, CUSOLVER_EIG_MODE_VECTOR = 1
   proc cusolverGetProperty*(`type`: libraryPropertyType; value: ptr cint): cusolverStatus_t {.
-      cdecl, importc: "cusolverGetProperty", dynlib: libName.}
+      cdecl, importc: "cusolverGetProperty", dyn.}

--- a/nimcuda/cusparse.nim
+++ b/nimcuda/cusparse.nim
@@ -3,14 +3,17 @@
 
 {.deadCodeElim: on.}
 when defined(windows):
-  const
-    libName = "cusparse.dll"
+  import os
+  {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cusparse.lib" & "\"".}
+  {.pragma: dyn.}
 elif defined(macosx):
   const
     libName = "libcusparse.dylib"
+  {.pragma: dyn, dynlib: libName.}
 else:
   const
     libName = "libcusparse.so"
+  {.pragma: dyn, dynlib: libName.}
 type
   cudaStream_t* = pointer
 
@@ -196,24 +199,24 @@ when not defined(CUSPARSE_H):
       CUSPARSE_ALG1 = 1
   ##  CUSPARSE initialization and managment routines
   proc cusparseCreate*(handle: ptr cusparseHandle_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseCreate", dynlib: libName.}
+      importc: "cusparseCreate", dyn.}
   proc cusparseDestroy*(handle: cusparseHandle_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDestroy", dynlib: libName.}
+      importc: "cusparseDestroy", dyn.}
   proc cusparseGetVersion*(handle: cusparseHandle_t; version: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseGetVersion", dynlib: libName.}
+      cdecl, importc: "cusparseGetVersion", dyn.}
   proc cusparseGetProperty*(`type`: libraryPropertyType; value: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseGetProperty", dynlib: libName.}
+      cdecl, importc: "cusparseGetProperty", dyn.}
   proc cusparseSetStream*(handle: cusparseHandle_t; streamId: cudaStream_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseSetStream", dynlib: libName.}
+      cdecl, importc: "cusparseSetStream", dyn.}
   proc cusparseGetStream*(handle: cusparseHandle_t; streamId: ptr cudaStream_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseGetStream", dynlib: libName.}
+      cdecl, importc: "cusparseGetStream", dyn.}
   ##  CUSPARSE type creation, destruction, set and get routines
   proc cusparseGetPointerMode*(handle: cusparseHandle_t;
                               mode: ptr cusparsePointerMode_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseGetPointerMode", dynlib: libName.}
+      cdecl, importc: "cusparseGetPointerMode", dyn.}
   proc cusparseSetPointerMode*(handle: cusparseHandle_t;
                               mode: cusparsePointerMode_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseSetPointerMode", dynlib: libName.}
+      cdecl, importc: "cusparseSetPointerMode", dyn.}
   ##  sparse matrix descriptor
   ##  When the matrix descriptor is created, its fields are initialized to: 
   ##    CUSPARSE_MATRIX_TYPE_GENERAL
@@ -221,244 +224,244 @@ when not defined(CUSPARSE_H):
   ##    All other fields are uninitialized
   ## 
   proc cusparseCreateMatDescr*(descrA: ptr cusparseMatDescr_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCreateMatDescr", dynlib: libName.}
+      cdecl, importc: "cusparseCreateMatDescr", dyn.}
   proc cusparseDestroyMatDescr*(descrA: cusparseMatDescr_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDestroyMatDescr", dynlib: libName.}
+      cdecl, importc: "cusparseDestroyMatDescr", dyn.}
   proc cusparseCopyMatDescr*(dest: cusparseMatDescr_t; src: cusparseMatDescr_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCopyMatDescr", dynlib: libName.}
+      cdecl, importc: "cusparseCopyMatDescr", dyn.}
   proc cusparseSetMatType*(descrA: cusparseMatDescr_t; `type`: cusparseMatrixType_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseSetMatType", dynlib: libName.}
+      cdecl, importc: "cusparseSetMatType", dyn.}
   proc cusparseGetMatType*(descrA: cusparseMatDescr_t): cusparseMatrixType_t {.
-      cdecl, importc: "cusparseGetMatType", dynlib: libName.}
+      cdecl, importc: "cusparseGetMatType", dyn.}
   proc cusparseSetMatFillMode*(descrA: cusparseMatDescr_t;
                               fillMode: cusparseFillMode_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseSetMatFillMode", dynlib: libName.}
+      cdecl, importc: "cusparseSetMatFillMode", dyn.}
   proc cusparseGetMatFillMode*(descrA: cusparseMatDescr_t): cusparseFillMode_t {.
-      cdecl, importc: "cusparseGetMatFillMode", dynlib: libName.}
+      cdecl, importc: "cusparseGetMatFillMode", dyn.}
   proc cusparseSetMatDiagType*(descrA: cusparseMatDescr_t;
                               diagType: cusparseDiagType_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseSetMatDiagType", dynlib: libName.}
+      cdecl, importc: "cusparseSetMatDiagType", dyn.}
   proc cusparseGetMatDiagType*(descrA: cusparseMatDescr_t): cusparseDiagType_t {.
-      cdecl, importc: "cusparseGetMatDiagType", dynlib: libName.}
+      cdecl, importc: "cusparseGetMatDiagType", dyn.}
   proc cusparseSetMatIndexBase*(descrA: cusparseMatDescr_t;
                                base: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseSetMatIndexBase", dynlib: libName.}
+      cdecl, importc: "cusparseSetMatIndexBase", dyn.}
   proc cusparseGetMatIndexBase*(descrA: cusparseMatDescr_t): cusparseIndexBase_t {.
-      cdecl, importc: "cusparseGetMatIndexBase", dynlib: libName.}
+      cdecl, importc: "cusparseGetMatIndexBase", dyn.}
   ##  sparse triangular solve and incomplete-LU and Cholesky (algorithm 1)
   proc cusparseCreateSolveAnalysisInfo*(info: ptr cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCreateSolveAnalysisInfo", dynlib: libName.}
+      cdecl, importc: "cusparseCreateSolveAnalysisInfo", dyn.}
   proc cusparseDestroySolveAnalysisInfo*(info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDestroySolveAnalysisInfo", dynlib: libName.}
+      cdecl, importc: "cusparseDestroySolveAnalysisInfo", dyn.}
   proc cusparseGetLevelInfo*(handle: cusparseHandle_t;
                             info: cusparseSolveAnalysisInfo_t; nlevels: ptr cint;
                             levelPtr: ptr ptr cint; levelInd: ptr ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseGetLevelInfo", dynlib: libName.}
+      cdecl, importc: "cusparseGetLevelInfo", dyn.}
   ##  sparse triangular solve (algorithm 2)
   proc cusparseCreateCsrsv2Info*(info: ptr csrsv2Info_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseCreateCsrsv2Info", dynlib: libName.}
+      importc: "cusparseCreateCsrsv2Info", dyn.}
   proc cusparseDestroyCsrsv2Info*(info: csrsv2Info_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDestroyCsrsv2Info", dynlib: libName.}
+      importc: "cusparseDestroyCsrsv2Info", dyn.}
   ##  incomplete Cholesky (algorithm 2)
   proc cusparseCreateCsric02Info*(info: ptr csric02Info_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseCreateCsric02Info", dynlib: libName.}
+      importc: "cusparseCreateCsric02Info", dyn.}
   proc cusparseDestroyCsric02Info*(info: csric02Info_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDestroyCsric02Info", dynlib: libName.}
+      importc: "cusparseDestroyCsric02Info", dyn.}
   proc cusparseCreateBsric02Info*(info: ptr bsric02Info_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseCreateBsric02Info", dynlib: libName.}
+      importc: "cusparseCreateBsric02Info", dyn.}
   proc cusparseDestroyBsric02Info*(info: bsric02Info_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDestroyBsric02Info", dynlib: libName.}
+      importc: "cusparseDestroyBsric02Info", dyn.}
   ##  incomplete LU (algorithm 2)
   proc cusparseCreateCsrilu02Info*(info: ptr csrilu02Info_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCreateCsrilu02Info", dynlib: libName.}
+      cdecl, importc: "cusparseCreateCsrilu02Info", dyn.}
   proc cusparseDestroyCsrilu02Info*(info: csrilu02Info_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDestroyCsrilu02Info", dynlib: libName.}
+      importc: "cusparseDestroyCsrilu02Info", dyn.}
   proc cusparseCreateBsrilu02Info*(info: ptr bsrilu02Info_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCreateBsrilu02Info", dynlib: libName.}
+      cdecl, importc: "cusparseCreateBsrilu02Info", dyn.}
   proc cusparseDestroyBsrilu02Info*(info: bsrilu02Info_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDestroyBsrilu02Info", dynlib: libName.}
+      importc: "cusparseDestroyBsrilu02Info", dyn.}
   ##  block-CSR triangular solve (algorithm 2)
   proc cusparseCreateBsrsv2Info*(info: ptr bsrsv2Info_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseCreateBsrsv2Info", dynlib: libName.}
+      importc: "cusparseCreateBsrsv2Info", dyn.}
   proc cusparseDestroyBsrsv2Info*(info: bsrsv2Info_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDestroyBsrsv2Info", dynlib: libName.}
+      importc: "cusparseDestroyBsrsv2Info", dyn.}
   proc cusparseCreateBsrsm2Info*(info: ptr bsrsm2Info_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseCreateBsrsm2Info", dynlib: libName.}
+      importc: "cusparseCreateBsrsm2Info", dyn.}
   proc cusparseDestroyBsrsm2Info*(info: bsrsm2Info_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDestroyBsrsm2Info", dynlib: libName.}
+      importc: "cusparseDestroyBsrsm2Info", dyn.}
   ##  hybrid (HYB) format
   proc cusparseCreateHybMat*(hybA: ptr cusparseHybMat_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseCreateHybMat", dynlib: libName.}
+      importc: "cusparseCreateHybMat", dyn.}
   proc cusparseDestroyHybMat*(hybA: cusparseHybMat_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDestroyHybMat", dynlib: libName.}
+      importc: "cusparseDestroyHybMat", dyn.}
   ##  sorting information
   proc cusparseCreateCsru2csrInfo*(info: ptr csru2csrInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCreateCsru2csrInfo", dynlib: libName.}
+      cdecl, importc: "cusparseCreateCsru2csrInfo", dyn.}
   proc cusparseDestroyCsru2csrInfo*(info: csru2csrInfo_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDestroyCsru2csrInfo", dynlib: libName.}
+      importc: "cusparseDestroyCsru2csrInfo", dyn.}
   ##  coloring info
   proc cusparseCreateColorInfo*(info: ptr cusparseColorInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCreateColorInfo", dynlib: libName.}
+      cdecl, importc: "cusparseCreateColorInfo", dyn.}
   proc cusparseDestroyColorInfo*(info: cusparseColorInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDestroyColorInfo", dynlib: libName.}
+      cdecl, importc: "cusparseDestroyColorInfo", dyn.}
   proc cusparseSetColorAlgs*(info: cusparseColorInfo_t; alg: cusparseColorAlg_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseSetColorAlgs", dynlib: libName.}
+      cdecl, importc: "cusparseSetColorAlgs", dyn.}
   proc cusparseGetColorAlgs*(info: cusparseColorInfo_t; alg: ptr cusparseColorAlg_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseGetColorAlgs", dynlib: libName.}
+      cdecl, importc: "cusparseGetColorAlgs", dyn.}
   ##  --- Sparse Level 1 routines ---
   ##  Description: Addition of a scalar multiple of a sparse vector x  
   ##    and a dense vector y.
   proc cusparseSaxpyi*(handle: cusparseHandle_t; nnz: cint; alpha: ptr cfloat;
                       xVal: ptr cfloat; xInd: ptr cint; y: ptr cfloat;
                       idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseSaxpyi", dynlib: libName.}
+      importc: "cusparseSaxpyi", dyn.}
   proc cusparseDaxpyi*(handle: cusparseHandle_t; nnz: cint; alpha: ptr cdouble;
                       xVal: ptr cdouble; xInd: ptr cint; y: ptr cdouble;
                       idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDaxpyi", dynlib: libName.}
+      importc: "cusparseDaxpyi", dyn.}
   proc cusparseCaxpyi*(handle: cusparseHandle_t; nnz: cint; alpha: ptr cuComplex;
                       xVal: ptr cuComplex; xInd: ptr cint; y: ptr cuComplex;
                       idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseCaxpyi", dynlib: libName.}
+      importc: "cusparseCaxpyi", dyn.}
   proc cusparseZaxpyi*(handle: cusparseHandle_t; nnz: cint;
                       alpha: ptr cuDoubleComplex; xVal: ptr cuDoubleComplex;
                       xInd: ptr cint; y: ptr cuDoubleComplex;
                       idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseZaxpyi", dynlib: libName.}
+      importc: "cusparseZaxpyi", dyn.}
   ##  Description: dot product of a sparse vector x and a dense vector y.
   proc cusparseSdoti*(handle: cusparseHandle_t; nnz: cint; xVal: ptr cfloat;
                      xInd: ptr cint; y: ptr cfloat; resultDevHostPtr: ptr cfloat;
                      idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseSdoti", dynlib: libName.}
+      importc: "cusparseSdoti", dyn.}
   proc cusparseDdoti*(handle: cusparseHandle_t; nnz: cint; xVal: ptr cdouble;
                      xInd: ptr cint; y: ptr cdouble; resultDevHostPtr: ptr cdouble;
                      idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDdoti", dynlib: libName.}
+      importc: "cusparseDdoti", dyn.}
   proc cusparseCdoti*(handle: cusparseHandle_t; nnz: cint; xVal: ptr cuComplex;
                      xInd: ptr cint; y: ptr cuComplex;
                      resultDevHostPtr: ptr cuComplex; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCdoti", dynlib: libName.}
+      cdecl, importc: "cusparseCdoti", dyn.}
   proc cusparseZdoti*(handle: cusparseHandle_t; nnz: cint; xVal: ptr cuDoubleComplex;
                      xInd: ptr cint; y: ptr cuDoubleComplex;
                      resultDevHostPtr: ptr cuDoubleComplex;
                      idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseZdoti", dynlib: libName.}
+      importc: "cusparseZdoti", dyn.}
   ##  Description: dot product of complex conjugate of a sparse vector x
   ##    and a dense vector y.
   proc cusparseCdotci*(handle: cusparseHandle_t; nnz: cint; xVal: ptr cuComplex;
                       xInd: ptr cint; y: ptr cuComplex;
                       resultDevHostPtr: ptr cuComplex; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCdotci", dynlib: libName.}
+      cdecl, importc: "cusparseCdotci", dyn.}
   proc cusparseZdotci*(handle: cusparseHandle_t; nnz: cint;
                       xVal: ptr cuDoubleComplex; xInd: ptr cint;
                       y: ptr cuDoubleComplex;
                       resultDevHostPtr: ptr cuDoubleComplex;
                       idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseZdotci", dynlib: libName.}
+      importc: "cusparseZdotci", dyn.}
   ##  Description: Gather of non-zero elements from dense vector y into 
   ##    sparse vector x.
   proc cusparseSgthr*(handle: cusparseHandle_t; nnz: cint; y: ptr cfloat;
                      xVal: ptr cfloat; xInd: ptr cint; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseSgthr", dynlib: libName.}
+      cdecl, importc: "cusparseSgthr", dyn.}
   proc cusparseDgthr*(handle: cusparseHandle_t; nnz: cint; y: ptr cdouble;
                      xVal: ptr cdouble; xInd: ptr cint; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDgthr", dynlib: libName.}
+      cdecl, importc: "cusparseDgthr", dyn.}
   proc cusparseCgthr*(handle: cusparseHandle_t; nnz: cint; y: ptr cuComplex;
                      xVal: ptr cuComplex; xInd: ptr cint; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCgthr", dynlib: libName.}
+      cdecl, importc: "cusparseCgthr", dyn.}
   proc cusparseZgthr*(handle: cusparseHandle_t; nnz: cint; y: ptr cuDoubleComplex;
                      xVal: ptr cuDoubleComplex; xInd: ptr cint;
                      idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseZgthr", dynlib: libName.}
+      importc: "cusparseZgthr", dyn.}
   ##  Description: Gather of non-zero elements from desne vector y into 
   ##    sparse vector x (also replacing these elements in y by zeros).
   proc cusparseSgthrz*(handle: cusparseHandle_t; nnz: cint; y: ptr cfloat;
                       xVal: ptr cfloat; xInd: ptr cint; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseSgthrz", dynlib: libName.}
+      cdecl, importc: "cusparseSgthrz", dyn.}
   proc cusparseDgthrz*(handle: cusparseHandle_t; nnz: cint; y: ptr cdouble;
                       xVal: ptr cdouble; xInd: ptr cint; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDgthrz", dynlib: libName.}
+      cdecl, importc: "cusparseDgthrz", dyn.}
   proc cusparseCgthrz*(handle: cusparseHandle_t; nnz: cint; y: ptr cuComplex;
                       xVal: ptr cuComplex; xInd: ptr cint;
                       idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseCgthrz", dynlib: libName.}
+      importc: "cusparseCgthrz", dyn.}
   proc cusparseZgthrz*(handle: cusparseHandle_t; nnz: cint; y: ptr cuDoubleComplex;
                       xVal: ptr cuDoubleComplex; xInd: ptr cint;
                       idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseZgthrz", dynlib: libName.}
+      importc: "cusparseZgthrz", dyn.}
   ##  Description: Scatter of elements of the sparse vector x into 
   ##    dense vector y.
   proc cusparseSsctr*(handle: cusparseHandle_t; nnz: cint; xVal: ptr cfloat;
                      xInd: ptr cint; y: ptr cfloat; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseSsctr", dynlib: libName.}
+      cdecl, importc: "cusparseSsctr", dyn.}
   proc cusparseDsctr*(handle: cusparseHandle_t; nnz: cint; xVal: ptr cdouble;
                      xInd: ptr cint; y: ptr cdouble; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDsctr", dynlib: libName.}
+      cdecl, importc: "cusparseDsctr", dyn.}
   proc cusparseCsctr*(handle: cusparseHandle_t; nnz: cint; xVal: ptr cuComplex;
                      xInd: ptr cint; y: ptr cuComplex; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCsctr", dynlib: libName.}
+      cdecl, importc: "cusparseCsctr", dyn.}
   proc cusparseZsctr*(handle: cusparseHandle_t; nnz: cint; xVal: ptr cuDoubleComplex;
                      xInd: ptr cint; y: ptr cuDoubleComplex;
                      idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseZsctr", dynlib: libName.}
+      importc: "cusparseZsctr", dyn.}
   ##  Description: Givens rotation, where c and s are cosine and sine, 
   ##    x and y are sparse and dense vectors, respectively.
   proc cusparseSroti*(handle: cusparseHandle_t; nnz: cint; xVal: ptr cfloat;
                      xInd: ptr cint; y: ptr cfloat; c: ptr cfloat; s: ptr cfloat;
                      idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseSroti", dynlib: libName.}
+      importc: "cusparseSroti", dyn.}
   proc cusparseDroti*(handle: cusparseHandle_t; nnz: cint; xVal: ptr cdouble;
                      xInd: ptr cint; y: ptr cdouble; c: ptr cdouble; s: ptr cdouble;
                      idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDroti", dynlib: libName.}
+      importc: "cusparseDroti", dyn.}
   ##  --- Sparse Level 2 routines ---
   proc cusparseSgemvi*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       m: cint; n: cint; alpha: ptr cfloat; A: ptr cfloat; lda: cint;
                       nnz: cint; xVal: ptr cfloat; xInd: ptr cint; beta: ptr cfloat;
                       y: ptr cfloat; idxBase: cusparseIndexBase_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseSgemvi", dynlib: libName.}
+      cdecl, importc: "cusparseSgemvi", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cusparseSgemvi_bufferSize*(handle: cusparseHandle_t;
                                  transA: cusparseOperation_t; m: cint; n: cint;
                                  nnz: cint; pBufferSize: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseSgemvi_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseSgemvi_bufferSize", dyn.}
   proc cusparseDgemvi*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       m: cint; n: cint; alpha: ptr cdouble; A: ptr cdouble; lda: cint;
                       nnz: cint; xVal: ptr cdouble; xInd: ptr cint; beta: ptr cdouble;
                       y: ptr cdouble; idxBase: cusparseIndexBase_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseDgemvi", dynlib: libName.}
+      cdecl, importc: "cusparseDgemvi", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cusparseDgemvi_bufferSize*(handle: cusparseHandle_t;
                                  transA: cusparseOperation_t; m: cint; n: cint;
                                  nnz: cint; pBufferSize: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDgemvi_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseDgemvi_bufferSize", dyn.}
   proc cusparseCgemvi*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       m: cint; n: cint; alpha: ptr cuComplex; A: ptr cuComplex; lda: cint;
                       nnz: cint; xVal: ptr cuComplex; xInd: ptr cint;
                       beta: ptr cuComplex; y: ptr cuComplex;
                       idxBase: cusparseIndexBase_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseCgemvi", dynlib: libName.}
+      cdecl, importc: "cusparseCgemvi", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cusparseCgemvi_bufferSize*(handle: cusparseHandle_t;
                                  transA: cusparseOperation_t; m: cint; n: cint;
                                  nnz: cint; pBufferSize: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCgemvi_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseCgemvi_bufferSize", dyn.}
   proc cusparseZgemvi*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       m: cint; n: cint; alpha: ptr cuDoubleComplex;
                       A: ptr cuDoubleComplex; lda: cint; nnz: cint;
                       xVal: ptr cuDoubleComplex; xInd: ptr cint;
                       beta: ptr cuDoubleComplex; y: ptr cuDoubleComplex;
                       idxBase: cusparseIndexBase_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZgemvi", dynlib: libName.}
+      cdecl, importc: "cusparseZgemvi", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cusparseZgemvi_bufferSize*(handle: cusparseHandle_t;
                                  transA: cusparseOperation_t; m: cint; n: cint;
                                  nnz: cint; pBufferSize: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZgemvi_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseZgemvi_bufferSize", dyn.}
   ##  Description: Matrix-vector multiplication  y = alpha * op(A) * x  + beta * y, 
   ##    where A is a sparse matrix in CSR storage format, x and y are dense vectors.
   proc cusparseScsrmv*(handle: cusparseHandle_t; transA: cusparseOperation_t;
@@ -466,19 +469,19 @@ when not defined(CUSPARSE_H):
                       descrA: cusparseMatDescr_t; csrSortedValA: ptr cfloat;
                       csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                       x: ptr cfloat; beta: ptr cfloat; y: ptr cfloat): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrmv", dynlib: libName.}
+      cdecl, importc: "cusparseScsrmv", dyn.}
   proc cusparseDcsrmv*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       m: cint; n: cint; nnz: cint; alpha: ptr cdouble;
                       descrA: cusparseMatDescr_t; csrSortedValA: ptr cdouble;
                       csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                       x: ptr cdouble; beta: ptr cdouble; y: ptr cdouble): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrmv", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrmv", dyn.}
   proc cusparseCcsrmv*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       m: cint; n: cint; nnz: cint; alpha: ptr cuComplex;
                       descrA: cusparseMatDescr_t; csrSortedValA: ptr cuComplex;
                       csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                       x: ptr cuComplex; beta: ptr cuComplex; y: ptr cuComplex): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrmv", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrmv", dyn.}
   proc cusparseZcsrmv*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       m: cint; n: cint; nnz: cint; alpha: ptr cuDoubleComplex;
                       descrA: cusparseMatDescr_t;
@@ -486,7 +489,7 @@ when not defined(CUSPARSE_H):
                       csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                       x: ptr cuDoubleComplex; beta: ptr cuDoubleComplex;
                       y: ptr cuDoubleComplex): cusparseStatus_t {.cdecl,
-      importc: "cusparseZcsrmv", dynlib: libName.}
+      importc: "cusparseZcsrmv", dyn.}
   ## Returns number of bytes
   proc cusparseCsrmvEx_bufferSize*(handle: cusparseHandle_t;
                                   alg: cusparseAlgMode_t;
@@ -501,7 +504,7 @@ when not defined(CUSPARSE_H):
                                   ytype: cudaDataType;
                                   executiontype: cudaDataType;
                                   bufferSizeInBytes: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseCsrmvEx_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseCsrmvEx_bufferSize", dyn.}
   proc cusparseCsrmvEx*(handle: cusparseHandle_t; alg: cusparseAlgMode_t;
                        transA: cusparseOperation_t; m: cint; n: cint; nnz: cint;
                        alpha: pointer; alphatype: cudaDataType;
@@ -511,7 +514,7 @@ when not defined(CUSPARSE_H):
                        beta: pointer; betatype: cudaDataType; y: pointer;
                        ytype: cudaDataType; executiontype: cudaDataType;
                        buffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseCsrmvEx", dynlib: libName.}
+      importc: "cusparseCsrmvEx", dyn.}
   ##  Description: Matrix-vector multiplication  y = alpha * op(A) * x  + beta * y, 
   ##    where A is a sparse matrix in CSR storage format, x and y are dense vectors
   ##    using a Merge Path load-balancing implementation.
@@ -520,19 +523,19 @@ when not defined(CUSPARSE_H):
                          descrA: cusparseMatDescr_t; csrSortedValA: ptr cfloat;
                          csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                          x: ptr cfloat; beta: ptr cfloat; y: ptr cfloat): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrmv_mp", dynlib: libName.}
+      cdecl, importc: "cusparseScsrmv_mp", dyn.}
   proc cusparseDcsrmv_mp*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                          m: cint; n: cint; nnz: cint; alpha: ptr cdouble;
                          descrA: cusparseMatDescr_t; csrSortedValA: ptr cdouble;
                          csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                          x: ptr cdouble; beta: ptr cdouble; y: ptr cdouble): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrmv_mp", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrmv_mp", dyn.}
   proc cusparseCcsrmv_mp*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                          m: cint; n: cint; nnz: cint; alpha: ptr cuComplex;
                          descrA: cusparseMatDescr_t; csrSortedValA: ptr cuComplex;
                          csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                          x: ptr cuComplex; beta: ptr cuComplex; y: ptr cuComplex): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrmv_mp", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrmv_mp", dyn.}
   proc cusparseZcsrmv_mp*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                          m: cint; n: cint; nnz: cint; alpha: ptr cuDoubleComplex;
                          descrA: cusparseMatDescr_t;
@@ -540,29 +543,29 @@ when not defined(CUSPARSE_H):
                          csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                          x: ptr cuDoubleComplex; beta: ptr cuDoubleComplex;
                          y: ptr cuDoubleComplex): cusparseStatus_t {.cdecl,
-      importc: "cusparseZcsrmv_mp", dynlib: libName.}
+      importc: "cusparseZcsrmv_mp", dyn.}
   ##  Description: Matrix-vector multiplication  y = alpha * op(A) * x  + beta * y, 
   ##    where A is a sparse matrix in HYB storage format, x and y are dense vectors.
   proc cusparseShybmv*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       alpha: ptr cfloat; descrA: cusparseMatDescr_t;
                       hybA: cusparseHybMat_t; x: ptr cfloat; beta: ptr cfloat;
                       y: ptr cfloat): cusparseStatus_t {.cdecl,
-      importc: "cusparseShybmv", dynlib: libName.}
+      importc: "cusparseShybmv", dyn.}
   proc cusparseDhybmv*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       alpha: ptr cdouble; descrA: cusparseMatDescr_t;
                       hybA: cusparseHybMat_t; x: ptr cdouble; beta: ptr cdouble;
                       y: ptr cdouble): cusparseStatus_t {.cdecl,
-      importc: "cusparseDhybmv", dynlib: libName.}
+      importc: "cusparseDhybmv", dyn.}
   proc cusparseChybmv*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       alpha: ptr cuComplex; descrA: cusparseMatDescr_t;
                       hybA: cusparseHybMat_t; x: ptr cuComplex; beta: ptr cuComplex;
                       y: ptr cuComplex): cusparseStatus_t {.cdecl,
-      importc: "cusparseChybmv", dynlib: libName.}
+      importc: "cusparseChybmv", dyn.}
   proc cusparseZhybmv*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       alpha: ptr cuDoubleComplex; descrA: cusparseMatDescr_t;
                       hybA: cusparseHybMat_t; x: ptr cuDoubleComplex;
                       beta: ptr cuDoubleComplex; y: ptr cuDoubleComplex): cusparseStatus_t {.
-      cdecl, importc: "cusparseZhybmv", dynlib: libName.}
+      cdecl, importc: "cusparseZhybmv", dyn.}
   ##  Description: Matrix-vector multiplication  y = alpha * op(A) * x  + beta * y, 
   ##    where A is a sparse matrix in BSR storage format, x and y are dense vectors.
   proc cusparseSbsrmv*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
@@ -571,21 +574,21 @@ when not defined(CUSPARSE_H):
                       bsrSortedValA: ptr cfloat; bsrSortedRowPtrA: ptr cint;
                       bsrSortedColIndA: ptr cint; blockDim: cint; x: ptr cfloat;
                       beta: ptr cfloat; y: ptr cfloat): cusparseStatus_t {.cdecl,
-      importc: "cusparseSbsrmv", dynlib: libName.}
+      importc: "cusparseSbsrmv", dyn.}
   proc cusparseDbsrmv*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                       transA: cusparseOperation_t; mb: cint; nb: cint; nnzb: cint;
                       alpha: ptr cdouble; descrA: cusparseMatDescr_t;
                       bsrSortedValA: ptr cdouble; bsrSortedRowPtrA: ptr cint;
                       bsrSortedColIndA: ptr cint; blockDim: cint; x: ptr cdouble;
                       beta: ptr cdouble; y: ptr cdouble): cusparseStatus_t {.cdecl,
-      importc: "cusparseDbsrmv", dynlib: libName.}
+      importc: "cusparseDbsrmv", dyn.}
   proc cusparseCbsrmv*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                       transA: cusparseOperation_t; mb: cint; nb: cint; nnzb: cint;
                       alpha: ptr cuComplex; descrA: cusparseMatDescr_t;
                       bsrSortedValA: ptr cuComplex; bsrSortedRowPtrA: ptr cint;
                       bsrSortedColIndA: ptr cint; blockDim: cint; x: ptr cuComplex;
                       beta: ptr cuComplex; y: ptr cuComplex): cusparseStatus_t {.cdecl,
-      importc: "cusparseCbsrmv", dynlib: libName.}
+      importc: "cusparseCbsrmv", dyn.}
   proc cusparseZbsrmv*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                       transA: cusparseOperation_t; mb: cint; nb: cint; nnzb: cint;
                       alpha: ptr cuDoubleComplex; descrA: cusparseMatDescr_t;
@@ -593,7 +596,7 @@ when not defined(CUSPARSE_H):
                       bsrSortedRowPtrA: ptr cint; bsrSortedColIndA: ptr cint;
                       blockDim: cint; x: ptr cuDoubleComplex;
                       beta: ptr cuDoubleComplex; y: ptr cuDoubleComplex): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsrmv", dynlib: libName.}
+      cdecl, importc: "cusparseZbsrmv", dyn.}
   ##  Description: Matrix-vector multiplication  y = alpha * op(A) * x  + beta * y, 
   ##    where A is a sparse matrix in extended BSR storage format, x and y are dense 
   ##    vectors.
@@ -604,7 +607,7 @@ when not defined(CUSPARSE_H):
                        bsrSortedMaskPtrA: ptr cint; bsrSortedRowPtrA: ptr cint;
                        bsrSortedEndPtrA: ptr cint; bsrSortedColIndA: ptr cint;
                        blockDim: cint; x: ptr cfloat; beta: ptr cfloat; y: ptr cfloat): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsrxmv", dynlib: libName.}
+      cdecl, importc: "cusparseSbsrxmv", dyn.}
   proc cusparseDbsrxmv*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                        transA: cusparseOperation_t; sizeOfMask: cint; mb: cint;
                        nb: cint; nnzb: cint; alpha: ptr cdouble;
@@ -612,7 +615,7 @@ when not defined(CUSPARSE_H):
                        bsrSortedMaskPtrA: ptr cint; bsrSortedRowPtrA: ptr cint;
                        bsrSortedEndPtrA: ptr cint; bsrSortedColIndA: ptr cint;
                        blockDim: cint; x: ptr cdouble; beta: ptr cdouble; y: ptr cdouble): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsrxmv", dynlib: libName.}
+      cdecl, importc: "cusparseDbsrxmv", dyn.}
   proc cusparseCbsrxmv*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                        transA: cusparseOperation_t; sizeOfMask: cint; mb: cint;
                        nb: cint; nnzb: cint; alpha: ptr cuComplex;
@@ -621,7 +624,7 @@ when not defined(CUSPARSE_H):
                        bsrSortedEndPtrA: ptr cint; bsrSortedColIndA: ptr cint;
                        blockDim: cint; x: ptr cuComplex; beta: ptr cuComplex;
                        y: ptr cuComplex): cusparseStatus_t {.cdecl,
-      importc: "cusparseCbsrxmv", dynlib: libName.}
+      importc: "cusparseCbsrxmv", dyn.}
   proc cusparseZbsrxmv*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                        transA: cusparseOperation_t; sizeOfMask: cint; mb: cint;
                        nb: cint; nnzb: cint; alpha: ptr cuDoubleComplex;
@@ -631,7 +634,7 @@ when not defined(CUSPARSE_H):
                        bsrSortedEndPtrA: ptr cint; bsrSortedColIndA: ptr cint;
                        blockDim: cint; x: ptr cuDoubleComplex;
                        beta: ptr cuDoubleComplex; y: ptr cuDoubleComplex): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsrxmv", dynlib: libName.}
+      cdecl, importc: "cusparseZbsrxmv", dyn.}
   ##  Description: Solution of triangular linear system op(A) * x = alpha * f, 
   ##    where A is a sparse matrix in CSR storage format, rhs f and solution x 
   ##    are dense vectors. This routine implements algorithm 1 for the solve.
@@ -644,7 +647,7 @@ when not defined(CUSPARSE_H):
                                 csrSortedColIndA: ptr cint;
                                 info: cusparseSolveAnalysisInfo_t;
                                 executiontype: cudaDataType): cusparseStatus_t {.
-      cdecl, importc: "cusparseCsrsv_analysisEx", dynlib: libName.}
+      cdecl, importc: "cusparseCsrsv_analysisEx", dyn.}
   proc cusparseScsrsv_analysis*(handle: cusparseHandle_t;
                                transA: cusparseOperation_t; m: cint; nnz: cint;
                                descrA: cusparseMatDescr_t;
@@ -652,7 +655,7 @@ when not defined(CUSPARSE_H):
                                csrSortedRowPtrA: ptr cint;
                                csrSortedColIndA: ptr cint;
                                info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrsv_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseScsrsv_analysis", dyn.}
   proc cusparseDcsrsv_analysis*(handle: cusparseHandle_t;
                                transA: cusparseOperation_t; m: cint; nnz: cint;
                                descrA: cusparseMatDescr_t;
@@ -660,7 +663,7 @@ when not defined(CUSPARSE_H):
                                csrSortedRowPtrA: ptr cint;
                                csrSortedColIndA: ptr cint;
                                info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrsv_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrsv_analysis", dyn.}
   proc cusparseCcsrsv_analysis*(handle: cusparseHandle_t;
                                transA: cusparseOperation_t; m: cint; nnz: cint;
                                descrA: cusparseMatDescr_t;
@@ -668,7 +671,7 @@ when not defined(CUSPARSE_H):
                                csrSortedRowPtrA: ptr cint;
                                csrSortedColIndA: ptr cint;
                                info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrsv_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrsv_analysis", dyn.}
   proc cusparseZcsrsv_analysis*(handle: cusparseHandle_t;
                                transA: cusparseOperation_t; m: cint; nnz: cint;
                                descrA: cusparseMatDescr_t;
@@ -676,7 +679,7 @@ when not defined(CUSPARSE_H):
                                csrSortedRowPtrA: ptr cint;
                                csrSortedColIndA: ptr cint;
                                info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrsv_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrsv_analysis", dyn.}
   proc cusparseCsrsv_solveEx*(handle: cusparseHandle_t;
                              transA: cusparseOperation_t; m: cint; alpha: pointer;
                              alphatype: cudaDataType; descrA: cusparseMatDescr_t;
@@ -687,21 +690,21 @@ when not defined(CUSPARSE_H):
                              info: cusparseSolveAnalysisInfo_t; f: pointer;
                              ftype: cudaDataType; x: pointer; xtype: cudaDataType;
                              executiontype: cudaDataType): cusparseStatus_t {.
-      cdecl, importc: "cusparseCsrsv_solveEx", dynlib: libName.}
+      cdecl, importc: "cusparseCsrsv_solveEx", dyn.}
   proc cusparseScsrsv_solve*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                             m: cint; alpha: ptr cfloat; descrA: cusparseMatDescr_t;
                             csrSortedValA: ptr cfloat; csrSortedRowPtrA: ptr cint;
                             csrSortedColIndA: ptr cint;
                             info: cusparseSolveAnalysisInfo_t; f: ptr cfloat;
                             x: ptr cfloat): cusparseStatus_t {.cdecl,
-      importc: "cusparseScsrsv_solve", dynlib: libName.}
+      importc: "cusparseScsrsv_solve", dyn.}
   proc cusparseDcsrsv_solve*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                             m: cint; alpha: ptr cdouble; descrA: cusparseMatDescr_t;
                             csrSortedValA: ptr cdouble; csrSortedRowPtrA: ptr cint;
                             csrSortedColIndA: ptr cint;
                             info: cusparseSolveAnalysisInfo_t; f: ptr cdouble;
                             x: ptr cdouble): cusparseStatus_t {.cdecl,
-      importc: "cusparseDcsrsv_solve", dynlib: libName.}
+      importc: "cusparseDcsrsv_solve", dyn.}
   proc cusparseCcsrsv_solve*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                             m: cint; alpha: ptr cuComplex;
                             descrA: cusparseMatDescr_t;
@@ -709,7 +712,7 @@ when not defined(CUSPARSE_H):
                             csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                             info: cusparseSolveAnalysisInfo_t; f: ptr cuComplex;
                             x: ptr cuComplex): cusparseStatus_t {.cdecl,
-      importc: "cusparseCcsrsv_solve", dynlib: libName.}
+      importc: "cusparseCcsrsv_solve", dyn.}
   proc cusparseZcsrsv_solve*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                             m: cint; alpha: ptr cuDoubleComplex;
                             descrA: cusparseMatDescr_t;
@@ -717,14 +720,14 @@ when not defined(CUSPARSE_H):
                             csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                             info: cusparseSolveAnalysisInfo_t;
                             f: ptr cuDoubleComplex; x: ptr cuDoubleComplex): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrsv_solve", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrsv_solve", dyn.}
   ##  Description: Solution of triangular linear system op(A) * x = alpha * f, 
   ##    where A is a sparse matrix in CSR storage format, rhs f and solution y 
   ##    are dense vectors. This routine implements algorithm 1 for this problem. 
   ##    Also, it provides a utility function to query size of buffer used.
   proc cusparseXcsrsv2_zeroPivot*(handle: cusparseHandle_t; info: csrsv2Info_t;
                                  position: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseXcsrsv2_zeroPivot", dynlib: libName.}
+      importc: "cusparseXcsrsv2_zeroPivot", dyn.}
   proc cusparseScsrsv2_bufferSize*(handle: cusparseHandle_t;
                                   transA: cusparseOperation_t; m: cint; nnz: cint;
                                   descrA: cusparseMatDescr_t;
@@ -732,7 +735,7 @@ when not defined(CUSPARSE_H):
                                   csrSortedRowPtrA: ptr cint;
                                   csrSortedColIndA: ptr cint; info: csrsv2Info_t;
                                   pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrsv2_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseScsrsv2_bufferSize", dyn.}
   proc cusparseDcsrsv2_bufferSize*(handle: cusparseHandle_t;
                                   transA: cusparseOperation_t; m: cint; nnz: cint;
                                   descrA: cusparseMatDescr_t;
@@ -740,7 +743,7 @@ when not defined(CUSPARSE_H):
                                   csrSortedRowPtrA: ptr cint;
                                   csrSortedColIndA: ptr cint; info: csrsv2Info_t;
                                   pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrsv2_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrsv2_bufferSize", dyn.}
   proc cusparseCcsrsv2_bufferSize*(handle: cusparseHandle_t;
                                   transA: cusparseOperation_t; m: cint; nnz: cint;
                                   descrA: cusparseMatDescr_t;
@@ -748,7 +751,7 @@ when not defined(CUSPARSE_H):
                                   csrSortedRowPtrA: ptr cint;
                                   csrSortedColIndA: ptr cint; info: csrsv2Info_t;
                                   pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrsv2_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrsv2_bufferSize", dyn.}
   proc cusparseZcsrsv2_bufferSize*(handle: cusparseHandle_t;
                                   transA: cusparseOperation_t; m: cint; nnz: cint;
                                   descrA: cusparseMatDescr_t;
@@ -756,7 +759,7 @@ when not defined(CUSPARSE_H):
                                   csrSortedRowPtrA: ptr cint;
                                   csrSortedColIndA: ptr cint; info: csrsv2Info_t;
                                   pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrsv2_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrsv2_bufferSize", dyn.}
   proc cusparseScsrsv2_bufferSizeExt*(handle: cusparseHandle_t;
                                      transA: cusparseOperation_t; m: cint;
                                      nnz: cint; descrA: cusparseMatDescr_t;
@@ -764,7 +767,7 @@ when not defined(CUSPARSE_H):
                                      csrSortedRowPtrA: ptr cint;
                                      csrSortedColIndA: ptr cint;
                                      info: csrsv2Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrsv2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseScsrsv2_bufferSizeExt", dyn.}
   proc cusparseDcsrsv2_bufferSizeExt*(handle: cusparseHandle_t;
                                      transA: cusparseOperation_t; m: cint;
                                      nnz: cint; descrA: cusparseMatDescr_t;
@@ -772,7 +775,7 @@ when not defined(CUSPARSE_H):
                                      csrSortedRowPtrA: ptr cint;
                                      csrSortedColIndA: ptr cint;
                                      info: csrsv2Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrsv2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrsv2_bufferSizeExt", dyn.}
   proc cusparseCcsrsv2_bufferSizeExt*(handle: cusparseHandle_t;
                                      transA: cusparseOperation_t; m: cint;
                                      nnz: cint; descrA: cusparseMatDescr_t;
@@ -780,7 +783,7 @@ when not defined(CUSPARSE_H):
                                      csrSortedRowPtrA: ptr cint;
                                      csrSortedColIndA: ptr cint;
                                      info: csrsv2Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrsv2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrsv2_bufferSizeExt", dyn.}
   proc cusparseZcsrsv2_bufferSizeExt*(handle: cusparseHandle_t;
                                      transA: cusparseOperation_t; m: cint;
                                      nnz: cint; descrA: cusparseMatDescr_t;
@@ -788,7 +791,7 @@ when not defined(CUSPARSE_H):
                                      csrSortedRowPtrA: ptr cint;
                                      csrSortedColIndA: ptr cint;
                                      info: csrsv2Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrsv2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrsv2_bufferSizeExt", dyn.}
   proc cusparseScsrsv2_analysis*(handle: cusparseHandle_t;
                                 transA: cusparseOperation_t; m: cint; nnz: cint;
                                 descrA: cusparseMatDescr_t;
@@ -796,7 +799,7 @@ when not defined(CUSPARSE_H):
                                 csrSortedRowPtrA: ptr cint;
                                 csrSortedColIndA: ptr cint; info: csrsv2Info_t;
                                 policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrsv2_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseScsrsv2_analysis", dyn.}
   proc cusparseDcsrsv2_analysis*(handle: cusparseHandle_t;
                                 transA: cusparseOperation_t; m: cint; nnz: cint;
                                 descrA: cusparseMatDescr_t;
@@ -804,7 +807,7 @@ when not defined(CUSPARSE_H):
                                 csrSortedRowPtrA: ptr cint;
                                 csrSortedColIndA: ptr cint; info: csrsv2Info_t;
                                 policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrsv2_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrsv2_analysis", dyn.}
   proc cusparseCcsrsv2_analysis*(handle: cusparseHandle_t;
                                 transA: cusparseOperation_t; m: cint; nnz: cint;
                                 descrA: cusparseMatDescr_t;
@@ -812,7 +815,7 @@ when not defined(CUSPARSE_H):
                                 csrSortedRowPtrA: ptr cint;
                                 csrSortedColIndA: ptr cint; info: csrsv2Info_t;
                                 policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrsv2_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrsv2_analysis", dyn.}
   proc cusparseZcsrsv2_analysis*(handle: cusparseHandle_t;
                                 transA: cusparseOperation_t; m: cint; nnz: cint;
                                 descrA: cusparseMatDescr_t;
@@ -820,7 +823,7 @@ when not defined(CUSPARSE_H):
                                 csrSortedRowPtrA: ptr cint;
                                 csrSortedColIndA: ptr cint; info: csrsv2Info_t;
                                 policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrsv2_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrsv2_analysis", dyn.}
   proc cusparseScsrsv2_solve*(handle: cusparseHandle_t;
                              transA: cusparseOperation_t; m: cint; nnz: cint;
                              alpha: ptr cfloat; descrA: cusparseMatDescr_t;
@@ -828,7 +831,7 @@ when not defined(CUSPARSE_H):
                              csrSortedColIndA: ptr cint; info: csrsv2Info_t;
                              f: ptr cfloat; x: ptr cfloat;
                              policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrsv2_solve", dynlib: libName.}
+      cdecl, importc: "cusparseScsrsv2_solve", dyn.}
   proc cusparseDcsrsv2_solve*(handle: cusparseHandle_t;
                              transA: cusparseOperation_t; m: cint; nnz: cint;
                              alpha: ptr cdouble; descrA: cusparseMatDescr_t;
@@ -837,7 +840,7 @@ when not defined(CUSPARSE_H):
                              csrSortedColIndA: ptr cint; info: csrsv2Info_t;
                              f: ptr cdouble; x: ptr cdouble;
                              policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrsv2_solve", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrsv2_solve", dyn.}
   proc cusparseCcsrsv2_solve*(handle: cusparseHandle_t;
                              transA: cusparseOperation_t; m: cint; nnz: cint;
                              alpha: ptr cuComplex; descrA: cusparseMatDescr_t;
@@ -846,7 +849,7 @@ when not defined(CUSPARSE_H):
                              csrSortedColIndA: ptr cint; info: csrsv2Info_t;
                              f: ptr cuComplex; x: ptr cuComplex;
                              policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrsv2_solve", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrsv2_solve", dyn.}
   proc cusparseZcsrsv2_solve*(handle: cusparseHandle_t;
                              transA: cusparseOperation_t; m: cint; nnz: cint;
                              alpha: ptr cuDoubleComplex;
@@ -856,14 +859,14 @@ when not defined(CUSPARSE_H):
                              csrSortedColIndA: ptr cint; info: csrsv2Info_t;
                              f: ptr cuDoubleComplex; x: ptr cuDoubleComplex;
                              policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrsv2_solve", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrsv2_solve", dyn.}
   ##  Description: Solution of triangular linear system op(A) * x = alpha * f, 
   ##    where A is a sparse matrix in block-CSR storage format, rhs f and solution y 
   ##    are dense vectors. This routine implements algorithm 2 for this problem. 
   ##    Also, it provides a utility function to query size of buffer used.
   proc cusparseXbsrsv2_zeroPivot*(handle: cusparseHandle_t; info: bsrsv2Info_t;
                                  position: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseXbsrsv2_zeroPivot", dynlib: libName.}
+      importc: "cusparseXbsrsv2_zeroPivot", dyn.}
   proc cusparseSbsrsv2_bufferSize*(handle: cusparseHandle_t;
                                   dirA: cusparseDirection_t;
                                   transA: cusparseOperation_t; mb: cint; nnzb: cint;
@@ -872,7 +875,7 @@ when not defined(CUSPARSE_H):
                                   bsrSortedRowPtrA: ptr cint;
                                   bsrSortedColIndA: ptr cint; blockDim: cint;
                                   info: bsrsv2Info_t; pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsrsv2_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseSbsrsv2_bufferSize", dyn.}
   proc cusparseDbsrsv2_bufferSize*(handle: cusparseHandle_t;
                                   dirA: cusparseDirection_t;
                                   transA: cusparseOperation_t; mb: cint; nnzb: cint;
@@ -881,7 +884,7 @@ when not defined(CUSPARSE_H):
                                   bsrSortedRowPtrA: ptr cint;
                                   bsrSortedColIndA: ptr cint; blockDim: cint;
                                   info: bsrsv2Info_t; pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsrsv2_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseDbsrsv2_bufferSize", dyn.}
   proc cusparseCbsrsv2_bufferSize*(handle: cusparseHandle_t;
                                   dirA: cusparseDirection_t;
                                   transA: cusparseOperation_t; mb: cint; nnzb: cint;
@@ -890,7 +893,7 @@ when not defined(CUSPARSE_H):
                                   bsrSortedRowPtrA: ptr cint;
                                   bsrSortedColIndA: ptr cint; blockDim: cint;
                                   info: bsrsv2Info_t; pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsrsv2_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseCbsrsv2_bufferSize", dyn.}
   proc cusparseZbsrsv2_bufferSize*(handle: cusparseHandle_t;
                                   dirA: cusparseDirection_t;
                                   transA: cusparseOperation_t; mb: cint; nnzb: cint;
@@ -899,7 +902,7 @@ when not defined(CUSPARSE_H):
                                   bsrSortedRowPtrA: ptr cint;
                                   bsrSortedColIndA: ptr cint; blockDim: cint;
                                   info: bsrsv2Info_t; pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsrsv2_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseZbsrsv2_bufferSize", dyn.}
   proc cusparseSbsrsv2_bufferSizeExt*(handle: cusparseHandle_t;
                                      dirA: cusparseDirection_t;
                                      transA: cusparseOperation_t; mb: cint;
@@ -908,7 +911,7 @@ when not defined(CUSPARSE_H):
                                      bsrSortedRowPtrA: ptr cint;
                                      bsrSortedColIndA: ptr cint; blockSize: cint;
                                      info: bsrsv2Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsrsv2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseSbsrsv2_bufferSizeExt", dyn.}
   proc cusparseDbsrsv2_bufferSizeExt*(handle: cusparseHandle_t;
                                      dirA: cusparseDirection_t;
                                      transA: cusparseOperation_t; mb: cint;
@@ -917,7 +920,7 @@ when not defined(CUSPARSE_H):
                                      bsrSortedRowPtrA: ptr cint;
                                      bsrSortedColIndA: ptr cint; blockSize: cint;
                                      info: bsrsv2Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsrsv2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseDbsrsv2_bufferSizeExt", dyn.}
   proc cusparseCbsrsv2_bufferSizeExt*(handle: cusparseHandle_t;
                                      dirA: cusparseDirection_t;
                                      transA: cusparseOperation_t; mb: cint;
@@ -926,7 +929,7 @@ when not defined(CUSPARSE_H):
                                      bsrSortedRowPtrA: ptr cint;
                                      bsrSortedColIndA: ptr cint; blockSize: cint;
                                      info: bsrsv2Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsrsv2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseCbsrsv2_bufferSizeExt", dyn.}
   proc cusparseZbsrsv2_bufferSizeExt*(handle: cusparseHandle_t;
                                      dirA: cusparseDirection_t;
                                      transA: cusparseOperation_t; mb: cint;
@@ -935,7 +938,7 @@ when not defined(CUSPARSE_H):
                                      bsrSortedRowPtrA: ptr cint;
                                      bsrSortedColIndA: ptr cint; blockSize: cint;
                                      info: bsrsv2Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsrsv2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseZbsrsv2_bufferSizeExt", dyn.}
   proc cusparseSbsrsv2_analysis*(handle: cusparseHandle_t;
                                 dirA: cusparseDirection_t;
                                 transA: cusparseOperation_t; mb: cint; nnzb: cint;
@@ -945,7 +948,7 @@ when not defined(CUSPARSE_H):
                                 bsrSortedColIndA: ptr cint; blockDim: cint;
                                 info: bsrsv2Info_t; policy: cusparseSolvePolicy_t;
                                 pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseSbsrsv2_analysis", dynlib: libName.}
+      importc: "cusparseSbsrsv2_analysis", dyn.}
   proc cusparseDbsrsv2_analysis*(handle: cusparseHandle_t;
                                 dirA: cusparseDirection_t;
                                 transA: cusparseOperation_t; mb: cint; nnzb: cint;
@@ -955,7 +958,7 @@ when not defined(CUSPARSE_H):
                                 bsrSortedColIndA: ptr cint; blockDim: cint;
                                 info: bsrsv2Info_t; policy: cusparseSolvePolicy_t;
                                 pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseDbsrsv2_analysis", dynlib: libName.}
+      importc: "cusparseDbsrsv2_analysis", dyn.}
   proc cusparseCbsrsv2_analysis*(handle: cusparseHandle_t;
                                 dirA: cusparseDirection_t;
                                 transA: cusparseOperation_t; mb: cint; nnzb: cint;
@@ -965,7 +968,7 @@ when not defined(CUSPARSE_H):
                                 bsrSortedColIndA: ptr cint; blockDim: cint;
                                 info: bsrsv2Info_t; policy: cusparseSolvePolicy_t;
                                 pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseCbsrsv2_analysis", dynlib: libName.}
+      importc: "cusparseCbsrsv2_analysis", dyn.}
   proc cusparseZbsrsv2_analysis*(handle: cusparseHandle_t;
                                 dirA: cusparseDirection_t;
                                 transA: cusparseOperation_t; mb: cint; nnzb: cint;
@@ -975,7 +978,7 @@ when not defined(CUSPARSE_H):
                                 bsrSortedColIndA: ptr cint; blockDim: cint;
                                 info: bsrsv2Info_t; policy: cusparseSolvePolicy_t;
                                 pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseZbsrsv2_analysis", dynlib: libName.}
+      importc: "cusparseZbsrsv2_analysis", dyn.}
   proc cusparseSbsrsv2_solve*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                              transA: cusparseOperation_t; mb: cint; nnzb: cint;
                              alpha: ptr cfloat; descrA: cusparseMatDescr_t;
@@ -983,7 +986,7 @@ when not defined(CUSPARSE_H):
                              bsrSortedColIndA: ptr cint; blockDim: cint;
                              info: bsrsv2Info_t; f: ptr cfloat; x: ptr cfloat;
                              policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsrsv2_solve", dynlib: libName.}
+      cdecl, importc: "cusparseSbsrsv2_solve", dyn.}
   proc cusparseDbsrsv2_solve*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                              transA: cusparseOperation_t; mb: cint; nnzb: cint;
                              alpha: ptr cdouble; descrA: cusparseMatDescr_t;
@@ -992,7 +995,7 @@ when not defined(CUSPARSE_H):
                              bsrSortedColIndA: ptr cint; blockDim: cint;
                              info: bsrsv2Info_t; f: ptr cdouble; x: ptr cdouble;
                              policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsrsv2_solve", dynlib: libName.}
+      cdecl, importc: "cusparseDbsrsv2_solve", dyn.}
   proc cusparseCbsrsv2_solve*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                              transA: cusparseOperation_t; mb: cint; nnzb: cint;
                              alpha: ptr cuComplex; descrA: cusparseMatDescr_t;
@@ -1001,7 +1004,7 @@ when not defined(CUSPARSE_H):
                              bsrSortedColIndA: ptr cint; blockDim: cint;
                              info: bsrsv2Info_t; f: ptr cuComplex; x: ptr cuComplex;
                              policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsrsv2_solve", dynlib: libName.}
+      cdecl, importc: "cusparseCbsrsv2_solve", dyn.}
   proc cusparseZbsrsv2_solve*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                              transA: cusparseOperation_t; mb: cint; nnzb: cint;
                              alpha: ptr cuDoubleComplex;
@@ -1012,7 +1015,7 @@ when not defined(CUSPARSE_H):
                              info: bsrsv2Info_t; f: ptr cuDoubleComplex;
                              x: ptr cuDoubleComplex; policy: cusparseSolvePolicy_t;
                              pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseZbsrsv2_solve", dynlib: libName.}
+      importc: "cusparseZbsrsv2_solve", dyn.}
   ##  Description: Solution of triangular linear system op(A) * x = alpha * f, 
   ##    where A is a sparse matrix in HYB storage format, rhs f and solution x 
   ##    are dense vectors.
@@ -1020,46 +1023,46 @@ when not defined(CUSPARSE_H):
                                transA: cusparseOperation_t;
                                descrA: cusparseMatDescr_t; hybA: cusparseHybMat_t;
                                info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseShybsv_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseShybsv_analysis", dyn.}
   proc cusparseDhybsv_analysis*(handle: cusparseHandle_t;
                                transA: cusparseOperation_t;
                                descrA: cusparseMatDescr_t; hybA: cusparseHybMat_t;
                                info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDhybsv_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseDhybsv_analysis", dyn.}
   proc cusparseChybsv_analysis*(handle: cusparseHandle_t;
                                transA: cusparseOperation_t;
                                descrA: cusparseMatDescr_t; hybA: cusparseHybMat_t;
                                info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseChybsv_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseChybsv_analysis", dyn.}
   proc cusparseZhybsv_analysis*(handle: cusparseHandle_t;
                                transA: cusparseOperation_t;
                                descrA: cusparseMatDescr_t; hybA: cusparseHybMat_t;
                                info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseZhybsv_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseZhybsv_analysis", dyn.}
   proc cusparseShybsv_solve*(handle: cusparseHandle_t; trans: cusparseOperation_t;
                             alpha: ptr cfloat; descra: cusparseMatDescr_t;
                             hybA: cusparseHybMat_t;
                             info: cusparseSolveAnalysisInfo_t; f: ptr cfloat;
                             x: ptr cfloat): cusparseStatus_t {.cdecl,
-      importc: "cusparseShybsv_solve", dynlib: libName.}
+      importc: "cusparseShybsv_solve", dyn.}
   proc cusparseChybsv_solve*(handle: cusparseHandle_t; trans: cusparseOperation_t;
                             alpha: ptr cuComplex; descra: cusparseMatDescr_t;
                             hybA: cusparseHybMat_t;
                             info: cusparseSolveAnalysisInfo_t; f: ptr cuComplex;
                             x: ptr cuComplex): cusparseStatus_t {.cdecl,
-      importc: "cusparseChybsv_solve", dynlib: libName.}
+      importc: "cusparseChybsv_solve", dyn.}
   proc cusparseDhybsv_solve*(handle: cusparseHandle_t; trans: cusparseOperation_t;
                             alpha: ptr cdouble; descra: cusparseMatDescr_t;
                             hybA: cusparseHybMat_t;
                             info: cusparseSolveAnalysisInfo_t; f: ptr cdouble;
                             x: ptr cdouble): cusparseStatus_t {.cdecl,
-      importc: "cusparseDhybsv_solve", dynlib: libName.}
+      importc: "cusparseDhybsv_solve", dyn.}
   proc cusparseZhybsv_solve*(handle: cusparseHandle_t; trans: cusparseOperation_t;
                             alpha: ptr cuDoubleComplex; descra: cusparseMatDescr_t;
                             hybA: cusparseHybMat_t;
                             info: cusparseSolveAnalysisInfo_t;
                             f: ptr cuDoubleComplex; x: ptr cuDoubleComplex): cusparseStatus_t {.
-      cdecl, importc: "cusparseZhybsv_solve", dynlib: libName.}
+      cdecl, importc: "cusparseZhybsv_solve", dyn.}
   ##  --- Sparse Level 3 routines ---
   ##  Description: sparse - dense matrix multiplication C = alpha * op(A) * B  + beta * C, 
   ##    where A is a sparse matrix in CSR format, B and C are dense tall matrices.
@@ -1068,21 +1071,21 @@ when not defined(CUSPARSE_H):
                       descrA: cusparseMatDescr_t; csrSortedValA: ptr cfloat;
                       csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                       B: ptr cfloat; ldb: cint; beta: ptr cfloat; C: ptr cfloat; ldc: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrmm", dynlib: libName.}
+      cdecl, importc: "cusparseScsrmm", dyn.}
   proc cusparseDcsrmm*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       m: cint; n: cint; k: cint; nnz: cint; alpha: ptr cdouble;
                       descrA: cusparseMatDescr_t; csrSortedValA: ptr cdouble;
                       csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                       B: ptr cdouble; ldb: cint; beta: ptr cdouble; C: ptr cdouble;
                       ldc: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseDcsrmm", dynlib: libName.}
+      importc: "cusparseDcsrmm", dyn.}
   proc cusparseCcsrmm*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       m: cint; n: cint; k: cint; nnz: cint; alpha: ptr cuComplex;
                       descrA: cusparseMatDescr_t; csrSortedValA: ptr cuComplex;
                       csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                       B: ptr cuComplex; ldb: cint; beta: ptr cuComplex;
                       C: ptr cuComplex; ldc: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseCcsrmm", dynlib: libName.}
+      importc: "cusparseCcsrmm", dyn.}
   proc cusparseZcsrmm*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                       m: cint; n: cint; k: cint; nnz: cint; alpha: ptr cuDoubleComplex;
                       descrA: cusparseMatDescr_t;
@@ -1090,7 +1093,7 @@ when not defined(CUSPARSE_H):
                       csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                       B: ptr cuDoubleComplex; ldb: cint; beta: ptr cuDoubleComplex;
                       C: ptr cuDoubleComplex; ldc: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseZcsrmm", dynlib: libName.}
+      importc: "cusparseZcsrmm", dyn.}
   ##  Description: sparse - dense matrix multiplication C = alpha * op(A) * B  + beta * C, 
   ##    where A is a sparse matrix in CSR format, B and C are dense tall matrices.
   ##    This routine allows transposition of matrix B, which may improve performance.
@@ -1100,21 +1103,21 @@ when not defined(CUSPARSE_H):
                        csrSortedValA: ptr cfloat; csrSortedRowPtrA: ptr cint;
                        csrSortedColIndA: ptr cint; B: ptr cfloat; ldb: cint;
                        beta: ptr cfloat; C: ptr cfloat; ldc: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrmm2", dynlib: libName.}
+      cdecl, importc: "cusparseScsrmm2", dyn.}
   proc cusparseDcsrmm2*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                        transB: cusparseOperation_t; m: cint; n: cint; k: cint;
                        nnz: cint; alpha: ptr cdouble; descrA: cusparseMatDescr_t;
                        csrSortedValA: ptr cdouble; csrSortedRowPtrA: ptr cint;
                        csrSortedColIndA: ptr cint; B: ptr cdouble; ldb: cint;
                        beta: ptr cdouble; C: ptr cdouble; ldc: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrmm2", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrmm2", dyn.}
   proc cusparseCcsrmm2*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                        transB: cusparseOperation_t; m: cint; n: cint; k: cint;
                        nnz: cint; alpha: ptr cuComplex; descrA: cusparseMatDescr_t;
                        csrSortedValA: ptr cuComplex; csrSortedRowPtrA: ptr cint;
                        csrSortedColIndA: ptr cint; B: ptr cuComplex; ldb: cint;
                        beta: ptr cuComplex; C: ptr cuComplex; ldc: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrmm2", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrmm2", dyn.}
   proc cusparseZcsrmm2*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                        transB: cusparseOperation_t; m: cint; n: cint; k: cint;
                        nnz: cint; alpha: ptr cuDoubleComplex;
@@ -1123,7 +1126,7 @@ when not defined(CUSPARSE_H):
                        csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                        B: ptr cuDoubleComplex; ldb: cint; beta: ptr cuDoubleComplex;
                        C: ptr cuDoubleComplex; ldc: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseZcsrmm2", dynlib: libName.}
+      importc: "cusparseZcsrmm2", dyn.}
   ##  Description: sparse - dense matrix multiplication C = alpha * op(A) * B  + beta * C, 
   ##    where A is a sparse matrix in block-CSR format, B and C are dense tall matrices.
   ##    This routine allows transposition of matrix B, which may improve performance.
@@ -1134,7 +1137,7 @@ when not defined(CUSPARSE_H):
                       bsrSortedRowPtrA: ptr cint; bsrSortedColIndA: ptr cint;
                       blockSize: cint; B: ptr cfloat; ldb: cint; beta: ptr cfloat;
                       C: ptr cfloat; ldc: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseSbsrmm", dynlib: libName.}
+      importc: "cusparseSbsrmm", dyn.}
   proc cusparseDbsrmm*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                       transA: cusparseOperation_t; transB: cusparseOperation_t;
                       mb: cint; n: cint; kb: cint; nnzb: cint; alpha: ptr cdouble;
@@ -1142,7 +1145,7 @@ when not defined(CUSPARSE_H):
                       bsrSortedRowPtrA: ptr cint; bsrSortedColIndA: ptr cint;
                       blockSize: cint; B: ptr cdouble; ldb: cint; beta: ptr cdouble;
                       C: ptr cdouble; ldc: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseDbsrmm", dynlib: libName.}
+      importc: "cusparseDbsrmm", dyn.}
   proc cusparseCbsrmm*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                       transA: cusparseOperation_t; transB: cusparseOperation_t;
                       mb: cint; n: cint; kb: cint; nnzb: cint; alpha: ptr cuComplex;
@@ -1150,7 +1153,7 @@ when not defined(CUSPARSE_H):
                       bsrSortedRowPtrA: ptr cint; bsrSortedColIndA: ptr cint;
                       blockSize: cint; B: ptr cuComplex; ldb: cint;
                       beta: ptr cuComplex; C: ptr cuComplex; ldc: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsrmm", dynlib: libName.}
+      cdecl, importc: "cusparseCbsrmm", dyn.}
   proc cusparseZbsrmm*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                       transA: cusparseOperation_t; transB: cusparseOperation_t;
                       mb: cint; n: cint; kb: cint; nnzb: cint;
@@ -1159,7 +1162,7 @@ when not defined(CUSPARSE_H):
                       bsrSortedRowPtrA: ptr cint; bsrSortedColIndA: ptr cint;
                       blockSize: cint; B: ptr cuDoubleComplex; ldb: cint;
                       beta: ptr cuDoubleComplex; C: ptr cuDoubleComplex; ldc: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsrmm", dynlib: libName.}
+      cdecl, importc: "cusparseZbsrmm", dyn.}
   ##  Description: dense - sparse matrix multiplication C = alpha * A * B  + beta * C, 
   ##    where A is column-major dense matrix, B is a sparse matrix in CSC format, 
   ##    and C is column-major dense matrix.
@@ -1167,14 +1170,14 @@ when not defined(CUSPARSE_H):
                       alpha: ptr cfloat; A: ptr cfloat; lda: cint; cscValB: ptr cfloat;
                       cscColPtrB: ptr cint; cscRowIndB: ptr cint; beta: ptr cfloat;
                       C: ptr cfloat; ldc: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseSgemmi", dynlib: libName.}
+      importc: "cusparseSgemmi", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cusparseDgemmi*(handle: cusparseHandle_t; m: cint; n: cint; k: cint; nnz: cint;
                       alpha: ptr cdouble; A: ptr cdouble; lda: cint;
                       cscValB: ptr cdouble; cscColPtrB: ptr cint;
                       cscRowIndB: ptr cint; beta: ptr cdouble; C: ptr cdouble; ldc: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDgemmi", dynlib: libName.}
+      cdecl, importc: "cusparseDgemmi", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cusparseCgemmi*(handle: cusparseHandle_t; m: cint; n: cint; k: cint; nnz: cint;
@@ -1182,7 +1185,7 @@ when not defined(CUSPARSE_H):
                       cscValB: ptr cuComplex; cscColPtrB: ptr cint;
                       cscRowIndB: ptr cint; beta: ptr cuComplex; C: ptr cuComplex;
                       ldc: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseCgemmi", dynlib: libName.}
+      importc: "cusparseCgemmi", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   proc cusparseZgemmi*(handle: cusparseHandle_t; m: cint; n: cint; k: cint; nnz: cint;
@@ -1190,7 +1193,7 @@ when not defined(CUSPARSE_H):
                       cscValB: ptr cuDoubleComplex; cscColPtrB: ptr cint;
                       cscRowIndB: ptr cint; beta: ptr cuDoubleComplex;
                       C: ptr cuDoubleComplex; ldc: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseZgemmi", dynlib: libName.}
+      importc: "cusparseZgemmi", dyn.}
     ##  host or device pointer
     ##  host or device pointer
   ##  Description: Solution of triangular linear system op(A) * X = alpha * F, 
@@ -1204,7 +1207,7 @@ when not defined(CUSPARSE_H):
                                csrSortedRowPtrA: ptr cint;
                                csrSortedColIndA: ptr cint;
                                info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrsm_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseScsrsm_analysis", dyn.}
   proc cusparseDcsrsm_analysis*(handle: cusparseHandle_t;
                                transA: cusparseOperation_t; m: cint; nnz: cint;
                                descrA: cusparseMatDescr_t;
@@ -1212,7 +1215,7 @@ when not defined(CUSPARSE_H):
                                csrSortedRowPtrA: ptr cint;
                                csrSortedColIndA: ptr cint;
                                info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrsm_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrsm_analysis", dyn.}
   proc cusparseCcsrsm_analysis*(handle: cusparseHandle_t;
                                transA: cusparseOperation_t; m: cint; nnz: cint;
                                descrA: cusparseMatDescr_t;
@@ -1220,7 +1223,7 @@ when not defined(CUSPARSE_H):
                                csrSortedRowPtrA: ptr cint;
                                csrSortedColIndA: ptr cint;
                                info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrsm_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrsm_analysis", dyn.}
   proc cusparseZcsrsm_analysis*(handle: cusparseHandle_t;
                                transA: cusparseOperation_t; m: cint; nnz: cint;
                                descrA: cusparseMatDescr_t;
@@ -1228,14 +1231,14 @@ when not defined(CUSPARSE_H):
                                csrSortedRowPtrA: ptr cint;
                                csrSortedColIndA: ptr cint;
                                info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrsm_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrsm_analysis", dyn.}
   proc cusparseScsrsm_solve*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                             m: cint; n: cint; alpha: ptr cfloat;
                             descrA: cusparseMatDescr_t; csrSortedValA: ptr cfloat;
                             csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                             info: cusparseSolveAnalysisInfo_t; F: ptr cfloat;
                             ldf: cint; X: ptr cfloat; ldx: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrsm_solve", dynlib: libName.}
+      cdecl, importc: "cusparseScsrsm_solve", dyn.}
   proc cusparseDcsrsm_solve*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                             m: cint; n: cint; alpha: ptr cdouble;
                             descrA: cusparseMatDescr_t;
@@ -1243,7 +1246,7 @@ when not defined(CUSPARSE_H):
                             csrSortedColIndA: ptr cint;
                             info: cusparseSolveAnalysisInfo_t; F: ptr cdouble;
                             ldf: cint; X: ptr cdouble; ldx: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrsm_solve", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrsm_solve", dyn.}
   proc cusparseCcsrsm_solve*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                             m: cint; n: cint; alpha: ptr cuComplex;
                             descrA: cusparseMatDescr_t;
@@ -1251,7 +1254,7 @@ when not defined(CUSPARSE_H):
                             csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                             info: cusparseSolveAnalysisInfo_t; F: ptr cuComplex;
                             ldf: cint; X: ptr cuComplex; ldx: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrsm_solve", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrsm_solve", dyn.}
   proc cusparseZcsrsm_solve*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                             m: cint; n: cint; alpha: ptr cuDoubleComplex;
                             descrA: cusparseMatDescr_t;
@@ -1260,14 +1263,14 @@ when not defined(CUSPARSE_H):
                             info: cusparseSolveAnalysisInfo_t;
                             F: ptr cuDoubleComplex; ldf: cint;
                             X: ptr cuDoubleComplex; ldx: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrsm_solve", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrsm_solve", dyn.}
   ##  Description: Solution of triangular linear system op(A) * X = alpha * F, 
   ##    with multiple right-hand-sides, where A is a sparse matrix in CSR storage 
   ##    format, rhs F and solution X are dense tall matrices.
   ##    This routine implements algorithm 2 for this problem.
   proc cusparseXbsrsm2_zeroPivot*(handle: cusparseHandle_t; info: bsrsm2Info_t;
                                  position: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseXbsrsm2_zeroPivot", dynlib: libName.}
+      importc: "cusparseXbsrsm2_zeroPivot", dyn.}
   proc cusparseSbsrsm2_bufferSize*(handle: cusparseHandle_t;
                                   dirA: cusparseDirection_t;
                                   transA: cusparseOperation_t;
@@ -1277,7 +1280,7 @@ when not defined(CUSPARSE_H):
                                   bsrSortedRowPtr: ptr cint;
                                   bsrSortedColInd: ptr cint; blockSize: cint;
                                   info: bsrsm2Info_t; pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsrsm2_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseSbsrsm2_bufferSize", dyn.}
   proc cusparseDbsrsm2_bufferSize*(handle: cusparseHandle_t;
                                   dirA: cusparseDirection_t;
                                   transA: cusparseOperation_t;
@@ -1287,7 +1290,7 @@ when not defined(CUSPARSE_H):
                                   bsrSortedRowPtr: ptr cint;
                                   bsrSortedColInd: ptr cint; blockSize: cint;
                                   info: bsrsm2Info_t; pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsrsm2_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseDbsrsm2_bufferSize", dyn.}
   proc cusparseCbsrsm2_bufferSize*(handle: cusparseHandle_t;
                                   dirA: cusparseDirection_t;
                                   transA: cusparseOperation_t;
@@ -1297,7 +1300,7 @@ when not defined(CUSPARSE_H):
                                   bsrSortedRowPtr: ptr cint;
                                   bsrSortedColInd: ptr cint; blockSize: cint;
                                   info: bsrsm2Info_t; pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsrsm2_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseCbsrsm2_bufferSize", dyn.}
   proc cusparseZbsrsm2_bufferSize*(handle: cusparseHandle_t;
                                   dirA: cusparseDirection_t;
                                   transA: cusparseOperation_t;
@@ -1307,7 +1310,7 @@ when not defined(CUSPARSE_H):
                                   bsrSortedRowPtr: ptr cint;
                                   bsrSortedColInd: ptr cint; blockSize: cint;
                                   info: bsrsm2Info_t; pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsrsm2_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseZbsrsm2_bufferSize", dyn.}
   proc cusparseSbsrsm2_bufferSizeExt*(handle: cusparseHandle_t;
                                      dirA: cusparseDirection_t;
                                      transA: cusparseOperation_t;
@@ -1317,7 +1320,7 @@ when not defined(CUSPARSE_H):
                                      bsrSortedRowPtr: ptr cint;
                                      bsrSortedColInd: ptr cint; blockSize: cint;
                                      info: bsrsm2Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsrsm2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseSbsrsm2_bufferSizeExt", dyn.}
   proc cusparseDbsrsm2_bufferSizeExt*(handle: cusparseHandle_t;
                                      dirA: cusparseDirection_t;
                                      transA: cusparseOperation_t;
@@ -1327,7 +1330,7 @@ when not defined(CUSPARSE_H):
                                      bsrSortedRowPtr: ptr cint;
                                      bsrSortedColInd: ptr cint; blockSize: cint;
                                      info: bsrsm2Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsrsm2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseDbsrsm2_bufferSizeExt", dyn.}
   proc cusparseCbsrsm2_bufferSizeExt*(handle: cusparseHandle_t;
                                      dirA: cusparseDirection_t;
                                      transA: cusparseOperation_t;
@@ -1337,7 +1340,7 @@ when not defined(CUSPARSE_H):
                                      bsrSortedRowPtr: ptr cint;
                                      bsrSortedColInd: ptr cint; blockSize: cint;
                                      info: bsrsm2Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsrsm2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseCbsrsm2_bufferSizeExt", dyn.}
   proc cusparseZbsrsm2_bufferSizeExt*(handle: cusparseHandle_t;
                                      dirA: cusparseDirection_t;
                                      transA: cusparseOperation_t;
@@ -1347,7 +1350,7 @@ when not defined(CUSPARSE_H):
                                      bsrSortedRowPtr: ptr cint;
                                      bsrSortedColInd: ptr cint; blockSize: cint;
                                      info: bsrsm2Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsrsm2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseZbsrsm2_bufferSizeExt", dyn.}
   proc cusparseSbsrsm2_analysis*(handle: cusparseHandle_t;
                                 dirA: cusparseDirection_t;
                                 transA: cusparseOperation_t;
@@ -1358,7 +1361,7 @@ when not defined(CUSPARSE_H):
                                 bsrSortedColInd: ptr cint; blockSize: cint;
                                 info: bsrsm2Info_t; policy: cusparseSolvePolicy_t;
                                 pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseSbsrsm2_analysis", dynlib: libName.}
+      importc: "cusparseSbsrsm2_analysis", dyn.}
   proc cusparseDbsrsm2_analysis*(handle: cusparseHandle_t;
                                 dirA: cusparseDirection_t;
                                 transA: cusparseOperation_t;
@@ -1369,7 +1372,7 @@ when not defined(CUSPARSE_H):
                                 bsrSortedColInd: ptr cint; blockSize: cint;
                                 info: bsrsm2Info_t; policy: cusparseSolvePolicy_t;
                                 pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseDbsrsm2_analysis", dynlib: libName.}
+      importc: "cusparseDbsrsm2_analysis", dyn.}
   proc cusparseCbsrsm2_analysis*(handle: cusparseHandle_t;
                                 dirA: cusparseDirection_t;
                                 transA: cusparseOperation_t;
@@ -1380,7 +1383,7 @@ when not defined(CUSPARSE_H):
                                 bsrSortedColInd: ptr cint; blockSize: cint;
                                 info: bsrsm2Info_t; policy: cusparseSolvePolicy_t;
                                 pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseCbsrsm2_analysis", dynlib: libName.}
+      importc: "cusparseCbsrsm2_analysis", dyn.}
   proc cusparseZbsrsm2_analysis*(handle: cusparseHandle_t;
                                 dirA: cusparseDirection_t;
                                 transA: cusparseOperation_t;
@@ -1391,7 +1394,7 @@ when not defined(CUSPARSE_H):
                                 bsrSortedColInd: ptr cint; blockSize: cint;
                                 info: bsrsm2Info_t; policy: cusparseSolvePolicy_t;
                                 pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseZbsrsm2_analysis", dynlib: libName.}
+      importc: "cusparseZbsrsm2_analysis", dyn.}
   proc cusparseSbsrsm2_solve*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                              transA: cusparseOperation_t;
                              transXY: cusparseOperation_t; mb: cint; n: cint;
@@ -1401,7 +1404,7 @@ when not defined(CUSPARSE_H):
                              blockSize: cint; info: bsrsm2Info_t; F: ptr cfloat;
                              ldf: cint; X: ptr cfloat; ldx: cint;
                              policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsrsm2_solve", dynlib: libName.}
+      cdecl, importc: "cusparseSbsrsm2_solve", dyn.}
   proc cusparseDbsrsm2_solve*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                              transA: cusparseOperation_t;
                              transXY: cusparseOperation_t; mb: cint; n: cint;
@@ -1412,7 +1415,7 @@ when not defined(CUSPARSE_H):
                              info: bsrsm2Info_t; F: ptr cdouble; ldf: cint;
                              X: ptr cdouble; ldx: cint;
                              policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsrsm2_solve", dynlib: libName.}
+      cdecl, importc: "cusparseDbsrsm2_solve", dyn.}
   proc cusparseCbsrsm2_solve*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                              transA: cusparseOperation_t;
                              transXY: cusparseOperation_t; mb: cint; n: cint;
@@ -1423,7 +1426,7 @@ when not defined(CUSPARSE_H):
                              blockSize: cint; info: bsrsm2Info_t; F: ptr cuComplex;
                              ldf: cint; X: ptr cuComplex; ldx: cint;
                              policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsrsm2_solve", dynlib: libName.}
+      cdecl, importc: "cusparseCbsrsm2_solve", dyn.}
   proc cusparseZbsrsm2_solve*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                              transA: cusparseOperation_t;
                              transXY: cusparseOperation_t; mb: cint; n: cint;
@@ -1435,7 +1438,7 @@ when not defined(CUSPARSE_H):
                              F: ptr cuDoubleComplex; ldf: cint;
                              X: ptr cuDoubleComplex; ldx: cint;
                              policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsrsm2_solve", dynlib: libName.}
+      cdecl, importc: "cusparseZbsrsm2_solve", dyn.}
   ##  --- Preconditioners ---
   ##  Description: Compute the incomplete-LU factorization with 0 fill-in (ILU0)
   ##    of the matrix A stored in CSR format based on the information in the opaque 
@@ -1448,7 +1451,7 @@ when not defined(CUSPARSE_H):
                          csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                          info: cusparseSolveAnalysisInfo_t;
                          executiontype: cudaDataType): cusparseStatus_t {.cdecl,
-      importc: "cusparseCsrilu0Ex", dynlib: libName.}
+      importc: "cusparseCsrilu0Ex", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                  to be the preconditioner M values
   proc cusparseScsrilu0*(handle: cusparseHandle_t; trans: cusparseOperation_t;
@@ -1456,7 +1459,7 @@ when not defined(CUSPARSE_H):
                         csrSortedValA_ValM: ptr cfloat; csrSortedRowPtrA: ptr cint;
                         csrSortedColIndA: ptr cint;
                         info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrilu0", dynlib: libName.}
+      cdecl, importc: "cusparseScsrilu0", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                  to be the preconditioner M values
   proc cusparseDcsrilu0*(handle: cusparseHandle_t; trans: cusparseOperation_t;
@@ -1464,7 +1467,7 @@ when not defined(CUSPARSE_H):
                         csrSortedValA_ValM: ptr cdouble;
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                         info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrilu0", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrilu0", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                  to be the preconditioner M values
   proc cusparseCcsrilu0*(handle: cusparseHandle_t; trans: cusparseOperation_t;
@@ -1472,7 +1475,7 @@ when not defined(CUSPARSE_H):
                         csrSortedValA_ValM: ptr cuComplex;
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                         info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrilu0", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrilu0", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                  to be the preconditioner M values
   proc cusparseZcsrilu0*(handle: cusparseHandle_t; trans: cusparseOperation_t;
@@ -1480,7 +1483,7 @@ when not defined(CUSPARSE_H):
                         csrSortedValA_ValM: ptr cuDoubleComplex;
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                         info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrilu0", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrilu0", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                  to be the preconditioner M values
   ##  Description: Compute the incomplete-LU factorization with 0 fill-in (ILU0)
@@ -1490,23 +1493,23 @@ when not defined(CUSPARSE_H):
   proc cusparseScsrilu02_numericBoost*(handle: cusparseHandle_t;
                                       info: csrilu02Info_t; enable_boost: cint;
                                       tol: ptr cdouble; boost_val: ptr cfloat): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrilu02_numericBoost", dynlib: libName.}
+      cdecl, importc: "cusparseScsrilu02_numericBoost", dyn.}
   proc cusparseDcsrilu02_numericBoost*(handle: cusparseHandle_t;
                                       info: csrilu02Info_t; enable_boost: cint;
                                       tol: ptr cdouble; boost_val: ptr cdouble): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrilu02_numericBoost", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrilu02_numericBoost", dyn.}
   proc cusparseCcsrilu02_numericBoost*(handle: cusparseHandle_t;
                                       info: csrilu02Info_t; enable_boost: cint;
                                       tol: ptr cdouble; boost_val: ptr cuComplex): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrilu02_numericBoost", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrilu02_numericBoost", dyn.}
   proc cusparseZcsrilu02_numericBoost*(handle: cusparseHandle_t;
                                       info: csrilu02Info_t; enable_boost: cint;
                                       tol: ptr cdouble;
                                       boost_val: ptr cuDoubleComplex): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrilu02_numericBoost", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrilu02_numericBoost", dyn.}
   proc cusparseXcsrilu02_zeroPivot*(handle: cusparseHandle_t; info: csrilu02Info_t;
                                    position: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseXcsrilu02_zeroPivot", dynlib: libName.}
+      importc: "cusparseXcsrilu02_zeroPivot", dyn.}
   proc cusparseScsrilu02_bufferSize*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                     descrA: cusparseMatDescr_t;
                                     csrSortedValA: ptr cfloat;
@@ -1514,7 +1517,7 @@ when not defined(CUSPARSE_H):
                                     csrSortedColIndA: ptr cint;
                                     info: csrilu02Info_t;
                                     pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrilu02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseScsrilu02_bufferSize", dyn.}
   proc cusparseDcsrilu02_bufferSize*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                     descrA: cusparseMatDescr_t;
                                     csrSortedValA: ptr cdouble;
@@ -1522,7 +1525,7 @@ when not defined(CUSPARSE_H):
                                     csrSortedColIndA: ptr cint;
                                     info: csrilu02Info_t;
                                     pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrilu02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrilu02_bufferSize", dyn.}
   proc cusparseCcsrilu02_bufferSize*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                     descrA: cusparseMatDescr_t;
                                     csrSortedValA: ptr cuComplex;
@@ -1530,7 +1533,7 @@ when not defined(CUSPARSE_H):
                                     csrSortedColIndA: ptr cint;
                                     info: csrilu02Info_t;
                                     pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrilu02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrilu02_bufferSize", dyn.}
   proc cusparseZcsrilu02_bufferSize*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                     descrA: cusparseMatDescr_t;
                                     csrSortedValA: ptr cuDoubleComplex;
@@ -1538,7 +1541,7 @@ when not defined(CUSPARSE_H):
                                     csrSortedColIndA: ptr cint;
                                     info: csrilu02Info_t;
                                     pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrilu02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrilu02_bufferSize", dyn.}
   proc cusparseScsrilu02_bufferSizeExt*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                        descrA: cusparseMatDescr_t;
                                        csrSortedVal: ptr cfloat;
@@ -1546,7 +1549,7 @@ when not defined(CUSPARSE_H):
                                        csrSortedColInd: ptr cint;
                                        info: csrilu02Info_t;
                                        pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrilu02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseScsrilu02_bufferSizeExt", dyn.}
   proc cusparseDcsrilu02_bufferSizeExt*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                        descrA: cusparseMatDescr_t;
                                        csrSortedVal: ptr cdouble;
@@ -1554,7 +1557,7 @@ when not defined(CUSPARSE_H):
                                        csrSortedColInd: ptr cint;
                                        info: csrilu02Info_t;
                                        pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrilu02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrilu02_bufferSizeExt", dyn.}
   proc cusparseCcsrilu02_bufferSizeExt*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                        descrA: cusparseMatDescr_t;
                                        csrSortedVal: ptr cuComplex;
@@ -1562,7 +1565,7 @@ when not defined(CUSPARSE_H):
                                        csrSortedColInd: ptr cint;
                                        info: csrilu02Info_t;
                                        pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrilu02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrilu02_bufferSizeExt", dyn.}
   proc cusparseZcsrilu02_bufferSizeExt*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                        descrA: cusparseMatDescr_t;
                                        csrSortedVal: ptr cuDoubleComplex;
@@ -1570,42 +1573,42 @@ when not defined(CUSPARSE_H):
                                        csrSortedColInd: ptr cint;
                                        info: csrilu02Info_t;
                                        pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrilu02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrilu02_bufferSizeExt", dyn.}
   proc cusparseScsrilu02_analysis*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                   descrA: cusparseMatDescr_t;
                                   csrSortedValA: ptr cfloat;
                                   csrSortedRowPtrA: ptr cint;
                                   csrSortedColIndA: ptr cint; info: csrilu02Info_t;
                                   policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrilu02_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseScsrilu02_analysis", dyn.}
   proc cusparseDcsrilu02_analysis*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                   descrA: cusparseMatDescr_t;
                                   csrSortedValA: ptr cdouble;
                                   csrSortedRowPtrA: ptr cint;
                                   csrSortedColIndA: ptr cint; info: csrilu02Info_t;
                                   policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrilu02_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrilu02_analysis", dyn.}
   proc cusparseCcsrilu02_analysis*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                   descrA: cusparseMatDescr_t;
                                   csrSortedValA: ptr cuComplex;
                                   csrSortedRowPtrA: ptr cint;
                                   csrSortedColIndA: ptr cint; info: csrilu02Info_t;
                                   policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrilu02_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrilu02_analysis", dyn.}
   proc cusparseZcsrilu02_analysis*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                   descrA: cusparseMatDescr_t;
                                   csrSortedValA: ptr cuDoubleComplex;
                                   csrSortedRowPtrA: ptr cint;
                                   csrSortedColIndA: ptr cint; info: csrilu02Info_t;
                                   policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrilu02_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrilu02_analysis", dyn.}
   proc cusparseScsrilu02*(handle: cusparseHandle_t; m: cint; nnz: cint;
                          descrA: cusparseMatDescr_t;
                          csrSortedValA_valM: ptr cfloat;
                          csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                          info: csrilu02Info_t; policy: cusparseSolvePolicy_t;
                          pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseScsrilu02", dynlib: libName.}
+      importc: "cusparseScsrilu02", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                   to be the preconditioner M values
   proc cusparseDcsrilu02*(handle: cusparseHandle_t; m: cint; nnz: cint;
@@ -1614,7 +1617,7 @@ when not defined(CUSPARSE_H):
                          csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                          info: csrilu02Info_t; policy: cusparseSolvePolicy_t;
                          pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseDcsrilu02", dynlib: libName.}
+      importc: "cusparseDcsrilu02", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                   to be the preconditioner M values
   proc cusparseCcsrilu02*(handle: cusparseHandle_t; m: cint; nnz: cint;
@@ -1623,7 +1626,7 @@ when not defined(CUSPARSE_H):
                          csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                          info: csrilu02Info_t; policy: cusparseSolvePolicy_t;
                          pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseCcsrilu02", dynlib: libName.}
+      importc: "cusparseCcsrilu02", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                   to be the preconditioner M values
   proc cusparseZcsrilu02*(handle: cusparseHandle_t; m: cint; nnz: cint;
@@ -1632,7 +1635,7 @@ when not defined(CUSPARSE_H):
                          csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                          info: csrilu02Info_t; policy: cusparseSolvePolicy_t;
                          pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseZcsrilu02", dynlib: libName.}
+      importc: "cusparseZcsrilu02", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                   to be the preconditioner M values
   ##  Description: Compute the incomplete-LU factorization with 0 fill-in (ILU0)
@@ -1642,23 +1645,23 @@ when not defined(CUSPARSE_H):
   proc cusparseSbsrilu02_numericBoost*(handle: cusparseHandle_t;
                                       info: bsrilu02Info_t; enable_boost: cint;
                                       tol: ptr cdouble; boost_val: ptr cfloat): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsrilu02_numericBoost", dynlib: libName.}
+      cdecl, importc: "cusparseSbsrilu02_numericBoost", dyn.}
   proc cusparseDbsrilu02_numericBoost*(handle: cusparseHandle_t;
                                       info: bsrilu02Info_t; enable_boost: cint;
                                       tol: ptr cdouble; boost_val: ptr cdouble): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsrilu02_numericBoost", dynlib: libName.}
+      cdecl, importc: "cusparseDbsrilu02_numericBoost", dyn.}
   proc cusparseCbsrilu02_numericBoost*(handle: cusparseHandle_t;
                                       info: bsrilu02Info_t; enable_boost: cint;
                                       tol: ptr cdouble; boost_val: ptr cuComplex): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsrilu02_numericBoost", dynlib: libName.}
+      cdecl, importc: "cusparseCbsrilu02_numericBoost", dyn.}
   proc cusparseZbsrilu02_numericBoost*(handle: cusparseHandle_t;
                                       info: bsrilu02Info_t; enable_boost: cint;
                                       tol: ptr cdouble;
                                       boost_val: ptr cuDoubleComplex): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsrilu02_numericBoost", dynlib: libName.}
+      cdecl, importc: "cusparseZbsrilu02_numericBoost", dyn.}
   proc cusparseXbsrilu02_zeroPivot*(handle: cusparseHandle_t; info: bsrilu02Info_t;
                                    position: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseXbsrilu02_zeroPivot", dynlib: libName.}
+      importc: "cusparseXbsrilu02_zeroPivot", dyn.}
   proc cusparseSbsrilu02_bufferSize*(handle: cusparseHandle_t;
                                     dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                     descrA: cusparseMatDescr_t;
@@ -1667,7 +1670,7 @@ when not defined(CUSPARSE_H):
                                     bsrSortedColInd: ptr cint; blockDim: cint;
                                     info: bsrilu02Info_t;
                                     pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsrilu02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseSbsrilu02_bufferSize", dyn.}
   proc cusparseDbsrilu02_bufferSize*(handle: cusparseHandle_t;
                                     dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                     descrA: cusparseMatDescr_t;
@@ -1676,7 +1679,7 @@ when not defined(CUSPARSE_H):
                                     bsrSortedColInd: ptr cint; blockDim: cint;
                                     info: bsrilu02Info_t;
                                     pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsrilu02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseDbsrilu02_bufferSize", dyn.}
   proc cusparseCbsrilu02_bufferSize*(handle: cusparseHandle_t;
                                     dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                     descrA: cusparseMatDescr_t;
@@ -1685,7 +1688,7 @@ when not defined(CUSPARSE_H):
                                     bsrSortedColInd: ptr cint; blockDim: cint;
                                     info: bsrilu02Info_t;
                                     pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsrilu02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseCbsrilu02_bufferSize", dyn.}
   proc cusparseZbsrilu02_bufferSize*(handle: cusparseHandle_t;
                                     dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                     descrA: cusparseMatDescr_t;
@@ -1694,7 +1697,7 @@ when not defined(CUSPARSE_H):
                                     bsrSortedColInd: ptr cint; blockDim: cint;
                                     info: bsrilu02Info_t;
                                     pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsrilu02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseZbsrilu02_bufferSize", dyn.}
   proc cusparseSbsrilu02_bufferSizeExt*(handle: cusparseHandle_t;
                                        dirA: cusparseDirection_t; mb: cint;
                                        nnzb: cint; descrA: cusparseMatDescr_t;
@@ -1703,7 +1706,7 @@ when not defined(CUSPARSE_H):
                                        bsrSortedColInd: ptr cint; blockSize: cint;
                                        info: bsrilu02Info_t;
                                        pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsrilu02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseSbsrilu02_bufferSizeExt", dyn.}
   proc cusparseDbsrilu02_bufferSizeExt*(handle: cusparseHandle_t;
                                        dirA: cusparseDirection_t; mb: cint;
                                        nnzb: cint; descrA: cusparseMatDescr_t;
@@ -1712,7 +1715,7 @@ when not defined(CUSPARSE_H):
                                        bsrSortedColInd: ptr cint; blockSize: cint;
                                        info: bsrilu02Info_t;
                                        pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsrilu02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseDbsrilu02_bufferSizeExt", dyn.}
   proc cusparseCbsrilu02_bufferSizeExt*(handle: cusparseHandle_t;
                                        dirA: cusparseDirection_t; mb: cint;
                                        nnzb: cint; descrA: cusparseMatDescr_t;
@@ -1721,7 +1724,7 @@ when not defined(CUSPARSE_H):
                                        bsrSortedColInd: ptr cint; blockSize: cint;
                                        info: bsrilu02Info_t;
                                        pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsrilu02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseCbsrilu02_bufferSizeExt", dyn.}
   proc cusparseZbsrilu02_bufferSizeExt*(handle: cusparseHandle_t;
                                        dirA: cusparseDirection_t; mb: cint;
                                        nnzb: cint; descrA: cusparseMatDescr_t;
@@ -1730,7 +1733,7 @@ when not defined(CUSPARSE_H):
                                        bsrSortedColInd: ptr cint; blockSize: cint;
                                        info: bsrilu02Info_t;
                                        pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsrilu02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseZbsrilu02_bufferSizeExt", dyn.}
   proc cusparseSbsrilu02_analysis*(handle: cusparseHandle_t;
                                   dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                   descrA: cusparseMatDescr_t;
@@ -1739,7 +1742,7 @@ when not defined(CUSPARSE_H):
                                   bsrSortedColInd: ptr cint; blockDim: cint;
                                   info: bsrilu02Info_t;
                                   policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsrilu02_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseSbsrilu02_analysis", dyn.}
   proc cusparseDbsrilu02_analysis*(handle: cusparseHandle_t;
                                   dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                   descrA: cusparseMatDescr_t;
@@ -1748,7 +1751,7 @@ when not defined(CUSPARSE_H):
                                   bsrSortedColInd: ptr cint; blockDim: cint;
                                   info: bsrilu02Info_t;
                                   policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsrilu02_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseDbsrilu02_analysis", dyn.}
   proc cusparseCbsrilu02_analysis*(handle: cusparseHandle_t;
                                   dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                   descrA: cusparseMatDescr_t;
@@ -1757,7 +1760,7 @@ when not defined(CUSPARSE_H):
                                   bsrSortedColInd: ptr cint; blockDim: cint;
                                   info: bsrilu02Info_t;
                                   policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsrilu02_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseCbsrilu02_analysis", dyn.}
   proc cusparseZbsrilu02_analysis*(handle: cusparseHandle_t;
                                   dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                   descrA: cusparseMatDescr_t;
@@ -1766,35 +1769,35 @@ when not defined(CUSPARSE_H):
                                   bsrSortedColInd: ptr cint; blockDim: cint;
                                   info: bsrilu02Info_t;
                                   policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsrilu02_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseZbsrilu02_analysis", dyn.}
   proc cusparseSbsrilu02*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                          mb: cint; nnzb: cint; descra: cusparseMatDescr_t;
                          bsrSortedVal: ptr cfloat; bsrSortedRowPtr: ptr cint;
                          bsrSortedColInd: ptr cint; blockDim: cint;
                          info: bsrilu02Info_t; policy: cusparseSolvePolicy_t;
                          pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseSbsrilu02", dynlib: libName.}
+      importc: "cusparseSbsrilu02", dyn.}
   proc cusparseDbsrilu02*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                          mb: cint; nnzb: cint; descra: cusparseMatDescr_t;
                          bsrSortedVal: ptr cdouble; bsrSortedRowPtr: ptr cint;
                          bsrSortedColInd: ptr cint; blockDim: cint;
                          info: bsrilu02Info_t; policy: cusparseSolvePolicy_t;
                          pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseDbsrilu02", dynlib: libName.}
+      importc: "cusparseDbsrilu02", dyn.}
   proc cusparseCbsrilu02*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                          mb: cint; nnzb: cint; descra: cusparseMatDescr_t;
                          bsrSortedVal: ptr cuComplex; bsrSortedRowPtr: ptr cint;
                          bsrSortedColInd: ptr cint; blockDim: cint;
                          info: bsrilu02Info_t; policy: cusparseSolvePolicy_t;
                          pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseCbsrilu02", dynlib: libName.}
+      importc: "cusparseCbsrilu02", dyn.}
   proc cusparseZbsrilu02*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                          mb: cint; nnzb: cint; descra: cusparseMatDescr_t;
                          bsrSortedVal: ptr cuDoubleComplex;
                          bsrSortedRowPtr: ptr cint; bsrSortedColInd: ptr cint;
                          blockDim: cint; info: bsrilu02Info_t;
                          policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsrilu02", dynlib: libName.}
+      cdecl, importc: "cusparseZbsrilu02", dyn.}
   ##  Description: Compute the incomplete-Cholesky factorization with 0 fill-in (IC0)
   ##    of the matrix A stored in CSR format based on the information in the opaque 
   ##    structure info that was obtained from the analysis phase (csrsv_analysis). 
@@ -1804,7 +1807,7 @@ when not defined(CUSPARSE_H):
                        csrSortedValA_ValM: ptr cfloat; csrSortedRowPtrA: ptr cint;
                        csrSortedColIndA: ptr cint;
                        info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsric0", dynlib: libName.}
+      cdecl, importc: "cusparseScsric0", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                  to be the preconditioner M values
   proc cusparseDcsric0*(handle: cusparseHandle_t; trans: cusparseOperation_t;
@@ -1812,7 +1815,7 @@ when not defined(CUSPARSE_H):
                        csrSortedValA_ValM: ptr cdouble; csrSortedRowPtrA: ptr cint;
                        csrSortedColIndA: ptr cint;
                        info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsric0", dynlib: libName.}
+      cdecl, importc: "cusparseDcsric0", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                  to be the preconditioner M values
   proc cusparseCcsric0*(handle: cusparseHandle_t; trans: cusparseOperation_t;
@@ -1820,7 +1823,7 @@ when not defined(CUSPARSE_H):
                        csrSortedValA_ValM: ptr cuComplex;
                        csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                        info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsric0", dynlib: libName.}
+      cdecl, importc: "cusparseCcsric0", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                  to be the preconditioner M values
   proc cusparseZcsric0*(handle: cusparseHandle_t; trans: cusparseOperation_t;
@@ -1828,7 +1831,7 @@ when not defined(CUSPARSE_H):
                        csrSortedValA_ValM: ptr cuDoubleComplex;
                        csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                        info: cusparseSolveAnalysisInfo_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsric0", dynlib: libName.}
+      cdecl, importc: "cusparseZcsric0", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                  to be the preconditioner M values
   ##  Description: Compute the incomplete-Cholesky factorization with 0 fill-in (IC0)
@@ -1837,97 +1840,97 @@ when not defined(CUSPARSE_H):
   ##    This routine implements algorithm 2 for this problem.
   proc cusparseXcsric02_zeroPivot*(handle: cusparseHandle_t; info: csric02Info_t;
                                   position: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseXcsric02_zeroPivot", dynlib: libName.}
+      importc: "cusparseXcsric02_zeroPivot", dyn.}
   proc cusparseScsric02_bufferSize*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                    descrA: cusparseMatDescr_t;
                                    csrSortedValA: ptr cfloat;
                                    csrSortedRowPtrA: ptr cint;
                                    csrSortedColIndA: ptr cint; info: csric02Info_t;
                                    pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsric02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseScsric02_bufferSize", dyn.}
   proc cusparseDcsric02_bufferSize*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                    descrA: cusparseMatDescr_t;
                                    csrSortedValA: ptr cdouble;
                                    csrSortedRowPtrA: ptr cint;
                                    csrSortedColIndA: ptr cint; info: csric02Info_t;
                                    pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsric02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseDcsric02_bufferSize", dyn.}
   proc cusparseCcsric02_bufferSize*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                    descrA: cusparseMatDescr_t;
                                    csrSortedValA: ptr cuComplex;
                                    csrSortedRowPtrA: ptr cint;
                                    csrSortedColIndA: ptr cint; info: csric02Info_t;
                                    pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsric02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseCcsric02_bufferSize", dyn.}
   proc cusparseZcsric02_bufferSize*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                    descrA: cusparseMatDescr_t;
                                    csrSortedValA: ptr cuDoubleComplex;
                                    csrSortedRowPtrA: ptr cint;
                                    csrSortedColIndA: ptr cint; info: csric02Info_t;
                                    pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsric02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseZcsric02_bufferSize", dyn.}
   proc cusparseScsric02_bufferSizeExt*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                       descrA: cusparseMatDescr_t;
                                       csrSortedVal: ptr cfloat;
                                       csrSortedRowPtr: ptr cint;
                                       csrSortedColInd: ptr cint;
                                       info: csric02Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsric02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseScsric02_bufferSizeExt", dyn.}
   proc cusparseDcsric02_bufferSizeExt*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                       descrA: cusparseMatDescr_t;
                                       csrSortedVal: ptr cdouble;
                                       csrSortedRowPtr: ptr cint;
                                       csrSortedColInd: ptr cint;
                                       info: csric02Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsric02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseDcsric02_bufferSizeExt", dyn.}
   proc cusparseCcsric02_bufferSizeExt*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                       descrA: cusparseMatDescr_t;
                                       csrSortedVal: ptr cuComplex;
                                       csrSortedRowPtr: ptr cint;
                                       csrSortedColInd: ptr cint;
                                       info: csric02Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsric02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseCcsric02_bufferSizeExt", dyn.}
   proc cusparseZcsric02_bufferSizeExt*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                       descrA: cusparseMatDescr_t;
                                       csrSortedVal: ptr cuDoubleComplex;
                                       csrSortedRowPtr: ptr cint;
                                       csrSortedColInd: ptr cint;
                                       info: csric02Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsric02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseZcsric02_bufferSizeExt", dyn.}
   proc cusparseScsric02_analysis*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                  descrA: cusparseMatDescr_t;
                                  csrSortedValA: ptr cfloat;
                                  csrSortedRowPtrA: ptr cint;
                                  csrSortedColIndA: ptr cint; info: csric02Info_t;
                                  policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsric02_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseScsric02_analysis", dyn.}
   proc cusparseDcsric02_analysis*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                  descrA: cusparseMatDescr_t;
                                  csrSortedValA: ptr cdouble;
                                  csrSortedRowPtrA: ptr cint;
                                  csrSortedColIndA: ptr cint; info: csric02Info_t;
                                  policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsric02_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseDcsric02_analysis", dyn.}
   proc cusparseCcsric02_analysis*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                  descrA: cusparseMatDescr_t;
                                  csrSortedValA: ptr cuComplex;
                                  csrSortedRowPtrA: ptr cint;
                                  csrSortedColIndA: ptr cint; info: csric02Info_t;
                                  policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsric02_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseCcsric02_analysis", dyn.}
   proc cusparseZcsric02_analysis*(handle: cusparseHandle_t; m: cint; nnz: cint;
                                  descrA: cusparseMatDescr_t;
                                  csrSortedValA: ptr cuDoubleComplex;
                                  csrSortedRowPtrA: ptr cint;
                                  csrSortedColIndA: ptr cint; info: csric02Info_t;
                                  policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsric02_analysis", dynlib: libName.}
+      cdecl, importc: "cusparseZcsric02_analysis", dyn.}
   proc cusparseScsric02*(handle: cusparseHandle_t; m: cint; nnz: cint;
                         descrA: cusparseMatDescr_t;
                         csrSortedValA_valM: ptr cfloat; csrSortedRowPtrA: ptr cint;
                         csrSortedColIndA: ptr cint; info: csric02Info_t;
                         policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsric02", dynlib: libName.}
+      cdecl, importc: "cusparseScsric02", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                  to be the preconditioner M values
   proc cusparseDcsric02*(handle: cusparseHandle_t; m: cint; nnz: cint;
@@ -1936,7 +1939,7 @@ when not defined(CUSPARSE_H):
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                         info: csric02Info_t; policy: cusparseSolvePolicy_t;
                         pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseDcsric02", dynlib: libName.}
+      importc: "cusparseDcsric02", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                  to be the preconditioner M values
   proc cusparseCcsric02*(handle: cusparseHandle_t; m: cint; nnz: cint;
@@ -1945,7 +1948,7 @@ when not defined(CUSPARSE_H):
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                         info: csric02Info_t; policy: cusparseSolvePolicy_t;
                         pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseCcsric02", dynlib: libName.}
+      importc: "cusparseCcsric02", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                  to be the preconditioner M values
   proc cusparseZcsric02*(handle: cusparseHandle_t; m: cint; nnz: cint;
@@ -1954,7 +1957,7 @@ when not defined(CUSPARSE_H):
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                         info: csric02Info_t; policy: cusparseSolvePolicy_t;
                         pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseZcsric02", dynlib: libName.}
+      importc: "cusparseZcsric02", dyn.}
     ##  matrix A values are updated inplace 
     ##                                                  to be the preconditioner M values
   ##  Description: Compute the incomplete-Cholesky factorization with 0 fill-in (IC0)
@@ -1963,7 +1966,7 @@ when not defined(CUSPARSE_H):
   ##    This routine implements algorithm 1 for this problem.
   proc cusparseXbsric02_zeroPivot*(handle: cusparseHandle_t; info: bsric02Info_t;
                                   position: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseXbsric02_zeroPivot", dynlib: libName.}
+      importc: "cusparseXbsric02_zeroPivot", dyn.}
   proc cusparseSbsric02_bufferSize*(handle: cusparseHandle_t;
                                    dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                    descrA: cusparseMatDescr_t;
@@ -1972,7 +1975,7 @@ when not defined(CUSPARSE_H):
                                    bsrSortedColInd: ptr cint; blockDim: cint;
                                    info: bsric02Info_t;
                                    pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsric02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseSbsric02_bufferSize", dyn.}
   proc cusparseDbsric02_bufferSize*(handle: cusparseHandle_t;
                                    dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                    descrA: cusparseMatDescr_t;
@@ -1981,7 +1984,7 @@ when not defined(CUSPARSE_H):
                                    bsrSortedColInd: ptr cint; blockDim: cint;
                                    info: bsric02Info_t;
                                    pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsric02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseDbsric02_bufferSize", dyn.}
   proc cusparseCbsric02_bufferSize*(handle: cusparseHandle_t;
                                    dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                    descrA: cusparseMatDescr_t;
@@ -1990,7 +1993,7 @@ when not defined(CUSPARSE_H):
                                    bsrSortedColInd: ptr cint; blockDim: cint;
                                    info: bsric02Info_t;
                                    pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsric02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseCbsric02_bufferSize", dyn.}
   proc cusparseZbsric02_bufferSize*(handle: cusparseHandle_t;
                                    dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                    descrA: cusparseMatDescr_t;
@@ -1999,7 +2002,7 @@ when not defined(CUSPARSE_H):
                                    bsrSortedColInd: ptr cint; blockDim: cint;
                                    info: bsric02Info_t;
                                    pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsric02_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseZbsric02_bufferSize", dyn.}
   proc cusparseSbsric02_bufferSizeExt*(handle: cusparseHandle_t;
                                       dirA: cusparseDirection_t; mb: cint;
                                       nnzb: cint; descrA: cusparseMatDescr_t;
@@ -2007,7 +2010,7 @@ when not defined(CUSPARSE_H):
                                       bsrSortedRowPtr: ptr cint;
                                       bsrSortedColInd: ptr cint; blockSize: cint;
                                       info: bsric02Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsric02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseSbsric02_bufferSizeExt", dyn.}
   proc cusparseDbsric02_bufferSizeExt*(handle: cusparseHandle_t;
                                       dirA: cusparseDirection_t; mb: cint;
                                       nnzb: cint; descrA: cusparseMatDescr_t;
@@ -2015,7 +2018,7 @@ when not defined(CUSPARSE_H):
                                       bsrSortedRowPtr: ptr cint;
                                       bsrSortedColInd: ptr cint; blockSize: cint;
                                       info: bsric02Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsric02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseDbsric02_bufferSizeExt", dyn.}
   proc cusparseCbsric02_bufferSizeExt*(handle: cusparseHandle_t;
                                       dirA: cusparseDirection_t; mb: cint;
                                       nnzb: cint; descrA: cusparseMatDescr_t;
@@ -2023,7 +2026,7 @@ when not defined(CUSPARSE_H):
                                       bsrSortedRowPtr: ptr cint;
                                       bsrSortedColInd: ptr cint; blockSize: cint;
                                       info: bsric02Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsric02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseCbsric02_bufferSizeExt", dyn.}
   proc cusparseZbsric02_bufferSizeExt*(handle: cusparseHandle_t;
                                       dirA: cusparseDirection_t; mb: cint;
                                       nnzb: cint; descrA: cusparseMatDescr_t;
@@ -2031,7 +2034,7 @@ when not defined(CUSPARSE_H):
                                       bsrSortedRowPtr: ptr cint;
                                       bsrSortedColInd: ptr cint; blockSize: cint;
                                       info: bsric02Info_t; pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsric02_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseZbsric02_bufferSizeExt", dyn.}
   proc cusparseSbsric02_analysis*(handle: cusparseHandle_t;
                                  dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                  descrA: cusparseMatDescr_t;
@@ -2041,7 +2044,7 @@ when not defined(CUSPARSE_H):
                                  info: bsric02Info_t;
                                  policy: cusparseSolvePolicy_t;
                                  pInputBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseSbsric02_analysis", dynlib: libName.}
+      importc: "cusparseSbsric02_analysis", dyn.}
   proc cusparseDbsric02_analysis*(handle: cusparseHandle_t;
                                  dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                  descrA: cusparseMatDescr_t;
@@ -2051,7 +2054,7 @@ when not defined(CUSPARSE_H):
                                  info: bsric02Info_t;
                                  policy: cusparseSolvePolicy_t;
                                  pInputBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseDbsric02_analysis", dynlib: libName.}
+      importc: "cusparseDbsric02_analysis", dyn.}
   proc cusparseCbsric02_analysis*(handle: cusparseHandle_t;
                                  dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                  descrA: cusparseMatDescr_t;
@@ -2061,7 +2064,7 @@ when not defined(CUSPARSE_H):
                                  info: bsric02Info_t;
                                  policy: cusparseSolvePolicy_t;
                                  pInputBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseCbsric02_analysis", dynlib: libName.}
+      importc: "cusparseCbsric02_analysis", dyn.}
   proc cusparseZbsric02_analysis*(handle: cusparseHandle_t;
                                  dirA: cusparseDirection_t; mb: cint; nnzb: cint;
                                  descrA: cusparseMatDescr_t;
@@ -2071,35 +2074,35 @@ when not defined(CUSPARSE_H):
                                  info: bsric02Info_t;
                                  policy: cusparseSolvePolicy_t;
                                  pInputBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseZbsric02_analysis", dynlib: libName.}
+      importc: "cusparseZbsric02_analysis", dyn.}
   proc cusparseSbsric02*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                         mb: cint; nnzb: cint; descrA: cusparseMatDescr_t;
                         bsrSortedVal: ptr cfloat; bsrSortedRowPtr: ptr cint;
                         bsrSortedColInd: ptr cint; blockDim: cint;
                         info: bsric02Info_t; policy: cusparseSolvePolicy_t;
                         pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseSbsric02", dynlib: libName.}
+      importc: "cusparseSbsric02", dyn.}
   proc cusparseDbsric02*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                         mb: cint; nnzb: cint; descrA: cusparseMatDescr_t;
                         bsrSortedVal: ptr cdouble; bsrSortedRowPtr: ptr cint;
                         bsrSortedColInd: ptr cint; blockDim: cint;
                         info: bsric02Info_t; policy: cusparseSolvePolicy_t;
                         pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseDbsric02", dynlib: libName.}
+      importc: "cusparseDbsric02", dyn.}
   proc cusparseCbsric02*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                         mb: cint; nnzb: cint; descrA: cusparseMatDescr_t;
                         bsrSortedVal: ptr cuComplex; bsrSortedRowPtr: ptr cint;
                         bsrSortedColInd: ptr cint; blockDim: cint;
                         info: bsric02Info_t; policy: cusparseSolvePolicy_t;
                         pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseCbsric02", dynlib: libName.}
+      importc: "cusparseCbsric02", dyn.}
   proc cusparseZbsric02*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                         mb: cint; nnzb: cint; descrA: cusparseMatDescr_t;
                         bsrSortedVal: ptr cuDoubleComplex;
                         bsrSortedRowPtr: ptr cint; bsrSortedColInd: ptr cint;
                         blockDim: cint; info: bsric02Info_t;
                         policy: cusparseSolvePolicy_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsric02", dynlib: libName.}
+      cdecl, importc: "cusparseZbsric02", dyn.}
   ##  Description: Solution of tridiagonal linear system A * X = F, 
   ##    with multiple right-hand-sides. The coefficient matrix A is 
   ##    composed of lower (dl), main (d) and upper (du) diagonals, and 
@@ -2107,17 +2110,17 @@ when not defined(CUSPARSE_H):
   ##    These routine use pivoting.
   proc cusparseSgtsv*(handle: cusparseHandle_t; m: cint; n: cint; dl: ptr cfloat;
                      d: ptr cfloat; du: ptr cfloat; B: ptr cfloat; ldb: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseSgtsv", dynlib: libName.}
+      cdecl, importc: "cusparseSgtsv", dyn.}
   proc cusparseDgtsv*(handle: cusparseHandle_t; m: cint; n: cint; dl: ptr cdouble;
                      d: ptr cdouble; du: ptr cdouble; B: ptr cdouble; ldb: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDgtsv", dynlib: libName.}
+      cdecl, importc: "cusparseDgtsv", dyn.}
   proc cusparseCgtsv*(handle: cusparseHandle_t; m: cint; n: cint; dl: ptr cuComplex;
                      d: ptr cuComplex; du: ptr cuComplex; B: ptr cuComplex; ldb: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCgtsv", dynlib: libName.}
+      cdecl, importc: "cusparseCgtsv", dyn.}
   proc cusparseZgtsv*(handle: cusparseHandle_t; m: cint; n: cint;
                      dl: ptr cuDoubleComplex; d: ptr cuDoubleComplex;
                      du: ptr cuDoubleComplex; B: ptr cuDoubleComplex; ldb: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZgtsv", dynlib: libName.}
+      cdecl, importc: "cusparseZgtsv", dyn.}
   ##  Description: Solution of tridiagonal linear system A * X = F, 
   ##    with multiple right-hand-sides. The coefficient matrix A is 
   ##    composed of lower (dl), main (d) and upper (du) diagonals, and 
@@ -2126,20 +2129,20 @@ when not defined(CUSPARSE_H):
   proc cusparseSgtsv_nopivot*(handle: cusparseHandle_t; m: cint; n: cint;
                              dl: ptr cfloat; d: ptr cfloat; du: ptr cfloat;
                              B: ptr cfloat; ldb: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseSgtsv_nopivot", dynlib: libName.}
+      importc: "cusparseSgtsv_nopivot", dyn.}
   proc cusparseDgtsv_nopivot*(handle: cusparseHandle_t; m: cint; n: cint;
                              dl: ptr cdouble; d: ptr cdouble; du: ptr cdouble;
                              B: ptr cdouble; ldb: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseDgtsv_nopivot", dynlib: libName.}
+      importc: "cusparseDgtsv_nopivot", dyn.}
   proc cusparseCgtsv_nopivot*(handle: cusparseHandle_t; m: cint; n: cint;
                              dl: ptr cuComplex; d: ptr cuComplex; du: ptr cuComplex;
                              B: ptr cuComplex; ldb: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseCgtsv_nopivot", dynlib: libName.}
+      importc: "cusparseCgtsv_nopivot", dyn.}
   proc cusparseZgtsv_nopivot*(handle: cusparseHandle_t; m: cint; n: cint;
                              dl: ptr cuDoubleComplex; d: ptr cuDoubleComplex;
                              du: ptr cuDoubleComplex; B: ptr cuDoubleComplex;
                              ldb: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseZgtsv_nopivot", dynlib: libName.}
+      importc: "cusparseZgtsv_nopivot", dyn.}
   ##  Description: Solution of a set of tridiagonal linear systems 
   ##    A_{i} * x_{i} = f_{i} for i=1,...,batchCount. The coefficient 
   ##    matrices A_{i} are composed of lower (dl), main (d) and upper (du) 
@@ -2148,21 +2151,21 @@ when not defined(CUSPARSE_H):
   proc cusparseSgtsvStridedBatch*(handle: cusparseHandle_t; m: cint; dl: ptr cfloat;
                                  d: ptr cfloat; du: ptr cfloat; x: ptr cfloat;
                                  batchCount: cint; batchStride: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseSgtsvStridedBatch", dynlib: libName.}
+      cdecl, importc: "cusparseSgtsvStridedBatch", dyn.}
   proc cusparseDgtsvStridedBatch*(handle: cusparseHandle_t; m: cint; dl: ptr cdouble;
                                  d: ptr cdouble; du: ptr cdouble; x: ptr cdouble;
                                  batchCount: cint; batchStride: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDgtsvStridedBatch", dynlib: libName.}
+      cdecl, importc: "cusparseDgtsvStridedBatch", dyn.}
   proc cusparseCgtsvStridedBatch*(handle: cusparseHandle_t; m: cint;
                                  dl: ptr cuComplex; d: ptr cuComplex;
                                  du: ptr cuComplex; x: ptr cuComplex;
                                  batchCount: cint; batchStride: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCgtsvStridedBatch", dynlib: libName.}
+      cdecl, importc: "cusparseCgtsvStridedBatch", dyn.}
   proc cusparseZgtsvStridedBatch*(handle: cusparseHandle_t; m: cint;
                                  dl: ptr cuDoubleComplex; d: ptr cuDoubleComplex;
                                  du: ptr cuDoubleComplex; x: ptr cuDoubleComplex;
                                  batchCount: cint; batchStride: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZgtsvStridedBatch", dynlib: libName.}
+      cdecl, importc: "cusparseZgtsvStridedBatch", dyn.}
   ##  --- Sparse Level 4 routines ---
   ##  Description: Compute sparse - sparse matrix multiplication for matrices 
   ##    stored in CSR format.
@@ -2174,7 +2177,7 @@ when not defined(CUSPARSE_H):
                            csrSortedRowPtrB: ptr cint; csrSortedColIndB: ptr cint;
                            descrC: cusparseMatDescr_t; csrSortedRowPtrC: ptr cint;
                            nnzTotalDevHostPtr: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseXcsrgemmNnz", dynlib: libName.}
+      importc: "cusparseXcsrgemmNnz", dyn.}
   proc cusparseScsrgemm*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                         transB: cusparseOperation_t; m: cint; n: cint; k: cint;
                         descrA: cusparseMatDescr_t; nnzA: cint;
@@ -2184,7 +2187,7 @@ when not defined(CUSPARSE_H):
                         csrSortedRowPtrB: ptr cint; csrSortedColIndB: ptr cint;
                         descrC: cusparseMatDescr_t; csrSortedValC: ptr cfloat;
                         csrSortedRowPtrC: ptr cint; csrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrgemm", dynlib: libName.}
+      cdecl, importc: "cusparseScsrgemm", dyn.}
   proc cusparseDcsrgemm*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                         transB: cusparseOperation_t; m: cint; n: cint; k: cint;
                         descrA: cusparseMatDescr_t; nnzA: cint;
@@ -2194,7 +2197,7 @@ when not defined(CUSPARSE_H):
                         csrSortedRowPtrB: ptr cint; csrSortedColIndB: ptr cint;
                         descrC: cusparseMatDescr_t; csrSortedValC: ptr cdouble;
                         csrSortedRowPtrC: ptr cint; csrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrgemm", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrgemm", dyn.}
   proc cusparseCcsrgemm*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                         transB: cusparseOperation_t; m: cint; n: cint; k: cint;
                         descrA: cusparseMatDescr_t; nnzA: cint;
@@ -2204,7 +2207,7 @@ when not defined(CUSPARSE_H):
                         csrSortedRowPtrB: ptr cint; csrSortedColIndB: ptr cint;
                         descrC: cusparseMatDescr_t; csrSortedValC: ptr cuComplex;
                         csrSortedRowPtrC: ptr cint; csrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrgemm", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrgemm", dyn.}
   proc cusparseZcsrgemm*(handle: cusparseHandle_t; transA: cusparseOperation_t;
                         transB: cusparseOperation_t; m: cint; n: cint; k: cint;
                         descrA: cusparseMatDescr_t; nnzA: cint;
@@ -2216,13 +2219,13 @@ when not defined(CUSPARSE_H):
                         descrC: cusparseMatDescr_t;
                         csrSortedValC: ptr cuDoubleComplex;
                         csrSortedRowPtrC: ptr cint; csrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrgemm", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrgemm", dyn.}
   ##  Description: Compute sparse - sparse matrix multiplication for matrices 
   ##    stored in CSR format.
   proc cusparseCreateCsrgemm2Info*(info: ptr csrgemm2Info_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCreateCsrgemm2Info", dynlib: libName.}
+      cdecl, importc: "cusparseCreateCsrgemm2Info", dyn.}
   proc cusparseDestroyCsrgemm2Info*(info: csrgemm2Info_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDestroyCsrgemm2Info", dynlib: libName.}
+      importc: "cusparseDestroyCsrgemm2Info", dyn.}
   proc cusparseScsrgemm2_bufferSizeExt*(handle: cusparseHandle_t; m: cint; n: cint;
                                        k: cint; alpha: ptr cfloat;
                                        descrA: cusparseMatDescr_t; nnzA: cint;
@@ -2237,7 +2240,7 @@ when not defined(CUSPARSE_H):
                                        csrSortedColIndD: ptr cint;
                                        info: csrgemm2Info_t;
                                        pBufferSizeInBytes: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsrgemm2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseScsrgemm2_bufferSizeExt", dyn.}
   proc cusparseDcsrgemm2_bufferSizeExt*(handle: cusparseHandle_t; m: cint; n: cint;
                                        k: cint; alpha: ptr cdouble;
                                        descrA: cusparseMatDescr_t; nnzA: cint;
@@ -2252,7 +2255,7 @@ when not defined(CUSPARSE_H):
                                        csrSortedColIndD: ptr cint;
                                        info: csrgemm2Info_t;
                                        pBufferSizeInBytes: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsrgemm2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseDcsrgemm2_bufferSizeExt", dyn.}
   proc cusparseCcsrgemm2_bufferSizeExt*(handle: cusparseHandle_t; m: cint; n: cint;
                                        k: cint; alpha: ptr cuComplex;
                                        descrA: cusparseMatDescr_t; nnzA: cint;
@@ -2267,7 +2270,7 @@ when not defined(CUSPARSE_H):
                                        csrSortedColIndD: ptr cint;
                                        info: csrgemm2Info_t;
                                        pBufferSizeInBytes: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsrgemm2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseCcsrgemm2_bufferSizeExt", dyn.}
   proc cusparseZcsrgemm2_bufferSizeExt*(handle: cusparseHandle_t; m: cint; n: cint;
                                        k: cint; alpha: ptr cuDoubleComplex;
                                        descrA: cusparseMatDescr_t; nnzA: cint;
@@ -2282,7 +2285,7 @@ when not defined(CUSPARSE_H):
                                        csrSortedColIndD: ptr cint;
                                        info: csrgemm2Info_t;
                                        pBufferSizeInBytes: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrgemm2_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrgemm2_bufferSizeExt", dyn.}
   proc cusparseXcsrgemm2Nnz*(handle: cusparseHandle_t; m: cint; n: cint; k: cint;
                             descrA: cusparseMatDescr_t; nnzA: cint;
                             csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
@@ -2294,7 +2297,7 @@ when not defined(CUSPARSE_H):
                             csrSortedRowPtrC: ptr cint;
                             nnzTotalDevHostPtr: ptr cint; info: csrgemm2Info_t;
                             pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseXcsrgemm2Nnz", dynlib: libName.}
+      importc: "cusparseXcsrgemm2Nnz", dyn.}
   proc cusparseScsrgemm2*(handle: cusparseHandle_t; m: cint; n: cint; k: cint;
                          alpha: ptr cfloat; descrA: cusparseMatDescr_t; nnzA: cint;
                          csrSortedValA: ptr cfloat; csrSortedRowPtrA: ptr cint;
@@ -2307,7 +2310,7 @@ when not defined(CUSPARSE_H):
                          csrSortedValC: ptr cfloat; csrSortedRowPtrC: ptr cint;
                          csrSortedColIndC: ptr cint; info: csrgemm2Info_t;
                          pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseScsrgemm2", dynlib: libName.}
+      importc: "cusparseScsrgemm2", dyn.}
   proc cusparseDcsrgemm2*(handle: cusparseHandle_t; m: cint; n: cint; k: cint;
                          alpha: ptr cdouble; descrA: cusparseMatDescr_t; nnzA: cint;
                          csrSortedValA: ptr cdouble; csrSortedRowPtrA: ptr cint;
@@ -2320,7 +2323,7 @@ when not defined(CUSPARSE_H):
                          csrSortedValC: ptr cdouble; csrSortedRowPtrC: ptr cint;
                          csrSortedColIndC: ptr cint; info: csrgemm2Info_t;
                          pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseDcsrgemm2", dynlib: libName.}
+      importc: "cusparseDcsrgemm2", dyn.}
   proc cusparseCcsrgemm2*(handle: cusparseHandle_t; m: cint; n: cint; k: cint;
                          alpha: ptr cuComplex; descrA: cusparseMatDescr_t;
                          nnzA: cint; csrSortedValA: ptr cuComplex;
@@ -2334,7 +2337,7 @@ when not defined(CUSPARSE_H):
                          csrSortedValC: ptr cuComplex; csrSortedRowPtrC: ptr cint;
                          csrSortedColIndC: ptr cint; info: csrgemm2Info_t;
                          pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseCcsrgemm2", dynlib: libName.}
+      importc: "cusparseCcsrgemm2", dyn.}
   proc cusparseZcsrgemm2*(handle: cusparseHandle_t; m: cint; n: cint; k: cint;
                          alpha: ptr cuDoubleComplex; descrA: cusparseMatDescr_t;
                          nnzA: cint; csrSortedValA: ptr cuDoubleComplex;
@@ -2349,7 +2352,7 @@ when not defined(CUSPARSE_H):
                          csrSortedValC: ptr cuDoubleComplex;
                          csrSortedRowPtrC: ptr cint; csrSortedColIndC: ptr cint;
                          info: csrgemm2Info_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrgemm2", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrgemm2", dyn.}
   ##  Description: Compute sparse - sparse matrix addition of matrices 
   ##    stored in CSR format
   proc cusparseXcsrgeamNnz*(handle: cusparseHandle_t; m: cint; n: cint;
@@ -2359,7 +2362,7 @@ when not defined(CUSPARSE_H):
                            csrSortedRowPtrB: ptr cint; csrSortedColIndB: ptr cint;
                            descrC: cusparseMatDescr_t; csrSortedRowPtrC: ptr cint;
                            nnzTotalDevHostPtr: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseXcsrgeamNnz", dynlib: libName.}
+      importc: "cusparseXcsrgeamNnz", dyn.}
   proc cusparseScsrgeam*(handle: cusparseHandle_t; m: cint; n: cint; alpha: ptr cfloat;
                         descrA: cusparseMatDescr_t; nnzA: cint;
                         csrSortedValA: ptr cfloat; csrSortedRowPtrA: ptr cint;
@@ -2369,7 +2372,7 @@ when not defined(CUSPARSE_H):
                         csrSortedColIndB: ptr cint; descrC: cusparseMatDescr_t;
                         csrSortedValC: ptr cfloat; csrSortedRowPtrC: ptr cint;
                         csrSortedColIndC: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseScsrgeam", dynlib: libName.}
+      importc: "cusparseScsrgeam", dyn.}
   proc cusparseDcsrgeam*(handle: cusparseHandle_t; m: cint; n: cint;
                         alpha: ptr cdouble; descrA: cusparseMatDescr_t; nnzA: cint;
                         csrSortedValA: ptr cdouble; csrSortedRowPtrA: ptr cint;
@@ -2379,7 +2382,7 @@ when not defined(CUSPARSE_H):
                         csrSortedColIndB: ptr cint; descrC: cusparseMatDescr_t;
                         csrSortedValC: ptr cdouble; csrSortedRowPtrC: ptr cint;
                         csrSortedColIndC: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseDcsrgeam", dynlib: libName.}
+      importc: "cusparseDcsrgeam", dyn.}
   proc cusparseCcsrgeam*(handle: cusparseHandle_t; m: cint; n: cint;
                         alpha: ptr cuComplex; descrA: cusparseMatDescr_t; nnzA: cint;
                         csrSortedValA: ptr cuComplex; csrSortedRowPtrA: ptr cint;
@@ -2389,7 +2392,7 @@ when not defined(CUSPARSE_H):
                         csrSortedColIndB: ptr cint; descrC: cusparseMatDescr_t;
                         csrSortedValC: ptr cuComplex; csrSortedRowPtrC: ptr cint;
                         csrSortedColIndC: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseCcsrgeam", dynlib: libName.}
+      importc: "cusparseCcsrgeam", dyn.}
   proc cusparseZcsrgeam*(handle: cusparseHandle_t; m: cint; n: cint;
                         alpha: ptr cuDoubleComplex; descrA: cusparseMatDescr_t;
                         nnzA: cint; csrSortedValA: ptr cuDoubleComplex;
@@ -2400,7 +2403,7 @@ when not defined(CUSPARSE_H):
                         descrC: cusparseMatDescr_t;
                         csrSortedValC: ptr cuDoubleComplex;
                         csrSortedRowPtrC: ptr cint; csrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsrgeam", dynlib: libName.}
+      cdecl, importc: "cusparseZcsrgeam", dyn.}
   ##  --- Sparse Matrix Reorderings ---
   ##  Description: Find an approximate coloring of a matrix stored in CSR format.
   proc cusparseScsrcolor*(handle: cusparseHandle_t; m: cint; nnz: cint;
@@ -2409,21 +2412,21 @@ when not defined(CUSPARSE_H):
                          fractionToColor: ptr cfloat; ncolors: ptr cint;
                          coloring: ptr cint; reordering: ptr cint;
                          info: cusparseColorInfo_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseScsrcolor", dynlib: libName.}
+      importc: "cusparseScsrcolor", dyn.}
   proc cusparseDcsrcolor*(handle: cusparseHandle_t; m: cint; nnz: cint;
                          descrA: cusparseMatDescr_t; csrSortedValA: ptr cdouble;
                          csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                          fractionToColor: ptr cdouble; ncolors: ptr cint;
                          coloring: ptr cint; reordering: ptr cint;
                          info: cusparseColorInfo_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseDcsrcolor", dynlib: libName.}
+      importc: "cusparseDcsrcolor", dyn.}
   proc cusparseCcsrcolor*(handle: cusparseHandle_t; m: cint; nnz: cint;
                          descrA: cusparseMatDescr_t; csrSortedValA: ptr cuComplex;
                          csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                          fractionToColor: ptr cfloat; ncolors: ptr cint;
                          coloring: ptr cint; reordering: ptr cint;
                          info: cusparseColorInfo_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseCcsrcolor", dynlib: libName.}
+      importc: "cusparseCcsrcolor", dyn.}
   proc cusparseZcsrcolor*(handle: cusparseHandle_t; m: cint; nnz: cint;
                          descrA: cusparseMatDescr_t;
                          csrSortedValA: ptr cuDoubleComplex;
@@ -2431,26 +2434,26 @@ when not defined(CUSPARSE_H):
                          fractionToColor: ptr cdouble; ncolors: ptr cint;
                          coloring: ptr cint; reordering: ptr cint;
                          info: cusparseColorInfo_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseZcsrcolor", dynlib: libName.}
+      importc: "cusparseZcsrcolor", dyn.}
   ##  --- Sparse Format Conversion ---
   ##  Description: This routine finds the total number of non-zero elements and 
   ##    the number of non-zero elements per row or column in the dense matrix A.
   proc cusparseSnnz*(handle: cusparseHandle_t; dirA: cusparseDirection_t; m: cint;
                     n: cint; descrA: cusparseMatDescr_t; A: ptr cfloat; lda: cint;
                     nnzPerRowCol: ptr cint; nnzTotalDevHostPtr: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseSnnz", dynlib: libName.}
+      cdecl, importc: "cusparseSnnz", dyn.}
   proc cusparseDnnz*(handle: cusparseHandle_t; dirA: cusparseDirection_t; m: cint;
                     n: cint; descrA: cusparseMatDescr_t; A: ptr cdouble; lda: cint;
                     nnzPerRowCol: ptr cint; nnzTotalDevHostPtr: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDnnz", dynlib: libName.}
+      cdecl, importc: "cusparseDnnz", dyn.}
   proc cusparseCnnz*(handle: cusparseHandle_t; dirA: cusparseDirection_t; m: cint;
                     n: cint; descrA: cusparseMatDescr_t; A: ptr cuComplex; lda: cint;
                     nnzPerRowCol: ptr cint; nnzTotalDevHostPtr: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCnnz", dynlib: libName.}
+      cdecl, importc: "cusparseCnnz", dyn.}
   proc cusparseZnnz*(handle: cusparseHandle_t; dirA: cusparseDirection_t; m: cint;
                     n: cint; descrA: cusparseMatDescr_t; A: ptr cuDoubleComplex;
                     lda: cint; nnzPerRowCol: ptr cint; nnzTotalDevHostPtr: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZnnz", dynlib: libName.}
+      cdecl, importc: "cusparseZnnz", dyn.}
   ##  --- Sparse Format Conversion ---
   ##  Description: This routine finds the total number of non-zero elements and 
   ##    the number of non-zero elements per row in a noncompressed csr matrix A.
@@ -2458,23 +2461,23 @@ when not defined(CUSPARSE_H):
                              descr: cusparseMatDescr_t; values: ptr cfloat;
                              rowPtr: ptr cint; nnzPerRow: ptr cint;
                              nnzTotal: ptr cint; tol: cfloat): cusparseStatus_t {.
-      cdecl, importc: "cusparseSnnz_compress", dynlib: libName.}
+      cdecl, importc: "cusparseSnnz_compress", dyn.}
   proc cusparseDnnz_compress*(handle: cusparseHandle_t; m: cint;
                              descr: cusparseMatDescr_t; values: ptr cdouble;
                              rowPtr: ptr cint; nnzPerRow: ptr cint;
                              nnzTotal: ptr cint; tol: cdouble): cusparseStatus_t {.
-      cdecl, importc: "cusparseDnnz_compress", dynlib: libName.}
+      cdecl, importc: "cusparseDnnz_compress", dyn.}
   proc cusparseCnnz_compress*(handle: cusparseHandle_t; m: cint;
                              descr: cusparseMatDescr_t; values: ptr cuComplex;
                              rowPtr: ptr cint; nnzPerRow: ptr cint;
                              nnzTotal: ptr cint; tol: cuComplex): cusparseStatus_t {.
-      cdecl, importc: "cusparseCnnz_compress", dynlib: libName.}
+      cdecl, importc: "cusparseCnnz_compress", dyn.}
   proc cusparseZnnz_compress*(handle: cusparseHandle_t; m: cint;
                              descr: cusparseMatDescr_t;
                              values: ptr cuDoubleComplex; rowPtr: ptr cint;
                              nnzPerRow: ptr cint; nnzTotal: ptr cint;
                              tol: cuDoubleComplex): cusparseStatus_t {.cdecl,
-      importc: "cusparseZnnz_compress", dynlib: libName.}
+      importc: "cusparseZnnz_compress", dyn.}
   ##  Description: This routine takes as input a csr form where the values may have 0 elements
   ##    and compresses it to return a csr form with no zeros.
   proc cusparseScsr2csr_compress*(handle: cusparseHandle_t; m: cint; n: cint;
@@ -2482,14 +2485,14 @@ when not defined(CUSPARSE_H):
                                  inColInd: ptr cint; inRowPtr: ptr cint; inNnz: cint;
                                  nnzPerRow: ptr cint; outVal: ptr cfloat;
                                  outColInd: ptr cint; outRowPtr: ptr cint; tol: cfloat): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsr2csr_compress", dynlib: libName.}
+      cdecl, importc: "cusparseScsr2csr_compress", dyn.}
   proc cusparseDcsr2csr_compress*(handle: cusparseHandle_t; m: cint; n: cint;
                                  descra: cusparseMatDescr_t; inVal: ptr cdouble;
                                  inColInd: ptr cint; inRowPtr: ptr cint; inNnz: cint;
                                  nnzPerRow: ptr cint; outVal: ptr cdouble;
                                  outColInd: ptr cint; outRowPtr: ptr cint;
                                  tol: cdouble): cusparseStatus_t {.cdecl,
-      importc: "cusparseDcsr2csr_compress", dynlib: libName.}
+      importc: "cusparseDcsr2csr_compress", dyn.}
     ## number of rows
     ## csr values array-the elements which are below a certain tolerance will be remvoed
     ## corresponding input noncompressed row pointer
@@ -2500,7 +2503,7 @@ when not defined(CUSPARSE_H):
                                  nnzPerRow: ptr cint; outVal: ptr cuComplex;
                                  outColInd: ptr cint; outRowPtr: ptr cint;
                                  tol: cuComplex): cusparseStatus_t {.cdecl,
-      importc: "cusparseCcsr2csr_compress", dynlib: libName.}
+      importc: "cusparseCcsr2csr_compress", dyn.}
     ## number of rows
     ## csr values array-the elements which are below a certain tolerance will be remvoed
     ## corresponding input noncompressed row pointer
@@ -2512,7 +2515,7 @@ when not defined(CUSPARSE_H):
                                  nnzPerRow: ptr cint; outVal: ptr cuDoubleComplex;
                                  outColInd: ptr cint; outRowPtr: ptr cint;
                                  tol: cuDoubleComplex): cusparseStatus_t {.cdecl,
-      importc: "cusparseZcsr2csr_compress", dynlib: libName.}
+      importc: "cusparseZcsr2csr_compress", dyn.}
     ## number of rows
     ## csr values array-the elements which are below a certain tolerance will be remvoed
     ## corresponding input noncompressed row pointer
@@ -2524,46 +2527,46 @@ when not defined(CUSPARSE_H):
                           descrA: cusparseMatDescr_t; A: ptr cfloat; lda: cint;
                           nnzPerRow: ptr cint; csrSortedValA: ptr cfloat;
                           csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseSdense2csr", dynlib: libName.}
+      cdecl, importc: "cusparseSdense2csr", dyn.}
   proc cusparseDdense2csr*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t; A: ptr cdouble; lda: cint;
                           nnzPerRow: ptr cint; csrSortedValA: ptr cdouble;
                           csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDdense2csr", dynlib: libName.}
+      cdecl, importc: "cusparseDdense2csr", dyn.}
   proc cusparseCdense2csr*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t; A: ptr cuComplex; lda: cint;
                           nnzPerRow: ptr cint; csrSortedValA: ptr cuComplex;
                           csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCdense2csr", dynlib: libName.}
+      cdecl, importc: "cusparseCdense2csr", dyn.}
   proc cusparseZdense2csr*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t; A: ptr cuDoubleComplex;
                           lda: cint; nnzPerRow: ptr cint;
                           csrSortedValA: ptr cuDoubleComplex;
                           csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZdense2csr", dynlib: libName.}
+      cdecl, importc: "cusparseZdense2csr", dyn.}
   ##  Description: This routine converts a sparse matrix in CSR storage format
   ##    to a dense matrix.
   proc cusparseScsr2dense*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t; csrSortedValA: ptr cfloat;
                           csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                           A: ptr cfloat; lda: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseScsr2dense", dynlib: libName.}
+      importc: "cusparseScsr2dense", dyn.}
   proc cusparseDcsr2dense*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t; csrSortedValA: ptr cdouble;
                           csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                           A: ptr cdouble; lda: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseDcsr2dense", dynlib: libName.}
+      importc: "cusparseDcsr2dense", dyn.}
   proc cusparseCcsr2dense*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t;
                           csrSortedValA: ptr cuComplex; csrSortedRowPtrA: ptr cint;
                           csrSortedColIndA: ptr cint; A: ptr cuComplex; lda: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsr2dense", dynlib: libName.}
+      cdecl, importc: "cusparseCcsr2dense", dyn.}
   proc cusparseZcsr2dense*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t;
                           csrSortedValA: ptr cuDoubleComplex;
                           csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                           A: ptr cuDoubleComplex; lda: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsr2dense", dynlib: libName.}
+      cdecl, importc: "cusparseZcsr2dense", dyn.}
   ##  Description: This routine converts a dense matrix to a sparse matrix 
   ##    in the CSC storage format, using the information computed by the 
   ##    nnz routine.
@@ -2571,60 +2574,60 @@ when not defined(CUSPARSE_H):
                           descrA: cusparseMatDescr_t; A: ptr cfloat; lda: cint;
                           nnzPerCol: ptr cint; cscSortedValA: ptr cfloat;
                           cscSortedRowIndA: ptr cint; cscSortedColPtrA: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseSdense2csc", dynlib: libName.}
+      cdecl, importc: "cusparseSdense2csc", dyn.}
   proc cusparseDdense2csc*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t; A: ptr cdouble; lda: cint;
                           nnzPerCol: ptr cint; cscSortedValA: ptr cdouble;
                           cscSortedRowIndA: ptr cint; cscSortedColPtrA: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDdense2csc", dynlib: libName.}
+      cdecl, importc: "cusparseDdense2csc", dyn.}
   proc cusparseCdense2csc*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t; A: ptr cuComplex; lda: cint;
                           nnzPerCol: ptr cint; cscSortedValA: ptr cuComplex;
                           cscSortedRowIndA: ptr cint; cscSortedColPtrA: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCdense2csc", dynlib: libName.}
+      cdecl, importc: "cusparseCdense2csc", dyn.}
   proc cusparseZdense2csc*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t; A: ptr cuDoubleComplex;
                           lda: cint; nnzPerCol: ptr cint;
                           cscSortedValA: ptr cuDoubleComplex;
                           cscSortedRowIndA: ptr cint; cscSortedColPtrA: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZdense2csc", dynlib: libName.}
+      cdecl, importc: "cusparseZdense2csc", dyn.}
   ##  Description: This routine converts a sparse matrix in CSC storage format
   ##    to a dense matrix.
   proc cusparseScsc2dense*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t; cscSortedValA: ptr cfloat;
                           cscSortedRowIndA: ptr cint; cscSortedColPtrA: ptr cint;
                           A: ptr cfloat; lda: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseScsc2dense", dynlib: libName.}
+      importc: "cusparseScsc2dense", dyn.}
   proc cusparseDcsc2dense*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t; cscSortedValA: ptr cdouble;
                           cscSortedRowIndA: ptr cint; cscSortedColPtrA: ptr cint;
                           A: ptr cdouble; lda: cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseDcsc2dense", dynlib: libName.}
+      importc: "cusparseDcsc2dense", dyn.}
   proc cusparseCcsc2dense*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t;
                           cscSortedValA: ptr cuComplex; cscSortedRowIndA: ptr cint;
                           cscSortedColPtrA: ptr cint; A: ptr cuComplex; lda: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsc2dense", dynlib: libName.}
+      cdecl, importc: "cusparseCcsc2dense", dyn.}
   proc cusparseZcsc2dense*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t;
                           cscSortedValA: ptr cuDoubleComplex;
                           cscSortedRowIndA: ptr cint; cscSortedColPtrA: ptr cint;
                           A: ptr cuDoubleComplex; lda: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsc2dense", dynlib: libName.}
+      cdecl, importc: "cusparseZcsc2dense", dyn.}
   ##  Description: This routine compresses the indecis of rows or columns.
   ##    It can be interpreted as a conversion from COO to CSR sparse storage
   ##    format.
   proc cusparseXcoo2csr*(handle: cusparseHandle_t; cooRowInd: ptr cint; nnz: cint;
                         m: cint; csrSortedRowPtr: ptr cint;
                         idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseXcoo2csr", dynlib: libName.}
+      importc: "cusparseXcoo2csr", dyn.}
   ##  Description: This routine uncompresses the indecis of rows or columns.
   ##    It can be interpreted as a conversion from CSR to COO sparse storage
   ##    format.
   proc cusparseXcsr2coo*(handle: cusparseHandle_t; csrSortedRowPtr: ptr cint;
                         nnz: cint; m: cint; cooRowInd: ptr cint;
                         idxBase: cusparseIndexBase_t): cusparseStatus_t {.cdecl,
-      importc: "cusparseXcsr2coo", dynlib: libName.}
+      importc: "cusparseXcsr2coo", dyn.}
   ##  Description: This routine converts a matrix from CSR to CSC sparse 
   ##    storage format. The resulting matrix can be re-interpreted as a 
   ##    transpose of the original matrix in CSR storage format.
@@ -2635,32 +2638,32 @@ when not defined(CUSPARSE_H):
                          cscSortedRowInd: ptr cint; cscSortedColPtr: ptr cint;
                          copyValues: cusparseAction_t;
                          idxBase: cusparseIndexBase_t; executiontype: cudaDataType): cusparseStatus_t {.
-      cdecl, importc: "cusparseCsr2cscEx", dynlib: libName.}
+      cdecl, importc: "cusparseCsr2cscEx", dyn.}
   proc cusparseScsr2csc*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                         csrSortedVal: ptr cfloat; csrSortedRowPtr: ptr cint;
                         csrSortedColInd: ptr cint; cscSortedVal: ptr cfloat;
                         cscSortedRowInd: ptr cint; cscSortedColPtr: ptr cint;
                         copyValues: cusparseAction_t; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsr2csc", dynlib: libName.}
+      cdecl, importc: "cusparseScsr2csc", dyn.}
   proc cusparseDcsr2csc*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                         csrSortedVal: ptr cdouble; csrSortedRowPtr: ptr cint;
                         csrSortedColInd: ptr cint; cscSortedVal: ptr cdouble;
                         cscSortedRowInd: ptr cint; cscSortedColPtr: ptr cint;
                         copyValues: cusparseAction_t; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsr2csc", dynlib: libName.}
+      cdecl, importc: "cusparseDcsr2csc", dyn.}
   proc cusparseCcsr2csc*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                         csrSortedVal: ptr cuComplex; csrSortedRowPtr: ptr cint;
                         csrSortedColInd: ptr cint; cscSortedVal: ptr cuComplex;
                         cscSortedRowInd: ptr cint; cscSortedColPtr: ptr cint;
                         copyValues: cusparseAction_t; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsr2csc", dynlib: libName.}
+      cdecl, importc: "cusparseCcsr2csc", dyn.}
   proc cusparseZcsr2csc*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                         csrSortedVal: ptr cuDoubleComplex;
                         csrSortedRowPtr: ptr cint; csrSortedColInd: ptr cint;
                         cscSortedVal: ptr cuDoubleComplex;
                         cscSortedRowInd: ptr cint; cscSortedColPtr: ptr cint;
                         copyValues: cusparseAction_t; idxBase: cusparseIndexBase_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsr2csc", dynlib: libName.}
+      cdecl, importc: "cusparseZcsr2csc", dyn.}
   ##  Description: This routine converts a dense matrix to a sparse matrix 
   ##    in HYB storage format.
   proc cusparseSdense2hyb*(handle: cusparseHandle_t; m: cint; n: cint;
@@ -2668,39 +2671,39 @@ when not defined(CUSPARSE_H):
                           nnzPerRow: ptr cint; hybA: cusparseHybMat_t;
                           userEllWidth: cint;
                           partitionType: cusparseHybPartition_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseSdense2hyb", dynlib: libName.}
+      cdecl, importc: "cusparseSdense2hyb", dyn.}
   proc cusparseDdense2hyb*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t; A: ptr cdouble; lda: cint;
                           nnzPerRow: ptr cint; hybA: cusparseHybMat_t;
                           userEllWidth: cint;
                           partitionType: cusparseHybPartition_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDdense2hyb", dynlib: libName.}
+      cdecl, importc: "cusparseDdense2hyb", dyn.}
   proc cusparseCdense2hyb*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t; A: ptr cuComplex; lda: cint;
                           nnzPerRow: ptr cint; hybA: cusparseHybMat_t;
                           userEllWidth: cint;
                           partitionType: cusparseHybPartition_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCdense2hyb", dynlib: libName.}
+      cdecl, importc: "cusparseCdense2hyb", dyn.}
   proc cusparseZdense2hyb*(handle: cusparseHandle_t; m: cint; n: cint;
                           descrA: cusparseMatDescr_t; A: ptr cuDoubleComplex;
                           lda: cint; nnzPerRow: ptr cint; hybA: cusparseHybMat_t;
                           userEllWidth: cint;
                           partitionType: cusparseHybPartition_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseZdense2hyb", dynlib: libName.}
+      cdecl, importc: "cusparseZdense2hyb", dyn.}
   ##  Description: This routine converts a sparse matrix in HYB storage format
   ##    to a dense matrix.
   proc cusparseShyb2dense*(handle: cusparseHandle_t; descrA: cusparseMatDescr_t;
                           hybA: cusparseHybMat_t; A: ptr cfloat; lda: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseShyb2dense", dynlib: libName.}
+      cdecl, importc: "cusparseShyb2dense", dyn.}
   proc cusparseDhyb2dense*(handle: cusparseHandle_t; descrA: cusparseMatDescr_t;
                           hybA: cusparseHybMat_t; A: ptr cdouble; lda: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDhyb2dense", dynlib: libName.}
+      cdecl, importc: "cusparseDhyb2dense", dyn.}
   proc cusparseChyb2dense*(handle: cusparseHandle_t; descrA: cusparseMatDescr_t;
                           hybA: cusparseHybMat_t; A: ptr cuComplex; lda: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseChyb2dense", dynlib: libName.}
+      cdecl, importc: "cusparseChyb2dense", dyn.}
   proc cusparseZhyb2dense*(handle: cusparseHandle_t; descrA: cusparseMatDescr_t;
                           hybA: cusparseHybMat_t; A: ptr cuDoubleComplex; lda: cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZhyb2dense", dynlib: libName.}
+      cdecl, importc: "cusparseZhyb2dense", dyn.}
   ##  Description: This routine converts a sparse matrix in CSR storage format
   ##    to a sparse matrix in HYB storage format.
   proc cusparseScsr2hyb*(handle: cusparseHandle_t; m: cint; n: cint;
@@ -2708,45 +2711,45 @@ when not defined(CUSPARSE_H):
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                         hybA: cusparseHybMat_t; userEllWidth: cint;
                         partitionType: cusparseHybPartition_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsr2hyb", dynlib: libName.}
+      cdecl, importc: "cusparseScsr2hyb", dyn.}
   proc cusparseDcsr2hyb*(handle: cusparseHandle_t; m: cint; n: cint;
                         descrA: cusparseMatDescr_t; csrSortedValA: ptr cdouble;
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                         hybA: cusparseHybMat_t; userEllWidth: cint;
                         partitionType: cusparseHybPartition_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsr2hyb", dynlib: libName.}
+      cdecl, importc: "cusparseDcsr2hyb", dyn.}
   proc cusparseCcsr2hyb*(handle: cusparseHandle_t; m: cint; n: cint;
                         descrA: cusparseMatDescr_t; csrSortedValA: ptr cuComplex;
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                         hybA: cusparseHybMat_t; userEllWidth: cint;
                         partitionType: cusparseHybPartition_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsr2hyb", dynlib: libName.}
+      cdecl, importc: "cusparseCcsr2hyb", dyn.}
   proc cusparseZcsr2hyb*(handle: cusparseHandle_t; m: cint; n: cint;
                         descrA: cusparseMatDescr_t;
                         csrSortedValA: ptr cuDoubleComplex;
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                         hybA: cusparseHybMat_t; userEllWidth: cint;
                         partitionType: cusparseHybPartition_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsr2hyb", dynlib: libName.}
+      cdecl, importc: "cusparseZcsr2hyb", dyn.}
   ##  Description: This routine converts a sparse matrix in HYB storage format
   ##    to a sparse matrix in CSR storage format.
   proc cusparseShyb2csr*(handle: cusparseHandle_t; descrA: cusparseMatDescr_t;
                         hybA: cusparseHybMat_t; csrSortedValA: ptr cfloat;
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseShyb2csr", dynlib: libName.}
+      cdecl, importc: "cusparseShyb2csr", dyn.}
   proc cusparseDhyb2csr*(handle: cusparseHandle_t; descrA: cusparseMatDescr_t;
                         hybA: cusparseHybMat_t; csrSortedValA: ptr cdouble;
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDhyb2csr", dynlib: libName.}
+      cdecl, importc: "cusparseDhyb2csr", dyn.}
   proc cusparseChyb2csr*(handle: cusparseHandle_t; descrA: cusparseMatDescr_t;
                         hybA: cusparseHybMat_t; csrSortedValA: ptr cuComplex;
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseChyb2csr", dynlib: libName.}
+      cdecl, importc: "cusparseChyb2csr", dyn.}
   proc cusparseZhyb2csr*(handle: cusparseHandle_t; descrA: cusparseMatDescr_t;
                         hybA: cusparseHybMat_t;
                         csrSortedValA: ptr cuDoubleComplex;
                         csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZhyb2csr", dynlib: libName.}
+      cdecl, importc: "cusparseZhyb2csr", dyn.}
   ##  Description: This routine converts a sparse matrix in CSC storage format
   ##    to a sparse matrix in HYB storage format.
   proc cusparseScsc2hyb*(handle: cusparseHandle_t; m: cint; n: cint;
@@ -2754,44 +2757,44 @@ when not defined(CUSPARSE_H):
                         cscSortedRowIndA: ptr cint; cscSortedColPtrA: ptr cint;
                         hybA: cusparseHybMat_t; userEllWidth: cint;
                         partitionType: cusparseHybPartition_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsc2hyb", dynlib: libName.}
+      cdecl, importc: "cusparseScsc2hyb", dyn.}
   proc cusparseDcsc2hyb*(handle: cusparseHandle_t; m: cint; n: cint;
                         descrA: cusparseMatDescr_t; cscSortedValA: ptr cdouble;
                         cscSortedRowIndA: ptr cint; cscSortedColPtrA: ptr cint;
                         hybA: cusparseHybMat_t; userEllWidth: cint;
                         partitionType: cusparseHybPartition_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsc2hyb", dynlib: libName.}
+      cdecl, importc: "cusparseDcsc2hyb", dyn.}
   proc cusparseCcsc2hyb*(handle: cusparseHandle_t; m: cint; n: cint;
                         descrA: cusparseMatDescr_t; cscSortedValA: ptr cuComplex;
                         cscSortedRowIndA: ptr cint; cscSortedColPtrA: ptr cint;
                         hybA: cusparseHybMat_t; userEllWidth: cint;
                         partitionType: cusparseHybPartition_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsc2hyb", dynlib: libName.}
+      cdecl, importc: "cusparseCcsc2hyb", dyn.}
   proc cusparseZcsc2hyb*(handle: cusparseHandle_t; m: cint; n: cint;
                         descrA: cusparseMatDescr_t;
                         cscSortedValA: ptr cuDoubleComplex;
                         cscSortedRowIndA: ptr cint; cscSortedColPtrA: ptr cint;
                         hybA: cusparseHybMat_t; userEllWidth: cint;
                         partitionType: cusparseHybPartition_t): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsc2hyb", dynlib: libName.}
+      cdecl, importc: "cusparseZcsc2hyb", dyn.}
   ##  Description: This routine converts a sparse matrix in HYB storage format
   ##    to a sparse matrix in CSC storage format.
   proc cusparseShyb2csc*(handle: cusparseHandle_t; descrA: cusparseMatDescr_t;
                         hybA: cusparseHybMat_t; cscSortedVal: ptr cfloat;
                         cscSortedRowInd: ptr cint; cscSortedColPtr: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseShyb2csc", dynlib: libName.}
+      cdecl, importc: "cusparseShyb2csc", dyn.}
   proc cusparseDhyb2csc*(handle: cusparseHandle_t; descrA: cusparseMatDescr_t;
                         hybA: cusparseHybMat_t; cscSortedVal: ptr cdouble;
                         cscSortedRowInd: ptr cint; cscSortedColPtr: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDhyb2csc", dynlib: libName.}
+      cdecl, importc: "cusparseDhyb2csc", dyn.}
   proc cusparseChyb2csc*(handle: cusparseHandle_t; descrA: cusparseMatDescr_t;
                         hybA: cusparseHybMat_t; cscSortedVal: ptr cuComplex;
                         cscSortedRowInd: ptr cint; cscSortedColPtr: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseChyb2csc", dynlib: libName.}
+      cdecl, importc: "cusparseChyb2csc", dyn.}
   proc cusparseZhyb2csc*(handle: cusparseHandle_t; descrA: cusparseMatDescr_t;
                         hybA: cusparseHybMat_t; cscSortedVal: ptr cuDoubleComplex;
                         cscSortedRowInd: ptr cint; cscSortedColPtr: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZhyb2csc", dynlib: libName.}
+      cdecl, importc: "cusparseZhyb2csc", dyn.}
   ##  Description: This routine converts a sparse matrix in CSR storage format
   ##    to a sparse matrix in block-CSR storage format.
   proc cusparseXcsr2bsrNnz*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
@@ -2799,28 +2802,28 @@ when not defined(CUSPARSE_H):
                            csrSortedRowPtrA: ptr cint; csrSortedColIndA: ptr cint;
                            blockDim: cint; descrC: cusparseMatDescr_t;
                            bsrSortedRowPtrC: ptr cint; nnzTotalDevHostPtr: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseXcsr2bsrNnz", dynlib: libName.}
+      cdecl, importc: "cusparseXcsr2bsrNnz", dyn.}
   proc cusparseScsr2bsr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                         m: cint; n: cint; descrA: cusparseMatDescr_t;
                         csrSortedValA: ptr cfloat; csrSortedRowPtrA: ptr cint;
                         csrSortedColIndA: ptr cint; blockDim: cint;
                         descrC: cusparseMatDescr_t; bsrSortedValC: ptr cfloat;
                         bsrSortedRowPtrC: ptr cint; bsrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsr2bsr", dynlib: libName.}
+      cdecl, importc: "cusparseScsr2bsr", dyn.}
   proc cusparseDcsr2bsr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                         m: cint; n: cint; descrA: cusparseMatDescr_t;
                         csrSortedValA: ptr cdouble; csrSortedRowPtrA: ptr cint;
                         csrSortedColIndA: ptr cint; blockDim: cint;
                         descrC: cusparseMatDescr_t; bsrSortedValC: ptr cdouble;
                         bsrSortedRowPtrC: ptr cint; bsrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsr2bsr", dynlib: libName.}
+      cdecl, importc: "cusparseDcsr2bsr", dyn.}
   proc cusparseCcsr2bsr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                         m: cint; n: cint; descrA: cusparseMatDescr_t;
                         csrSortedValA: ptr cuComplex; csrSortedRowPtrA: ptr cint;
                         csrSortedColIndA: ptr cint; blockDim: cint;
                         descrC: cusparseMatDescr_t; bsrSortedValC: ptr cuComplex;
                         bsrSortedRowPtrC: ptr cint; bsrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsr2bsr", dynlib: libName.}
+      cdecl, importc: "cusparseCcsr2bsr", dyn.}
   proc cusparseZcsr2bsr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                         m: cint; n: cint; descrA: cusparseMatDescr_t;
                         csrSortedValA: ptr cuDoubleComplex;
@@ -2828,7 +2831,7 @@ when not defined(CUSPARSE_H):
                         blockDim: cint; descrC: cusparseMatDescr_t;
                         bsrSortedValC: ptr cuDoubleComplex;
                         bsrSortedRowPtrC: ptr cint; bsrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsr2bsr", dynlib: libName.}
+      cdecl, importc: "cusparseZcsr2bsr", dyn.}
   ##  Description: This routine converts a sparse matrix in block-CSR storage format
   ##    to a sparse matrix in CSR storage format.
   proc cusparseSbsr2csr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
@@ -2837,21 +2840,21 @@ when not defined(CUSPARSE_H):
                         bsrSortedColIndA: ptr cint; blockDim: cint;
                         descrC: cusparseMatDescr_t; csrSortedValC: ptr cfloat;
                         csrSortedRowPtrC: ptr cint; csrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseSbsr2csr", dynlib: libName.}
+      cdecl, importc: "cusparseSbsr2csr", dyn.}
   proc cusparseDbsr2csr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                         mb: cint; nb: cint; descrA: cusparseMatDescr_t;
                         bsrSortedValA: ptr cdouble; bsrSortedRowPtrA: ptr cint;
                         bsrSortedColIndA: ptr cint; blockDim: cint;
                         descrC: cusparseMatDescr_t; csrSortedValC: ptr cdouble;
                         csrSortedRowPtrC: ptr cint; csrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDbsr2csr", dynlib: libName.}
+      cdecl, importc: "cusparseDbsr2csr", dyn.}
   proc cusparseCbsr2csr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                         mb: cint; nb: cint; descrA: cusparseMatDescr_t;
                         bsrSortedValA: ptr cuComplex; bsrSortedRowPtrA: ptr cint;
                         bsrSortedColIndA: ptr cint; blockDim: cint;
                         descrC: cusparseMatDescr_t; csrSortedValC: ptr cuComplex;
                         csrSortedRowPtrC: ptr cint; csrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCbsr2csr", dynlib: libName.}
+      cdecl, importc: "cusparseCbsr2csr", dyn.}
   proc cusparseZbsr2csr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                         mb: cint; nb: cint; descrA: cusparseMatDescr_t;
                         bsrSortedValA: ptr cuDoubleComplex;
@@ -2859,7 +2862,7 @@ when not defined(CUSPARSE_H):
                         blockDim: cint; descrC: cusparseMatDescr_t;
                         csrSortedValC: ptr cuDoubleComplex;
                         csrSortedRowPtrC: ptr cint; csrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZbsr2csr", dynlib: libName.}
+      cdecl, importc: "cusparseZbsr2csr", dyn.}
   ##  Description: This routine converts a sparse matrix in general block-CSR storage format
   ##    to a sparse matrix in general block-CSC storage format.
   proc cusparseSgebsr2gebsc_bufferSize*(handle: cusparseHandle_t; mb: cint; nb: cint;
@@ -2868,21 +2871,21 @@ when not defined(CUSPARSE_H):
                                        bsrSortedColInd: ptr cint;
                                        rowBlockDim: cint; colBlockDim: cint;
                                        pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseSgebsr2gebsc_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseSgebsr2gebsc_bufferSize", dyn.}
   proc cusparseDgebsr2gebsc_bufferSize*(handle: cusparseHandle_t; mb: cint; nb: cint;
                                        nnzb: cint; bsrSortedVal: ptr cdouble;
                                        bsrSortedRowPtr: ptr cint;
                                        bsrSortedColInd: ptr cint;
                                        rowBlockDim: cint; colBlockDim: cint;
                                        pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDgebsr2gebsc_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseDgebsr2gebsc_bufferSize", dyn.}
   proc cusparseCgebsr2gebsc_bufferSize*(handle: cusparseHandle_t; mb: cint; nb: cint;
                                        nnzb: cint; bsrSortedVal: ptr cuComplex;
                                        bsrSortedRowPtr: ptr cint;
                                        bsrSortedColInd: ptr cint;
                                        rowBlockDim: cint; colBlockDim: cint;
                                        pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCgebsr2gebsc_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseCgebsr2gebsc_bufferSize", dyn.}
   proc cusparseZgebsr2gebsc_bufferSize*(handle: cusparseHandle_t; mb: cint; nb: cint;
                                        nnzb: cint;
                                        bsrSortedVal: ptr cuDoubleComplex;
@@ -2890,27 +2893,27 @@ when not defined(CUSPARSE_H):
                                        bsrSortedColInd: ptr cint;
                                        rowBlockDim: cint; colBlockDim: cint;
                                        pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZgebsr2gebsc_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseZgebsr2gebsc_bufferSize", dyn.}
   proc cusparseSgebsr2gebsc_bufferSizeExt*(handle: cusparseHandle_t; mb: cint;
       nb: cint; nnzb: cint; bsrSortedVal: ptr cfloat; bsrSortedRowPtr: ptr cint;
       bsrSortedColInd: ptr cint; rowBlockDim: cint; colBlockDim: cint;
       pBufferSize: ptr csize): cusparseStatus_t {.cdecl,
-      importc: "cusparseSgebsr2gebsc_bufferSizeExt", dynlib: libName.}
+      importc: "cusparseSgebsr2gebsc_bufferSizeExt", dyn.}
   proc cusparseDgebsr2gebsc_bufferSizeExt*(handle: cusparseHandle_t; mb: cint;
       nb: cint; nnzb: cint; bsrSortedVal: ptr cdouble; bsrSortedRowPtr: ptr cint;
       bsrSortedColInd: ptr cint; rowBlockDim: cint; colBlockDim: cint;
       pBufferSize: ptr csize): cusparseStatus_t {.cdecl,
-      importc: "cusparseDgebsr2gebsc_bufferSizeExt", dynlib: libName.}
+      importc: "cusparseDgebsr2gebsc_bufferSizeExt", dyn.}
   proc cusparseCgebsr2gebsc_bufferSizeExt*(handle: cusparseHandle_t; mb: cint;
       nb: cint; nnzb: cint; bsrSortedVal: ptr cuComplex; bsrSortedRowPtr: ptr cint;
       bsrSortedColInd: ptr cint; rowBlockDim: cint; colBlockDim: cint;
       pBufferSize: ptr csize): cusparseStatus_t {.cdecl,
-      importc: "cusparseCgebsr2gebsc_bufferSizeExt", dynlib: libName.}
+      importc: "cusparseCgebsr2gebsc_bufferSizeExt", dyn.}
   proc cusparseZgebsr2gebsc_bufferSizeExt*(handle: cusparseHandle_t; mb: cint;
       nb: cint; nnzb: cint; bsrSortedVal: ptr cuDoubleComplex;
       bsrSortedRowPtr: ptr cint; bsrSortedColInd: ptr cint; rowBlockDim: cint;
       colBlockDim: cint; pBufferSize: ptr csize): cusparseStatus_t {.cdecl,
-      importc: "cusparseZgebsr2gebsc_bufferSizeExt", dynlib: libName.}
+      importc: "cusparseZgebsr2gebsc_bufferSizeExt", dyn.}
   proc cusparseSgebsr2gebsc*(handle: cusparseHandle_t; mb: cint; nb: cint; nnzb: cint;
                             bsrSortedVal: ptr cfloat; bsrSortedRowPtr: ptr cint;
                             bsrSortedColInd: ptr cint; rowBlockDim: cint;
@@ -2918,7 +2921,7 @@ when not defined(CUSPARSE_H):
                             bscRowInd: ptr cint; bscColPtr: ptr cint;
                             copyValues: cusparseAction_t;
                             baseIdx: cusparseIndexBase_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseSgebsr2gebsc", dynlib: libName.}
+      cdecl, importc: "cusparseSgebsr2gebsc", dyn.}
   proc cusparseDgebsr2gebsc*(handle: cusparseHandle_t; mb: cint; nb: cint; nnzb: cint;
                             bsrSortedVal: ptr cdouble; bsrSortedRowPtr: ptr cint;
                             bsrSortedColInd: ptr cint; rowBlockDim: cint;
@@ -2926,7 +2929,7 @@ when not defined(CUSPARSE_H):
                             bscRowInd: ptr cint; bscColPtr: ptr cint;
                             copyValues: cusparseAction_t;
                             baseIdx: cusparseIndexBase_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseDgebsr2gebsc", dynlib: libName.}
+      cdecl, importc: "cusparseDgebsr2gebsc", dyn.}
   proc cusparseCgebsr2gebsc*(handle: cusparseHandle_t; mb: cint; nb: cint; nnzb: cint;
                             bsrSortedVal: ptr cuComplex; bsrSortedRowPtr: ptr cint;
                             bsrSortedColInd: ptr cint; rowBlockDim: cint;
@@ -2934,7 +2937,7 @@ when not defined(CUSPARSE_H):
                             bscRowInd: ptr cint; bscColPtr: ptr cint;
                             copyValues: cusparseAction_t;
                             baseIdx: cusparseIndexBase_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseCgebsr2gebsc", dynlib: libName.}
+      cdecl, importc: "cusparseCgebsr2gebsc", dyn.}
   proc cusparseZgebsr2gebsc*(handle: cusparseHandle_t; mb: cint; nb: cint; nnzb: cint;
                             bsrSortedVal: ptr cuDoubleComplex;
                             bsrSortedRowPtr: ptr cint; bsrSortedColInd: ptr cint;
@@ -2942,7 +2945,7 @@ when not defined(CUSPARSE_H):
                             bscVal: ptr cuDoubleComplex; bscRowInd: ptr cint;
                             bscColPtr: ptr cint; copyValues: cusparseAction_t;
                             baseIdx: cusparseIndexBase_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZgebsr2gebsc", dynlib: libName.}
+      cdecl, importc: "cusparseZgebsr2gebsc", dyn.}
   ##  Description: This routine converts a sparse matrix in general block-CSR storage format
   ##    to a sparse matrix in CSR storage format.
   proc cusparseXgebsr2csr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
@@ -2951,7 +2954,7 @@ when not defined(CUSPARSE_H):
                           rowBlockDim: cint; colBlockDim: cint;
                           descrC: cusparseMatDescr_t; csrSortedRowPtrC: ptr cint;
                           csrSortedColIndC: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseXgebsr2csr", dynlib: libName.}
+      importc: "cusparseXgebsr2csr", dyn.}
   proc cusparseSgebsr2csr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                           mb: cint; nb: cint; descrA: cusparseMatDescr_t;
                           bsrSortedValA: ptr cfloat; bsrSortedRowPtrA: ptr cint;
@@ -2959,7 +2962,7 @@ when not defined(CUSPARSE_H):
                           colBlockDim: cint; descrC: cusparseMatDescr_t;
                           csrSortedValC: ptr cfloat; csrSortedRowPtrC: ptr cint;
                           csrSortedColIndC: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseSgebsr2csr", dynlib: libName.}
+      importc: "cusparseSgebsr2csr", dyn.}
   proc cusparseDgebsr2csr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                           mb: cint; nb: cint; descrA: cusparseMatDescr_t;
                           bsrSortedValA: ptr cdouble; bsrSortedRowPtrA: ptr cint;
@@ -2967,7 +2970,7 @@ when not defined(CUSPARSE_H):
                           colBlockDim: cint; descrC: cusparseMatDescr_t;
                           csrSortedValC: ptr cdouble; csrSortedRowPtrC: ptr cint;
                           csrSortedColIndC: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseDgebsr2csr", dynlib: libName.}
+      importc: "cusparseDgebsr2csr", dyn.}
   proc cusparseCgebsr2csr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                           mb: cint; nb: cint; descrA: cusparseMatDescr_t;
                           bsrSortedValA: ptr cuComplex; bsrSortedRowPtrA: ptr cint;
@@ -2975,7 +2978,7 @@ when not defined(CUSPARSE_H):
                           colBlockDim: cint; descrC: cusparseMatDescr_t;
                           csrSortedValC: ptr cuComplex; csrSortedRowPtrC: ptr cint;
                           csrSortedColIndC: ptr cint): cusparseStatus_t {.cdecl,
-      importc: "cusparseCgebsr2csr", dynlib: libName.}
+      importc: "cusparseCgebsr2csr", dyn.}
   proc cusparseZgebsr2csr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                           mb: cint; nb: cint; descrA: cusparseMatDescr_t;
                           bsrSortedValA: ptr cuDoubleComplex;
@@ -2984,7 +2987,7 @@ when not defined(CUSPARSE_H):
                           descrC: cusparseMatDescr_t;
                           csrSortedValC: ptr cuDoubleComplex;
                           csrSortedRowPtrC: ptr cint; csrSortedColIndC: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZgebsr2csr", dynlib: libName.}
+      cdecl, importc: "cusparseZgebsr2csr", dyn.}
   ##  Description: This routine converts a sparse matrix in CSR storage format
   ##    to a sparse matrix in general block-CSR storage format.
   proc cusparseScsr2gebsr_bufferSize*(handle: cusparseHandle_t;
@@ -2995,7 +2998,7 @@ when not defined(CUSPARSE_H):
                                      csrSortedColIndA: ptr cint; rowBlockDim: cint;
                                      colBlockDim: cint;
                                      pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsr2gebsr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseScsr2gebsr_bufferSize", dyn.}
   proc cusparseDcsr2gebsr_bufferSize*(handle: cusparseHandle_t;
                                      dirA: cusparseDirection_t; m: cint; n: cint;
                                      descrA: cusparseMatDescr_t;
@@ -3004,7 +3007,7 @@ when not defined(CUSPARSE_H):
                                      csrSortedColIndA: ptr cint; rowBlockDim: cint;
                                      colBlockDim: cint;
                                      pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsr2gebsr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseDcsr2gebsr_bufferSize", dyn.}
   proc cusparseCcsr2gebsr_bufferSize*(handle: cusparseHandle_t;
                                      dirA: cusparseDirection_t; m: cint; n: cint;
                                      descrA: cusparseMatDescr_t;
@@ -3013,7 +3016,7 @@ when not defined(CUSPARSE_H):
                                      csrSortedColIndA: ptr cint; rowBlockDim: cint;
                                      colBlockDim: cint;
                                      pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsr2gebsr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseCcsr2gebsr_bufferSize", dyn.}
   proc cusparseZcsr2gebsr_bufferSize*(handle: cusparseHandle_t;
                                      dirA: cusparseDirection_t; m: cint; n: cint;
                                      descrA: cusparseMatDescr_t;
@@ -3022,7 +3025,7 @@ when not defined(CUSPARSE_H):
                                      csrSortedColIndA: ptr cint; rowBlockDim: cint;
                                      colBlockDim: cint;
                                      pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsr2gebsr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseZcsr2gebsr_bufferSize", dyn.}
   proc cusparseScsr2gebsr_bufferSizeExt*(handle: cusparseHandle_t;
                                         dirA: cusparseDirection_t; m: cint; n: cint;
                                         descrA: cusparseMatDescr_t;
@@ -3031,7 +3034,7 @@ when not defined(CUSPARSE_H):
                                         csrSortedColIndA: ptr cint;
                                         rowBlockDim: cint; colBlockDim: cint;
                                         pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsr2gebsr_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseScsr2gebsr_bufferSizeExt", dyn.}
   proc cusparseDcsr2gebsr_bufferSizeExt*(handle: cusparseHandle_t;
                                         dirA: cusparseDirection_t; m: cint; n: cint;
                                         descrA: cusparseMatDescr_t;
@@ -3040,7 +3043,7 @@ when not defined(CUSPARSE_H):
                                         csrSortedColIndA: ptr cint;
                                         rowBlockDim: cint; colBlockDim: cint;
                                         pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsr2gebsr_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseDcsr2gebsr_bufferSizeExt", dyn.}
   proc cusparseCcsr2gebsr_bufferSizeExt*(handle: cusparseHandle_t;
                                         dirA: cusparseDirection_t; m: cint; n: cint;
                                         descrA: cusparseMatDescr_t;
@@ -3049,7 +3052,7 @@ when not defined(CUSPARSE_H):
                                         csrSortedColIndA: ptr cint;
                                         rowBlockDim: cint; colBlockDim: cint;
                                         pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsr2gebsr_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseCcsr2gebsr_bufferSizeExt", dyn.}
   proc cusparseZcsr2gebsr_bufferSizeExt*(handle: cusparseHandle_t;
                                         dirA: cusparseDirection_t; m: cint; n: cint;
                                         descrA: cusparseMatDescr_t;
@@ -3058,7 +3061,7 @@ when not defined(CUSPARSE_H):
                                         csrSortedColIndA: ptr cint;
                                         rowBlockDim: cint; colBlockDim: cint;
                                         pBufferSize: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsr2gebsr_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseZcsr2gebsr_bufferSizeExt", dyn.}
   proc cusparseXcsr2gebsrNnz*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                              m: cint; n: cint; descrA: cusparseMatDescr_t;
                              csrSortedRowPtrA: ptr cint;
@@ -3067,7 +3070,7 @@ when not defined(CUSPARSE_H):
                              bsrSortedRowPtrC: ptr cint; rowBlockDim: cint;
                              colBlockDim: cint; nnzTotalDevHostPtr: ptr cint;
                              pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseXcsr2gebsrNnz", dynlib: libName.}
+      importc: "cusparseXcsr2gebsrNnz", dyn.}
   proc cusparseScsr2gebsr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                           m: cint; n: cint; descrA: cusparseMatDescr_t;
                           csrSortedValA: ptr cfloat; csrSortedRowPtrA: ptr cint;
@@ -3075,7 +3078,7 @@ when not defined(CUSPARSE_H):
                           bsrSortedValC: ptr cfloat; bsrSortedRowPtrC: ptr cint;
                           bsrSortedColIndC: ptr cint; rowBlockDim: cint;
                           colBlockDim: cint; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsr2gebsr", dynlib: libName.}
+      cdecl, importc: "cusparseScsr2gebsr", dyn.}
   proc cusparseDcsr2gebsr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                           m: cint; n: cint; descrA: cusparseMatDescr_t;
                           csrSortedValA: ptr cdouble; csrSortedRowPtrA: ptr cint;
@@ -3083,7 +3086,7 @@ when not defined(CUSPARSE_H):
                           bsrSortedValC: ptr cdouble; bsrSortedRowPtrC: ptr cint;
                           bsrSortedColIndC: ptr cint; rowBlockDim: cint;
                           colBlockDim: cint; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsr2gebsr", dynlib: libName.}
+      cdecl, importc: "cusparseDcsr2gebsr", dyn.}
   proc cusparseCcsr2gebsr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                           m: cint; n: cint; descrA: cusparseMatDescr_t;
                           csrSortedValA: ptr cuComplex; csrSortedRowPtrA: ptr cint;
@@ -3091,7 +3094,7 @@ when not defined(CUSPARSE_H):
                           bsrSortedValC: ptr cuComplex; bsrSortedRowPtrC: ptr cint;
                           bsrSortedColIndC: ptr cint; rowBlockDim: cint;
                           colBlockDim: cint; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsr2gebsr", dynlib: libName.}
+      cdecl, importc: "cusparseCcsr2gebsr", dyn.}
   proc cusparseZcsr2gebsr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                           m: cint; n: cint; descrA: cusparseMatDescr_t;
                           csrSortedValA: ptr cuDoubleComplex;
@@ -3100,7 +3103,7 @@ when not defined(CUSPARSE_H):
                           bsrSortedValC: ptr cuDoubleComplex;
                           bsrSortedRowPtrC: ptr cint; bsrSortedColIndC: ptr cint;
                           rowBlockDim: cint; colBlockDim: cint; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsr2gebsr", dynlib: libName.}
+      cdecl, importc: "cusparseZcsr2gebsr", dyn.}
   ##  Description: This routine converts a sparse matrix in general block-CSR storage format
   ##    to a sparse matrix in general block-CSR storage format with different block size.
   proc cusparseSgebsr2gebsr_bufferSize*(handle: cusparseHandle_t;
@@ -3113,7 +3116,7 @@ when not defined(CUSPARSE_H):
                                        rowBlockDimA: cint; colBlockDimA: cint;
                                        rowBlockDimC: cint; colBlockDimC: cint;
                                        pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseSgebsr2gebsr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseSgebsr2gebsr_bufferSize", dyn.}
   proc cusparseDgebsr2gebsr_bufferSize*(handle: cusparseHandle_t;
                                        dirA: cusparseDirection_t; mb: cint;
                                        nb: cint; nnzb: cint;
@@ -3124,7 +3127,7 @@ when not defined(CUSPARSE_H):
                                        rowBlockDimA: cint; colBlockDimA: cint;
                                        rowBlockDimC: cint; colBlockDimC: cint;
                                        pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseDgebsr2gebsr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseDgebsr2gebsr_bufferSize", dyn.}
   proc cusparseCgebsr2gebsr_bufferSize*(handle: cusparseHandle_t;
                                        dirA: cusparseDirection_t; mb: cint;
                                        nb: cint; nnzb: cint;
@@ -3135,7 +3138,7 @@ when not defined(CUSPARSE_H):
                                        rowBlockDimA: cint; colBlockDimA: cint;
                                        rowBlockDimC: cint; colBlockDimC: cint;
                                        pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseCgebsr2gebsr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseCgebsr2gebsr_bufferSize", dyn.}
   proc cusparseZgebsr2gebsr_bufferSize*(handle: cusparseHandle_t;
                                        dirA: cusparseDirection_t; mb: cint;
                                        nb: cint; nnzb: cint;
@@ -3146,35 +3149,35 @@ when not defined(CUSPARSE_H):
                                        rowBlockDimA: cint; colBlockDimA: cint;
                                        rowBlockDimC: cint; colBlockDimC: cint;
                                        pBufferSizeInBytes: ptr cint): cusparseStatus_t {.
-      cdecl, importc: "cusparseZgebsr2gebsr_bufferSize", dynlib: libName.}
+      cdecl, importc: "cusparseZgebsr2gebsr_bufferSize", dyn.}
   proc cusparseSgebsr2gebsr_bufferSizeExt*(handle: cusparseHandle_t;
       dirA: cusparseDirection_t; mb: cint; nb: cint; nnzb: cint;
       descrA: cusparseMatDescr_t; bsrSortedValA: ptr cfloat;
       bsrSortedRowPtrA: ptr cint; bsrSortedColIndA: ptr cint; rowBlockDimA: cint;
       colBlockDimA: cint; rowBlockDimC: cint; colBlockDimC: cint;
       pBufferSize: ptr csize): cusparseStatus_t {.cdecl,
-      importc: "cusparseSgebsr2gebsr_bufferSizeExt", dynlib: libName.}
+      importc: "cusparseSgebsr2gebsr_bufferSizeExt", dyn.}
   proc cusparseDgebsr2gebsr_bufferSizeExt*(handle: cusparseHandle_t;
       dirA: cusparseDirection_t; mb: cint; nb: cint; nnzb: cint;
       descrA: cusparseMatDescr_t; bsrSortedValA: ptr cdouble;
       bsrSortedRowPtrA: ptr cint; bsrSortedColIndA: ptr cint; rowBlockDimA: cint;
       colBlockDimA: cint; rowBlockDimC: cint; colBlockDimC: cint;
       pBufferSize: ptr csize): cusparseStatus_t {.cdecl,
-      importc: "cusparseDgebsr2gebsr_bufferSizeExt", dynlib: libName.}
+      importc: "cusparseDgebsr2gebsr_bufferSizeExt", dyn.}
   proc cusparseCgebsr2gebsr_bufferSizeExt*(handle: cusparseHandle_t;
       dirA: cusparseDirection_t; mb: cint; nb: cint; nnzb: cint;
       descrA: cusparseMatDescr_t; bsrSortedValA: ptr cuComplex;
       bsrSortedRowPtrA: ptr cint; bsrSortedColIndA: ptr cint; rowBlockDimA: cint;
       colBlockDimA: cint; rowBlockDimC: cint; colBlockDimC: cint;
       pBufferSize: ptr csize): cusparseStatus_t {.cdecl,
-      importc: "cusparseCgebsr2gebsr_bufferSizeExt", dynlib: libName.}
+      importc: "cusparseCgebsr2gebsr_bufferSizeExt", dyn.}
   proc cusparseZgebsr2gebsr_bufferSizeExt*(handle: cusparseHandle_t;
       dirA: cusparseDirection_t; mb: cint; nb: cint; nnzb: cint;
       descrA: cusparseMatDescr_t; bsrSortedValA: ptr cuDoubleComplex;
       bsrSortedRowPtrA: ptr cint; bsrSortedColIndA: ptr cint; rowBlockDimA: cint;
       colBlockDimA: cint; rowBlockDimC: cint; colBlockDimC: cint;
       pBufferSize: ptr csize): cusparseStatus_t {.cdecl,
-      importc: "cusparseZgebsr2gebsr_bufferSizeExt", dynlib: libName.}
+      importc: "cusparseZgebsr2gebsr_bufferSizeExt", dyn.}
   proc cusparseXgebsr2gebsrNnz*(handle: cusparseHandle_t;
                                dirA: cusparseDirection_t; mb: cint; nb: cint;
                                nnzb: cint; descrA: cusparseMatDescr_t;
@@ -3184,7 +3187,7 @@ when not defined(CUSPARSE_H):
                                bsrSortedRowPtrC: ptr cint; rowBlockDimC: cint;
                                colBlockDimC: cint; nnzTotalDevHostPtr: ptr cint;
                                pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseXgebsr2gebsrNnz", dynlib: libName.}
+      importc: "cusparseXgebsr2gebsrNnz", dyn.}
   proc cusparseSgebsr2gebsr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                             mb: cint; nb: cint; nnzb: cint;
                             descrA: cusparseMatDescr_t; bsrSortedValA: ptr cfloat;
@@ -3193,7 +3196,7 @@ when not defined(CUSPARSE_H):
                             descrC: cusparseMatDescr_t; bsrSortedValC: ptr cfloat;
                             bsrSortedRowPtrC: ptr cint; bsrSortedColIndC: ptr cint;
                             rowBlockDimC: cint; colBlockDimC: cint; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseSgebsr2gebsr", dynlib: libName.}
+      cdecl, importc: "cusparseSgebsr2gebsr", dyn.}
   proc cusparseDgebsr2gebsr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                             mb: cint; nb: cint; nnzb: cint;
                             descrA: cusparseMatDescr_t;
@@ -3203,7 +3206,7 @@ when not defined(CUSPARSE_H):
                             bsrSortedValC: ptr cdouble; bsrSortedRowPtrC: ptr cint;
                             bsrSortedColIndC: ptr cint; rowBlockDimC: cint;
                             colBlockDimC: cint; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseDgebsr2gebsr", dynlib: libName.}
+      cdecl, importc: "cusparseDgebsr2gebsr", dyn.}
   proc cusparseCgebsr2gebsr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                             mb: cint; nb: cint; nnzb: cint;
                             descrA: cusparseMatDescr_t;
@@ -3214,7 +3217,7 @@ when not defined(CUSPARSE_H):
                             bsrSortedValC: ptr cuComplex;
                             bsrSortedRowPtrC: ptr cint; bsrSortedColIndC: ptr cint;
                             rowBlockDimC: cint; colBlockDimC: cint; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseCgebsr2gebsr", dynlib: libName.}
+      cdecl, importc: "cusparseCgebsr2gebsr", dyn.}
   proc cusparseZgebsr2gebsr*(handle: cusparseHandle_t; dirA: cusparseDirection_t;
                             mb: cint; nb: cint; nnzb: cint;
                             descrA: cusparseMatDescr_t;
@@ -3225,46 +3228,46 @@ when not defined(CUSPARSE_H):
                             bsrSortedValC: ptr cuDoubleComplex;
                             bsrSortedRowPtrC: ptr cint; bsrSortedColIndC: ptr cint;
                             rowBlockDimC: cint; colBlockDimC: cint; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZgebsr2gebsr", dynlib: libName.}
+      cdecl, importc: "cusparseZgebsr2gebsr", dyn.}
   ##  --- Sparse Matrix Sorting ---
   ##  Description: Create a identity sequence p=[0,1,...,n-1].
   proc cusparseCreateIdentityPermutation*(handle: cusparseHandle_t; n: cint;
       p: ptr cint): cusparseStatus_t {.cdecl, importc: "cusparseCreateIdentityPermutation",
-                                   dynlib: libName.}
+                                   dyn.}
   ##  Description: Sort sparse matrix stored in COO format
   proc cusparseXcoosort_bufferSizeExt*(handle: cusparseHandle_t; m: cint; n: cint;
                                       nnz: cint; cooRowsA: ptr cint;
                                       cooColsA: ptr cint;
                                       pBufferSizeInBytes: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseXcoosort_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseXcoosort_bufferSizeExt", dyn.}
   proc cusparseXcoosortByRow*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                              cooRowsA: ptr cint; cooColsA: ptr cint; P: ptr cint;
                              pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseXcoosortByRow", dynlib: libName.}
+      importc: "cusparseXcoosortByRow", dyn.}
   proc cusparseXcoosortByColumn*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                                 cooRowsA: ptr cint; cooColsA: ptr cint; P: ptr cint;
                                 pBuffer: pointer): cusparseStatus_t {.cdecl,
-      importc: "cusparseXcoosortByColumn", dynlib: libName.}
+      importc: "cusparseXcoosortByColumn", dyn.}
   ##  Description: Sort sparse matrix stored in CSR format
   proc cusparseXcsrsort_bufferSizeExt*(handle: cusparseHandle_t; m: cint; n: cint;
                                       nnz: cint; csrRowPtrA: ptr cint;
                                       csrColIndA: ptr cint;
                                       pBufferSizeInBytes: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseXcsrsort_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseXcsrsort_bufferSizeExt", dyn.}
   proc cusparseXcsrsort*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                         descrA: cusparseMatDescr_t; csrRowPtrA: ptr cint;
                         csrColIndA: ptr cint; P: ptr cint; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseXcsrsort", dynlib: libName.}
+      cdecl, importc: "cusparseXcsrsort", dyn.}
   ##  Description: Sort sparse matrix stored in CSC format
   proc cusparseXcscsort_bufferSizeExt*(handle: cusparseHandle_t; m: cint; n: cint;
                                       nnz: cint; cscColPtrA: ptr cint;
                                       cscRowIndA: ptr cint;
                                       pBufferSizeInBytes: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseXcscsort_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseXcscsort_bufferSizeExt", dyn.}
   proc cusparseXcscsort*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                         descrA: cusparseMatDescr_t; cscColPtrA: ptr cint;
                         cscRowIndA: ptr cint; P: ptr cint; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseXcscsort", dynlib: libName.}
+      cdecl, importc: "cusparseXcscsort", dyn.}
   ##  Description: Wrapper that sorts sparse matrix stored in CSR format 
   ##    (without exposing the permutation).
   proc cusparseScsru2csr_bufferSizeExt*(handle: cusparseHandle_t; m: cint; n: cint;
@@ -3272,64 +3275,64 @@ when not defined(CUSPARSE_H):
                                        csrRowPtr: ptr cint; csrColInd: ptr cint;
                                        info: csru2csrInfo_t;
                                        pBufferSizeInBytes: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsru2csr_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseScsru2csr_bufferSizeExt", dyn.}
   proc cusparseDcsru2csr_bufferSizeExt*(handle: cusparseHandle_t; m: cint; n: cint;
                                        nnz: cint; csrVal: ptr cdouble;
                                        csrRowPtr: ptr cint; csrColInd: ptr cint;
                                        info: csru2csrInfo_t;
                                        pBufferSizeInBytes: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsru2csr_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseDcsru2csr_bufferSizeExt", dyn.}
   proc cusparseCcsru2csr_bufferSizeExt*(handle: cusparseHandle_t; m: cint; n: cint;
                                        nnz: cint; csrVal: ptr cuComplex;
                                        csrRowPtr: ptr cint; csrColInd: ptr cint;
                                        info: csru2csrInfo_t;
                                        pBufferSizeInBytes: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsru2csr_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseCcsru2csr_bufferSizeExt", dyn.}
   proc cusparseZcsru2csr_bufferSizeExt*(handle: cusparseHandle_t; m: cint; n: cint;
                                        nnz: cint; csrVal: ptr cuDoubleComplex;
                                        csrRowPtr: ptr cint; csrColInd: ptr cint;
                                        info: csru2csrInfo_t;
                                        pBufferSizeInBytes: ptr csize): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsru2csr_bufferSizeExt", dynlib: libName.}
+      cdecl, importc: "cusparseZcsru2csr_bufferSizeExt", dyn.}
   proc cusparseScsru2csr*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                          descrA: cusparseMatDescr_t; csrVal: ptr cfloat;
                          csrRowPtr: ptr cint; csrColInd: ptr cint;
                          info: csru2csrInfo_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsru2csr", dynlib: libName.}
+      cdecl, importc: "cusparseScsru2csr", dyn.}
   proc cusparseDcsru2csr*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                          descrA: cusparseMatDescr_t; csrVal: ptr cdouble;
                          csrRowPtr: ptr cint; csrColInd: ptr cint;
                          info: csru2csrInfo_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsru2csr", dynlib: libName.}
+      cdecl, importc: "cusparseDcsru2csr", dyn.}
   proc cusparseCcsru2csr*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                          descrA: cusparseMatDescr_t; csrVal: ptr cuComplex;
                          csrRowPtr: ptr cint; csrColInd: ptr cint;
                          info: csru2csrInfo_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsru2csr", dynlib: libName.}
+      cdecl, importc: "cusparseCcsru2csr", dyn.}
   proc cusparseZcsru2csr*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                          descrA: cusparseMatDescr_t; csrVal: ptr cuDoubleComplex;
                          csrRowPtr: ptr cint; csrColInd: ptr cint;
                          info: csru2csrInfo_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsru2csr", dynlib: libName.}
+      cdecl, importc: "cusparseZcsru2csr", dyn.}
   ##  Description: Wrapper that un-sorts sparse matrix stored in CSR format 
   ##    (without exposing the permutation).
   proc cusparseScsr2csru*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                          descrA: cusparseMatDescr_t; csrVal: ptr cfloat;
                          csrRowPtr: ptr cint; csrColInd: ptr cint;
                          info: csru2csrInfo_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseScsr2csru", dynlib: libName.}
+      cdecl, importc: "cusparseScsr2csru", dyn.}
   proc cusparseDcsr2csru*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                          descrA: cusparseMatDescr_t; csrVal: ptr cdouble;
                          csrRowPtr: ptr cint; csrColInd: ptr cint;
                          info: csru2csrInfo_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseDcsr2csru", dynlib: libName.}
+      cdecl, importc: "cusparseDcsr2csru", dyn.}
   proc cusparseCcsr2csru*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                          descrA: cusparseMatDescr_t; csrVal: ptr cuComplex;
                          csrRowPtr: ptr cint; csrColInd: ptr cint;
                          info: csru2csrInfo_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseCcsr2csru", dynlib: libName.}
+      cdecl, importc: "cusparseCcsr2csru", dyn.}
   proc cusparseZcsr2csru*(handle: cusparseHandle_t; m: cint; n: cint; nnz: cint;
                          descrA: cusparseMatDescr_t; csrVal: ptr cuDoubleComplex;
                          csrRowPtr: ptr cint; csrColInd: ptr cint;
                          info: csru2csrInfo_t; pBuffer: pointer): cusparseStatus_t {.
-      cdecl, importc: "cusparseZcsr2csru", dynlib: libName.}
+      cdecl, importc: "cusparseZcsr2csru", dyn.}

--- a/nimcuda/nvblas.nim
+++ b/nimcuda/nvblas.nim
@@ -1,13 +1,16 @@
  {.deadCodeElim: on.}
 when defined(windows):
-  const
-    libName = "nvblas.dll"
+  import os
+  {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "nvblas.lib" & "\"".}
+  {.pragma: dyn.}
 elif defined(macosx):
   const
     libName = "libnvblas.dylib"
+  {.pragma: dyn, dynlib: libName.}
 else:
   const
     libName = "libnvblas.so"
+  {.pragma: dyn, dynlib: libName.}
 import
   cuComplex
 
@@ -67,240 +70,240 @@ when not defined(NVBLAS_H):
   proc sgemm1*(transa: cstring; transb: cstring; m: ptr cint; n: ptr cint; k: ptr cint;
               alpha: ptr cfloat; a: ptr cfloat; lda: ptr cint; b: ptr cfloat; ldb: ptr cint;
               beta: ptr cfloat; c: ptr cfloat; ldc: ptr cint) {.cdecl, importc: "sgemm_",
-      dynlib: libName.}
+      dyn.}
   proc dgemm1*(transa: cstring; transb: cstring; m: ptr cint; n: ptr cint; k: ptr cint;
               alpha: ptr cdouble; a: ptr cdouble; lda: ptr cint; b: ptr cdouble;
               ldb: ptr cint; beta: ptr cdouble; c: ptr cdouble; ldc: ptr cint) {.cdecl,
-      importc: "dgemm_", dynlib: libName.}
+      importc: "dgemm_", dyn.}
   proc cgemm1*(transa: cstring; transb: cstring; m: ptr cint; n: ptr cint; k: ptr cint;
               alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint; b: ptr cuComplex;
               ldb: ptr cint; beta: ptr cuComplex; c: ptr cuComplex; ldc: ptr cint) {.cdecl,
-      importc: "cgemm_", dynlib: libName.}
+      importc: "cgemm_", dyn.}
   proc zgemm1*(transa: cstring; transb: cstring; m: ptr cint; n: ptr cint; k: ptr cint;
               alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex; lda: ptr cint;
               b: ptr cuDoubleComplex; ldb: ptr cint; beta: ptr cuDoubleComplex;
               c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl, importc: "zgemm_",
-      dynlib: libName.}
+      dyn.}
   proc sgemm*(transa: cstring; transb: cstring; m: ptr cint; n: ptr cint; k: ptr cint;
              alpha: ptr cfloat; a: ptr cfloat; lda: ptr cint; b: ptr cfloat; ldb: ptr cint;
              beta: ptr cfloat; c: ptr cfloat; ldc: ptr cint) {.cdecl, importc: "sgemm",
-      dynlib: libName.}
+      dyn.}
   proc dgemm*(transa: cstring; transb: cstring; m: ptr cint; n: ptr cint; k: ptr cint;
              alpha: ptr cdouble; a: ptr cdouble; lda: ptr cint; b: ptr cdouble;
              ldb: ptr cint; beta: ptr cdouble; c: ptr cdouble; ldc: ptr cint) {.cdecl,
-      importc: "dgemm", dynlib: libName.}
+      importc: "dgemm", dyn.}
   proc cgemm*(transa: cstring; transb: cstring; m: ptr cint; n: ptr cint; k: ptr cint;
              alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint; b: ptr cuComplex;
              ldb: ptr cint; beta: ptr cuComplex; c: ptr cuComplex; ldc: ptr cint) {.cdecl,
-      importc: "cgemm", dynlib: libName.}
+      importc: "cgemm", dyn.}
   proc zgemm*(transa: cstring; transb: cstring; m: ptr cint; n: ptr cint; k: ptr cint;
              alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex; lda: ptr cint;
              b: ptr cuDoubleComplex; ldb: ptr cint; beta: ptr cuDoubleComplex;
              c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl, importc: "zgemm",
-      dynlib: libName.}
+      dyn.}
   ##  SYRK
   proc ssyrk1*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint; alpha: ptr cfloat;
               a: ptr cfloat; lda: ptr cint; beta: ptr cfloat; c: ptr cfloat; ldc: ptr cint) {.
-      cdecl, importc: "ssyrk_", dynlib: libName.}
+      cdecl, importc: "ssyrk_", dyn.}
   proc dsyrk1*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint; alpha: ptr cdouble;
               a: ptr cdouble; lda: ptr cint; beta: ptr cdouble; c: ptr cdouble;
-              ldc: ptr cint) {.cdecl, importc: "dsyrk_", dynlib: libName.}
+              ldc: ptr cint) {.cdecl, importc: "dsyrk_", dyn.}
   proc csyrk1*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint;
               alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint; beta: ptr cuComplex;
               c: ptr cuComplex; ldc: ptr cint) {.cdecl, importc: "csyrk_",
-      dynlib: libName.}
+      dyn.}
   proc zsyrk1*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint;
               alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex; lda: ptr cint;
               beta: ptr cuDoubleComplex; c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl,
-      importc: "zsyrk_", dynlib: libName.}
+      importc: "zsyrk_", dyn.}
   proc ssyrk*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint; alpha: ptr cfloat;
              a: ptr cfloat; lda: ptr cint; beta: ptr cfloat; c: ptr cfloat; ldc: ptr cint) {.
-      cdecl, importc: "ssyrk", dynlib: libName.}
+      cdecl, importc: "ssyrk", dyn.}
   proc dsyrk*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint; alpha: ptr cdouble;
              a: ptr cdouble; lda: ptr cint; beta: ptr cdouble; c: ptr cdouble; ldc: ptr cint) {.
-      cdecl, importc: "dsyrk", dynlib: libName.}
+      cdecl, importc: "dsyrk", dyn.}
   proc csyrk*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint;
              alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint; beta: ptr cuComplex;
-             c: ptr cuComplex; ldc: ptr cint) {.cdecl, importc: "csyrk", dynlib: libName.}
+             c: ptr cuComplex; ldc: ptr cint) {.cdecl, importc: "csyrk", dyn.}
   proc zsyrk*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint;
              alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex; lda: ptr cint;
              beta: ptr cuDoubleComplex; c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl,
-      importc: "zsyrk", dynlib: libName.}
+      importc: "zsyrk", dyn.}
   ##  HERK
   proc cherk1*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint; alpha: ptr cfloat;
               a: ptr cuComplex; lda: ptr cint; beta: ptr cfloat; c: ptr cuComplex;
-              ldc: ptr cint) {.cdecl, importc: "cherk_", dynlib: libName.}
+              ldc: ptr cint) {.cdecl, importc: "cherk_", dyn.}
   proc zherk1*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint; alpha: ptr cdouble;
               a: ptr cuDoubleComplex; lda: ptr cint; beta: ptr cdouble;
               c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl, importc: "zherk_",
-      dynlib: libName.}
+      dyn.}
   proc cherk*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint; alpha: ptr cfloat;
              a: ptr cuComplex; lda: ptr cint; beta: ptr cfloat; c: ptr cuComplex;
-             ldc: ptr cint) {.cdecl, importc: "cherk", dynlib: libName.}
+             ldc: ptr cint) {.cdecl, importc: "cherk", dyn.}
   proc zherk*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint; alpha: ptr cdouble;
              a: ptr cuDoubleComplex; lda: ptr cint; beta: ptr cdouble;
              c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl, importc: "zherk",
-      dynlib: libName.}
+      dyn.}
   ##  TRSM
   proc strsm1*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
               n: ptr cint; alpha: ptr cfloat; a: ptr cfloat; lda: ptr cint; b: ptr cfloat;
-              ldb: ptr cint) {.cdecl, importc: "strsm_", dynlib: libName.}
+              ldb: ptr cint) {.cdecl, importc: "strsm_", dyn.}
   proc dtrsm1*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
               n: ptr cint; alpha: ptr cdouble; a: ptr cdouble; lda: ptr cint;
-              b: ptr cdouble; ldb: ptr cint) {.cdecl, importc: "dtrsm_", dynlib: libName.}
+              b: ptr cdouble; ldb: ptr cint) {.cdecl, importc: "dtrsm_", dyn.}
   proc ctrsm1*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
               n: ptr cint; alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint;
               b: ptr cuComplex; ldb: ptr cint) {.cdecl, importc: "ctrsm_",
-      dynlib: libName.}
+      dyn.}
   proc ztrsm1*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
               n: ptr cint; alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex;
               lda: ptr cint; b: ptr cuDoubleComplex; ldb: ptr cint) {.cdecl,
-      importc: "ztrsm_", dynlib: libName.}
+      importc: "ztrsm_", dyn.}
   proc strsm*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
              n: ptr cint; alpha: ptr cfloat; a: ptr cfloat; lda: ptr cint; b: ptr cfloat;
-             ldb: ptr cint) {.cdecl, importc: "strsm", dynlib: libName.}
+             ldb: ptr cint) {.cdecl, importc: "strsm", dyn.}
   proc dtrsm*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
              n: ptr cint; alpha: ptr cdouble; a: ptr cdouble; lda: ptr cint; b: ptr cdouble;
-             ldb: ptr cint) {.cdecl, importc: "dtrsm", dynlib: libName.}
+             ldb: ptr cint) {.cdecl, importc: "dtrsm", dyn.}
   proc ctrsm*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
              n: ptr cint; alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint;
-             b: ptr cuComplex; ldb: ptr cint) {.cdecl, importc: "ctrsm", dynlib: libName.}
+             b: ptr cuComplex; ldb: ptr cint) {.cdecl, importc: "ctrsm", dyn.}
   proc ztrsm*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
              n: ptr cint; alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex;
              lda: ptr cint; b: ptr cuDoubleComplex; ldb: ptr cint) {.cdecl,
-      importc: "ztrsm", dynlib: libName.}
+      importc: "ztrsm", dyn.}
   ##  SYMM
   proc ssymm1*(side: cstring; uplo: cstring; m: ptr cint; n: ptr cint; alpha: ptr cfloat;
               a: ptr cfloat; lda: ptr cint; b: ptr cfloat; ldb: ptr cint; beta: ptr cfloat;
-              c: ptr cfloat; ldc: ptr cint) {.cdecl, importc: "ssymm_", dynlib: libName.}
+              c: ptr cfloat; ldc: ptr cint) {.cdecl, importc: "ssymm_", dyn.}
   proc dsymm1*(side: cstring; uplo: cstring; m: ptr cint; n: ptr cint; alpha: ptr cdouble;
               a: ptr cdouble; lda: ptr cint; b: ptr cdouble; ldb: ptr cint;
               beta: ptr cdouble; c: ptr cdouble; ldc: ptr cint) {.cdecl,
-      importc: "dsymm_", dynlib: libName.}
+      importc: "dsymm_", dyn.}
   proc csymm1*(side: cstring; uplo: cstring; m: ptr cint; n: ptr cint;
               alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint; b: ptr cuComplex;
               ldb: ptr cint; beta: ptr cuComplex; c: ptr cuComplex; ldc: ptr cint) {.cdecl,
-      importc: "csymm_", dynlib: libName.}
+      importc: "csymm_", dyn.}
   proc zsymm1*(side: cstring; uplo: cstring; m: ptr cint; n: ptr cint;
               alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex; lda: ptr cint;
               b: ptr cuDoubleComplex; ldb: ptr cint; beta: ptr cuDoubleComplex;
               c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl, importc: "zsymm_",
-      dynlib: libName.}
+      dyn.}
   proc ssymm*(side: cstring; uplo: cstring; m: ptr cint; n: ptr cint; alpha: ptr cfloat;
              a: ptr cfloat; lda: ptr cint; b: ptr cfloat; ldb: ptr cint; beta: ptr cfloat;
-             c: ptr cfloat; ldc: ptr cint) {.cdecl, importc: "ssymm", dynlib: libName.}
+             c: ptr cfloat; ldc: ptr cint) {.cdecl, importc: "ssymm", dyn.}
   proc dsymm*(side: cstring; uplo: cstring; m: ptr cint; n: ptr cint; alpha: ptr cdouble;
              a: ptr cdouble; lda: ptr cint; b: ptr cdouble; ldb: ptr cint;
              beta: ptr cdouble; c: ptr cdouble; ldc: ptr cint) {.cdecl, importc: "dsymm",
-      dynlib: libName.}
+      dyn.}
   proc csymm*(side: cstring; uplo: cstring; m: ptr cint; n: ptr cint; alpha: ptr cuComplex;
              a: ptr cuComplex; lda: ptr cint; b: ptr cuComplex; ldb: ptr cint;
              beta: ptr cuComplex; c: ptr cuComplex; ldc: ptr cint) {.cdecl,
-      importc: "csymm", dynlib: libName.}
+      importc: "csymm", dyn.}
   proc zsymm*(side: cstring; uplo: cstring; m: ptr cint; n: ptr cint;
              alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex; lda: ptr cint;
              b: ptr cuDoubleComplex; ldb: ptr cint; beta: ptr cuDoubleComplex;
              c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl, importc: "zsymm",
-      dynlib: libName.}
+      dyn.}
   ##  HEMM
   proc chemm1*(side: cstring; uplo: cstring; m: ptr cint; n: ptr cint;
               alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint; b: ptr cuComplex;
               ldb: ptr cint; beta: ptr cuComplex; c: ptr cuComplex; ldc: ptr cint) {.cdecl,
-      importc: "chemm_", dynlib: libName.}
+      importc: "chemm_", dyn.}
   proc zhemm1*(side: cstring; uplo: cstring; m: ptr cint; n: ptr cint;
               alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex; lda: ptr cint;
               b: ptr cuDoubleComplex; ldb: ptr cint; beta: ptr cuDoubleComplex;
               c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl, importc: "zhemm_",
-      dynlib: libName.}
+      dyn.}
   ##  HEMM with no underscore
   proc chemm*(side: cstring; uplo: cstring; m: ptr cint; n: ptr cint; alpha: ptr cuComplex;
              a: ptr cuComplex; lda: ptr cint; b: ptr cuComplex; ldb: ptr cint;
              beta: ptr cuComplex; c: ptr cuComplex; ldc: ptr cint) {.cdecl,
-      importc: "chemm", dynlib: libName.}
+      importc: "chemm", dyn.}
   proc zhemm*(side: cstring; uplo: cstring; m: ptr cint; n: ptr cint;
              alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex; lda: ptr cint;
              b: ptr cuDoubleComplex; ldb: ptr cint; beta: ptr cuDoubleComplex;
              c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl, importc: "zhemm",
-      dynlib: libName.}
+      dyn.}
   ##  SYR2K
   proc ssyr2k1*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint; alpha: ptr cfloat;
                a: ptr cfloat; lda: ptr cint; b: ptr cfloat; ldb: ptr cint; beta: ptr cfloat;
-               c: ptr cfloat; ldc: ptr cint) {.cdecl, importc: "ssyr2k_", dynlib: libName.}
+               c: ptr cfloat; ldc: ptr cint) {.cdecl, importc: "ssyr2k_", dyn.}
   proc dsyr2k1*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint;
                alpha: ptr cdouble; a: ptr cdouble; lda: ptr cint; b: ptr cdouble;
                ldb: ptr cint; beta: ptr cdouble; c: ptr cdouble; ldc: ptr cint) {.cdecl,
-      importc: "dsyr2k_", dynlib: libName.}
+      importc: "dsyr2k_", dyn.}
   proc csyr2k1*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint;
                alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint; b: ptr cuComplex;
                ldb: ptr cint; beta: ptr cuComplex; c: ptr cuComplex; ldc: ptr cint) {.cdecl,
-      importc: "csyr2k_", dynlib: libName.}
+      importc: "csyr2k_", dyn.}
   proc zsyr2k1*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint;
                alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex; lda: ptr cint;
                b: ptr cuDoubleComplex; ldb: ptr cint; beta: ptr cuDoubleComplex;
                c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl, importc: "zsyr2k_",
-      dynlib: libName.}
+      dyn.}
   ##  SYR2K no_underscore
   proc ssyr2k*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint; alpha: ptr cfloat;
               a: ptr cfloat; lda: ptr cint; b: ptr cfloat; ldb: ptr cint; beta: ptr cfloat;
-              c: ptr cfloat; ldc: ptr cint) {.cdecl, importc: "ssyr2k", dynlib: libName.}
+              c: ptr cfloat; ldc: ptr cint) {.cdecl, importc: "ssyr2k", dyn.}
   proc dsyr2k*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint; alpha: ptr cdouble;
               a: ptr cdouble; lda: ptr cint; b: ptr cdouble; ldb: ptr cint;
               beta: ptr cdouble; c: ptr cdouble; ldc: ptr cint) {.cdecl,
-      importc: "dsyr2k", dynlib: libName.}
+      importc: "dsyr2k", dyn.}
   proc csyr2k*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint;
               alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint; b: ptr cuComplex;
               ldb: ptr cint; beta: ptr cuComplex; c: ptr cuComplex; ldc: ptr cint) {.cdecl,
-      importc: "csyr2k", dynlib: libName.}
+      importc: "csyr2k", dyn.}
   proc zsyr2k*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint;
               alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex; lda: ptr cint;
               b: ptr cuDoubleComplex; ldb: ptr cint; beta: ptr cuDoubleComplex;
               c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl, importc: "zsyr2k",
-      dynlib: libName.}
+      dyn.}
   ##  HERK
   proc cher2k1*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint;
                alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint; b: ptr cuComplex;
                ldb: ptr cint; beta: ptr cfloat; c: ptr cuComplex; ldc: ptr cint) {.cdecl,
-      importc: "cher2k_", dynlib: libName.}
+      importc: "cher2k_", dyn.}
   proc zher2k1*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint;
                alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex; lda: ptr cint;
                b: ptr cuDoubleComplex; ldb: ptr cint; beta: ptr cdouble;
                c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl, importc: "zher2k_",
-      dynlib: libName.}
+      dyn.}
   ##  HER2K with no underscore
   proc cher2k*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint;
               alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint; b: ptr cuComplex;
               ldb: ptr cint; beta: ptr cfloat; c: ptr cuComplex; ldc: ptr cint) {.cdecl,
-      importc: "cher2k", dynlib: libName.}
+      importc: "cher2k", dyn.}
   proc zher2k*(uplo: cstring; trans: cstring; n: ptr cint; k: ptr cint;
               alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex; lda: ptr cint;
               b: ptr cuDoubleComplex; ldb: ptr cint; beta: ptr cdouble;
               c: ptr cuDoubleComplex; ldc: ptr cint) {.cdecl, importc: "zher2k",
-      dynlib: libName.}
+      dyn.}
   ##  TRMM
   proc strmm1*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
               n: ptr cint; alpha: ptr cfloat; a: ptr cfloat; lda: ptr cint; b: ptr cfloat;
-              ldb: ptr cint) {.cdecl, importc: "strmm_", dynlib: libName.}
+              ldb: ptr cint) {.cdecl, importc: "strmm_", dyn.}
   proc dtrmm1*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
               n: ptr cint; alpha: ptr cdouble; a: ptr cdouble; lda: ptr cint;
-              b: ptr cdouble; ldb: ptr cint) {.cdecl, importc: "dtrmm_", dynlib: libName.}
+              b: ptr cdouble; ldb: ptr cint) {.cdecl, importc: "dtrmm_", dyn.}
   proc ctrmm1*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
               n: ptr cint; alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint;
               b: ptr cuComplex; ldb: ptr cint) {.cdecl, importc: "ctrmm_",
-      dynlib: libName.}
+      dyn.}
   proc ztrmm1*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
               n: ptr cint; alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex;
               lda: ptr cint; b: ptr cuDoubleComplex; ldb: ptr cint) {.cdecl,
-      importc: "ztrmm_", dynlib: libName.}
+      importc: "ztrmm_", dyn.}
   proc strmm*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
              n: ptr cint; alpha: ptr cfloat; a: ptr cfloat; lda: ptr cint; b: ptr cfloat;
-             ldb: ptr cint) {.cdecl, importc: "strmm", dynlib: libName.}
+             ldb: ptr cint) {.cdecl, importc: "strmm", dyn.}
   proc dtrmm*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
              n: ptr cint; alpha: ptr cdouble; a: ptr cdouble; lda: ptr cint; b: ptr cdouble;
-             ldb: ptr cint) {.cdecl, importc: "dtrmm", dynlib: libName.}
+             ldb: ptr cint) {.cdecl, importc: "dtrmm", dyn.}
   proc ctrmm*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
              n: ptr cint; alpha: ptr cuComplex; a: ptr cuComplex; lda: ptr cint;
-             b: ptr cuComplex; ldb: ptr cint) {.cdecl, importc: "ctrmm", dynlib: libName.}
+             b: ptr cuComplex; ldb: ptr cint) {.cdecl, importc: "ctrmm", dyn.}
   proc ztrmm*(side: cstring; uplo: cstring; transa: cstring; diag: cstring; m: ptr cint;
              n: ptr cint; alpha: ptr cuDoubleComplex; a: ptr cuDoubleComplex;
              lda: ptr cint; b: ptr cuDoubleComplex; ldb: ptr cint) {.cdecl,
-      importc: "ztrmm", dynlib: libName.}
+      importc: "ztrmm", dyn.}

--- a/nimcuda/nvgraph.nim
+++ b/nimcuda/nvgraph.nim
@@ -3,14 +3,17 @@
 
 {.deadCodeElim: on.}
 when defined(windows):
-  const
-    libName = "nvgraph.dll"
+  import os
+  {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "nvgraph.lib" & "\"".}
+  {.pragma: dyn.}
 elif defined(macosx):
   const
     libName = "libnvgraph.dylib"
+  {.pragma: dyn, dynlib: libName.}
 else:
   const
     libName = "libnvgraph.so"
+  {.pragma: dyn, dynlib: libName.}
 import
   library_types
 
@@ -37,7 +40,7 @@ type
 
 
 proc nvgraphStatusGetString*(status: nvgraphStatus_t): cstring {.cdecl,
-    importc: "nvgraphStatusGetString", dynlib: libName.}
+    importc: "nvgraphStatusGetString", dyn.}
 ##  Opaque structure holding nvGRAPH library context
 
 type
@@ -100,57 +103,57 @@ type
 ##  Open the library and create the handle
 
 proc nvgraphCreate*(handle: ptr nvgraphHandle_t): nvgraphStatus_t {.cdecl,
-    importc: "nvgraphCreate", dynlib: libName.}
+    importc: "nvgraphCreate", dyn.}
 ##   Close the library and destroy the handle
 
 proc nvgraphDestroy*(handle: nvgraphHandle_t): nvgraphStatus_t {.cdecl,
-    importc: "nvgraphDestroy", dynlib: libName.}
+    importc: "nvgraphDestroy", dyn.}
 ##  Create an empty graph descriptor
 
 proc nvgraphCreateGraphDescr*(handle: nvgraphHandle_t;
                              descrG: ptr nvgraphGraphDescr_t): nvgraphStatus_t {.
-    cdecl, importc: "nvgraphCreateGraphDescr", dynlib: libName.}
+    cdecl, importc: "nvgraphCreateGraphDescr", dyn.}
 ##  Destroy a graph descriptor
 
 proc nvgraphDestroyGraphDescr*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t): nvgraphStatus_t {.
-    cdecl, importc: "nvgraphDestroyGraphDescr", dynlib: libName.}
+    cdecl, importc: "nvgraphDestroyGraphDescr", dyn.}
 ##  Set size, topology data in the graph descriptor
 
 proc nvgraphSetGraphStructure*(handle: nvgraphHandle_t;
                               descrG: nvgraphGraphDescr_t; topologyData: pointer;
                               TType: nvgraphTopologyType_t): nvgraphStatus_t {.
-    cdecl, importc: "nvgraphSetGraphStructure", dynlib: libName.}
+    cdecl, importc: "nvgraphSetGraphStructure", dyn.}
 ##  Query size and topology information from the graph descriptor
 
 proc nvgraphGetGraphStructure*(handle: nvgraphHandle_t;
                               descrG: nvgraphGraphDescr_t; topologyData: pointer;
                               TType: ptr nvgraphTopologyType_t): nvgraphStatus_t {.
-    cdecl, importc: "nvgraphGetGraphStructure", dynlib: libName.}
+    cdecl, importc: "nvgraphGetGraphStructure", dyn.}
 ##  Allocate numsets vectors of size V reprensenting Vertex Data and attached them the graph.
 ##  settypes[i] is the type of vector #i, currently all Vertex and Edge data should have the same type
 
 proc nvgraphAllocateVertexData*(handle: nvgraphHandle_t;
                                descrG: nvgraphGraphDescr_t; numsets: csize;
                                settypes: ptr cudaDataType): nvgraphStatus_t {.cdecl,
-    importc: "nvgraphAllocateVertexData", dynlib: libName.}
+    importc: "nvgraphAllocateVertexData", dyn.}
 ##  Allocate numsets vectors of size E reprensenting Edge Data and attached them the graph.
 ##  settypes[i] is the type of vector #i, currently all Vertex and Edge data should have the same type
 
 proc nvgraphAllocateEdgeData*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                              numsets: csize; settypes: ptr cudaDataType): nvgraphStatus_t {.
-    cdecl, importc: "nvgraphAllocateEdgeData", dynlib: libName.}
+    cdecl, importc: "nvgraphAllocateEdgeData", dyn.}
 ##  Update the vertex set #setnum with the data in *vertexData, sets have 0-based index
 ##   Conversions are not sopported so nvgraphTopologyType_t should match the graph structure
 
 proc nvgraphSetVertexData*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                           vertexData: pointer; setnum: csize): nvgraphStatus_t {.
-    cdecl, importc: "nvgraphSetVertexData", dynlib: libName.}
+    cdecl, importc: "nvgraphSetVertexData", dyn.}
 ##  Copy the edge set #setnum in *edgeData, sets have 0-based index
 ##   Conversions are not sopported so nvgraphTopologyType_t should match the graph structure
 
 proc nvgraphGetVertexData*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                           vertexData: pointer; setnum: csize): nvgraphStatus_t {.
-    cdecl, importc: "nvgraphGetVertexData", dynlib: libName.}
+    cdecl, importc: "nvgraphGetVertexData", dyn.}
 ##  Convert the edge data to another topology
 ## 
 
@@ -159,26 +162,26 @@ proc nvgraphConvertTopology*(handle: nvgraphHandle_t;
                             srcEdgeData: pointer; dataType: ptr cudaDataType;
                             dstTType: nvgraphTopologyType_t; dstTopology: pointer;
                             dstEdgeData: pointer): nvgraphStatus_t {.cdecl,
-    importc: "nvgraphConvertTopology", dynlib: libName.}
+    importc: "nvgraphConvertTopology", dyn.}
 ##  Convert graph to another structure
 ## 
 
 proc nvgraphConvertGraph*(handle: nvgraphHandle_t; srcDescrG: nvgraphGraphDescr_t;
                          dstDescrG: nvgraphGraphDescr_t;
                          dstTType: nvgraphTopologyType_t): nvgraphStatus_t {.cdecl,
-    importc: "nvgraphConvertGraph", dynlib: libName.}
+    importc: "nvgraphConvertGraph", dyn.}
 ##  Update the edge set #setnum with the data in *edgeData, sets have 0-based index
 ##   Conversions are not sopported so nvgraphTopologyType_t should match the graph structure
 
 proc nvgraphSetEdgeData*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                         edgeData: pointer; setnum: csize): nvgraphStatus_t {.cdecl,
-    importc: "nvgraphSetEdgeData", dynlib: libName.}
+    importc: "nvgraphSetEdgeData", dyn.}
 ##  Copy the edge set #setnum in *edgeData, sets have 0-based index
 ##  Conversions are not sopported so nvgraphTopologyType_t should match the graph structure
 
 proc nvgraphGetEdgeData*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                         edgeData: pointer; setnum: csize): nvgraphStatus_t {.cdecl,
-    importc: "nvgraphGetEdgeData", dynlib: libName.}
+    importc: "nvgraphGetEdgeData", dyn.}
 ##  create a new graph by extracting a subgraph given a list of vertices
 ## 
 
@@ -186,7 +189,7 @@ proc nvgraphExtractSubgraphByVertex*(handle: nvgraphHandle_t;
                                     descrG: nvgraphGraphDescr_t;
                                     subdescrG: nvgraphGraphDescr_t;
                                     subvertices: ptr cint; numvertices: csize): nvgraphStatus_t {.
-    cdecl, importc: "nvgraphExtractSubgraphByVertex", dynlib: libName.}
+    cdecl, importc: "nvgraphExtractSubgraphByVertex", dyn.}
 ##  create a new graph by extracting a subgraph given a list of edges
 ## 
 
@@ -194,21 +197,21 @@ proc nvgraphExtractSubgraphByEdge*(handle: nvgraphHandle_t;
                                   descrG: nvgraphGraphDescr_t;
                                   subdescrG: nvgraphGraphDescr_t;
                                   subedges: ptr cint; numedges: csize): nvgraphStatus_t {.
-    cdecl, importc: "nvgraphExtractSubgraphByEdge", dynlib: libName.}
+    cdecl, importc: "nvgraphExtractSubgraphByEdge", dyn.}
 ##  nvGRAPH Semi-ring sparse matrix vector multiplication
 ## 
 
 proc nvgraphSrSpmv*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                    weight_index: csize; alpha: pointer; x_index: csize; beta: pointer;
                    y_index: csize; SR: nvgraphSemiring_t): nvgraphStatus_t {.cdecl,
-    importc: "nvgraphSrSpmv", dynlib: libName.}
+    importc: "nvgraphSrSpmv", dyn.}
 ##  nvGRAPH Single Source Shortest Path (SSSP)
 ##  Calculate the shortest path distance from a single vertex in the graph to all other vertices.
 ## 
 
 proc nvgraphSssp*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                  weight_index: csize; source_vert: ptr cint; sssp_index: csize): nvgraphStatus_t {.
-    cdecl, importc: "nvgraphSssp", dynlib: libName.}
+    cdecl, importc: "nvgraphSssp", dyn.}
 ##  nvGRAPH WidestPath
 ##  Find widest path potential from source_index to every other vertices.
 ## 
@@ -216,7 +219,7 @@ proc nvgraphSssp*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
 proc nvgraphWidestPath*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                        weight_index: csize; source_vert: ptr cint;
                        widest_path_index: csize): nvgraphStatus_t {.cdecl,
-    importc: "nvgraphWidestPath", dynlib: libName.}
+    importc: "nvgraphWidestPath", dyn.}
 ##  nvGRAPH PageRank
 ##  Find PageRank for each vertex of a graph with a given transition probabilities, a bookmark vector of dangling vertices, and the damping factor.
 ## 
@@ -225,4 +228,4 @@ proc nvgraphPagerank*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                      weight_index: csize; alpha: pointer; bookmark_index: csize;
                      has_guess: cint; pagerank_index: csize; tolerance: cfloat;
                      max_iter: cint): nvgraphStatus_t {.cdecl,
-    importc: "nvgraphPagerank", dynlib: libName.}
+    importc: "nvgraphPagerank", dyn.}


### PR DESCRIPTION
This should fix the library names used on windows.

Note: I did not directly test this as I do not have any experience with c2nim, but changing libName in the generated *.nim files as in the headers did the trick.