### PR TITLE
fix docs by escaping all rows with a `*` in it, except single `*`

### DIFF
--- a/nimcuda/cublas_api.nim
+++ b/nimcuda/cublas_api.nim
@@ -23,15 +23,15 @@ type
 import
   library_types, cuComplex
 
-## 
+##
 ##  Copyright 1993-2014 NVIDIA Corporation.  All rights reserved.
-## 
+##
 ##  NOTICE TO LICENSEE:
-## 
+##
 ##  This source code and/or documentation ("Licensed Deliverables") are
 ##  subject to NVIDIA intellectual property rights under U.S. and
 ##  international Copyright laws.
-## 
+##
 ##  These Licensed Deliverables contained herein is PROPRIETARY and
 ##  CONFIDENTIAL to NVIDIA and is being provided under the terms and
 ##  conditions of a form of NVIDIA software license agreement by and
@@ -40,7 +40,7 @@ import
 ##  the contrary in the License Agreement, reproduction or disclosure
 ##  of the Licensed Deliverables to any third party without the express
 ##  written consent of NVIDIA is prohibited.
-## 
+##
 ##  NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
 ##  LICENSE AGREEMENT, NVIDIA MAKES NO REPRESENTATION ABOUT THE
 ##  SUITABILITY OF THESE LICENSED DELIVERABLES FOR ANY PURPOSE.  IT IS
@@ -55,7 +55,7 @@ import
 ##  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 ##  ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
 ##  OF THESE LICENSED DELIVERABLES.
-## 
+##
 ##  U.S. Government End Users.  These Licensed Deliverables are a
 ##  "commercial item" as that term is defined at 48 C.F.R. 2.101 (OCT
 ##  1995), consisting of "commercial computer software" and "commercial
@@ -65,18 +65,18 @@ import
 ##  48 C.F.R. 227.7202-1 through 227.7202-4 (JUNE 1995), all
 ##  U.S. Government End Users acquire the Licensed Deliverables with
 ##  only those rights set forth herein.
-## 
+##
 ##  Any use of the Licensed Deliverables in individual and commercial
 ##  software must include, in the user documentation and internal
 ##  comments to the code, the above Disclaimer and U.S. Government End
 ##  Users Notice.
-## 
-## 
+##
+##
 ##  This is the public header file for the CUBLAS library, defining the API
-## 
-##  CUBLAS is an implementation of BLAS (Basic Linear Algebra Subroutines) 
-##  on top of the CUDA runtime. 
-## 
+##
+##  CUBLAS is an implementation of BLAS (Basic Linear Algebra Subroutines)
+##  on top of the CUDA runtime.
+##
 
 when not defined(CUBLAS_API_H):
   const
@@ -113,7 +113,7 @@ when not defined(CUBLAS_API_H):
   ##  Opaque structure holding CUBLAS library context
   type
     cublasContext* = object
-    
+
   type
     cublasHandle_t* = ptr cublasContext
   proc cublasCreate_v2*(handle: ptr cublasHandle_t): cublasStatus_t {.cdecl,
@@ -137,185 +137,185 @@ when not defined(CUBLAS_API_H):
       cdecl, importc: "cublasGetAtomicsMode", dyn.}
   proc cublasSetAtomicsMode*(handle: cublasHandle_t; mode: cublasAtomicsMode_t): cublasStatus_t {.
       cdecl, importc: "cublasSetAtomicsMode", dyn.}
-  ##  
-  ##  cublasStatus_t 
-  ##  cublasSetVector (int n, int elemSize, const void *x, int incx, 
-  ##                   void *y, int incy) 
-  ## 
-  ##  copies n elements from a vector x in CPU memory space to a vector y 
-  ##  in GPU memory space. Elements in both vectors are assumed to have a 
+  ##
+  ##  `cublasStatus_t`
+  ##  `cublasSetVector (int n, int elemSize, const void *x, int incx,`
+  ##                    `void *y, int incy)`
+  ##
+  ##  copies n elements from a vector x in CPU memory space to a vector y
+  ##  in GPU memory space. Elements in both vectors are assumed to have a
   ##  size of elemSize bytes. Storage spacing between consecutive elements
   ##  is incx for the source vector x and incy for the destination vector
   ##  y. In general, y points to an object, or part of an object, allocated
   ##  via cublasAlloc(). Column major format for two-dimensional matrices
-  ##  is assumed throughout CUBLAS. Therefore, if the increment for a vector 
-  ##  is equal to 1, this access a column vector while using an increment 
-  ##  equal to the leading dimension of the respective matrix accesses a 
+  ##  is assumed throughout CUBLAS. Therefore, if the increment for a vector
+  ##  is equal to 1, this access a column vector while using an increment
+  ##  equal to the leading dimension of the respective matrix accesses a
   ##  row vector.
-  ## 
+  ##
   ##  Return Values
   ##  -------------
   ##  CUBLAS_STATUS_NOT_INITIALIZED  if CUBLAS library not been initialized
   ##  CUBLAS_STATUS_INVALID_VALUE    if incx, incy, or elemSize <= 0
-  ##  CUBLAS_STATUS_MAPPING_ERROR    if an error occurred accessing GPU memory   
+  ##  CUBLAS_STATUS_MAPPING_ERROR    if an error occurred accessing GPU memory
   ##  CUBLAS_STATUS_SUCCESS          if the operation completed successfully
-  ## 
+  ##
   proc cublasSetVector*(n: cint; elemSize: cint; x: pointer; incx: cint;
                        devicePtr: pointer; incy: cint): cublasStatus_t {.cdecl,
       importc: "cublasSetVector", dyn.}
-  ##  
-  ##  cublasStatus_t 
-  ##  cublasGetVector (int n, int elemSize, const void *x, int incx, 
-  ##                   void *y, int incy)
-  ##  
-  ##  copies n elements from a vector x in GPU memory space to a vector y 
-  ##  in CPU memory space. Elements in both vectors are assumed to have a 
+  ##
+  ##  cublasStatus_t
+  ##  `cublasGetVector (int n, int elemSize, const void *x, int incx,`
+  ##                    `void *y, int incy)`
+  ##
+  ##  copies n elements from a vector x in GPU memory space to a vector y
+  ##  in CPU memory space. Elements in both vectors are assumed to have a
   ##  size of elemSize bytes. Storage spacing between consecutive elements
   ##  is incx for the source vector x and incy for the destination vector
   ##  y. In general, x points to an object, or part of an object, allocated
   ##  via cublasAlloc(). Column major format for two-dimensional matrices
-  ##  is assumed throughout CUBLAS. Therefore, if the increment for a vector 
-  ##  is equal to 1, this access a column vector while using an increment 
-  ##  equal to the leading dimension of the respective matrix accesses a 
+  ##  is assumed throughout CUBLAS. Therefore, if the increment for a vector
+  ##  is equal to 1, this access a column vector while using an increment
+  ##  equal to the leading dimension of the respective matrix accesses a
   ##  row vector.
-  ## 
+  ##
   ##  Return Values
   ##  -------------
   ##  CUBLAS_STATUS_NOT_INITIALIZED  if CUBLAS library not been initialized
   ##  CUBLAS_STATUS_INVALID_VALUE    if incx, incy, or elemSize <= 0
-  ##  CUBLAS_STATUS_MAPPING_ERROR    if an error occurred accessing GPU memory   
+  ##  CUBLAS_STATUS_MAPPING_ERROR    if an error occurred accessing GPU memory
   ##  CUBLAS_STATUS_SUCCESS          if the operation completed successfully
-  ## 
+  ##
   proc cublasGetVector*(n: cint; elemSize: cint; x: pointer; incx: cint; y: pointer;
                        incy: cint): cublasStatus_t {.cdecl,
       importc: "cublasGetVector", dyn.}
-  ## 
-  ##  cublasStatus_t 
-  ##  cublasSetMatrix (int rows, int cols, int elemSize, const void *A, 
-  ##                   int lda, void *B, int ldb)
-  ## 
+  ##
+  ##  cublasStatus_t
+  ##  `cublasSetMatrix (int rows, int cols, int elemSize, const void *A,`
+  ##                   `int lda, void *B, int ldb)`
+  ##
   ##  copies a tile of rows x cols elements from a matrix A in CPU memory
   ##  space to a matrix B in GPU memory space. Each element requires storage
-  ##  of elemSize bytes. Both matrices are assumed to be stored in column 
-  ##  major format, with the leading dimension (i.e. number of rows) of 
+  ##  of elemSize bytes. Both matrices are assumed to be stored in column
+  ##  major format, with the leading dimension (i.e. number of rows) of
   ##  source matrix A provided in lda, and the leading dimension of matrix B
-  ##  provided in ldb. In general, B points to an object, or part of an 
+  ##  provided in ldb. In general, B points to an object, or part of an
   ##  object, that was allocated via cublasAlloc().
-  ## 
-  ##  Return Values 
+  ##
+  ##  Return Values
   ##  -------------
   ##  CUBLAS_STATUS_NOT_INITIALIZED  if CUBLAS library has not been initialized
-  ##  CUBLAS_STATUS_INVALID_VALUE    if rows or cols < 0, or elemSize, lda, or 
+  ##  CUBLAS_STATUS_INVALID_VALUE    if rows or cols < 0, or elemSize, lda, or
   ##                                 ldb <= 0
   ##  CUBLAS_STATUS_MAPPING_ERROR    if error occurred accessing GPU memory
   ##  CUBLAS_STATUS_SUCCESS          if the operation completed successfully
-  ## 
+  ##
   proc cublasSetMatrix*(rows: cint; cols: cint; elemSize: cint; A: pointer; lda: cint;
                        B: pointer; ldb: cint): cublasStatus_t {.cdecl,
       importc: "cublasSetMatrix", dyn.}
-  ## 
-  ##  cublasStatus_t 
-  ##  cublasGetMatrix (int rows, int cols, int elemSize, const void *A, 
-  ##                   int lda, void *B, int ldb)
-  ## 
+  ##
+  ##  cublasStatus_t
+  ##  `cublasGetMatrix (int rows, int cols, int elemSize, const void *A,`
+  ##                   `int lda, void *B, int ldb)`
+  ##
   ##  copies a tile of rows x cols elements from a matrix A in GPU memory
   ##  space to a matrix B in CPU memory space. Each element requires storage
-  ##  of elemSize bytes. Both matrices are assumed to be stored in column 
-  ##  major format, with the leading dimension (i.e. number of rows) of 
+  ##  of elemSize bytes. Both matrices are assumed to be stored in column
+  ##  major format, with the leading dimension (i.e. number of rows) of
   ##  source matrix A provided in lda, and the leading dimension of matrix B
-  ##  provided in ldb. In general, A points to an object, or part of an 
+  ##  provided in ldb. In general, A points to an object, or part of an
   ##  object, that was allocated via cublasAlloc().
-  ## 
-  ##  Return Values 
+  ##
+  ##  Return Values
   ##  -------------
   ##  CUBLAS_STATUS_NOT_INITIALIZED  if CUBLAS library has not been initialized
   ##  CUBLAS_STATUS_INVALID_VALUE    if rows, cols, eleSize, lda, or ldb <= 0
   ##  CUBLAS_STATUS_MAPPING_ERROR    if error occurred accessing GPU memory
   ##  CUBLAS_STATUS_SUCCESS          if the operation completed successfully
-  ## 
+  ##
   proc cublasGetMatrix*(rows: cint; cols: cint; elemSize: cint; A: pointer; lda: cint;
                        B: pointer; ldb: cint): cublasStatus_t {.cdecl,
       importc: "cublasGetMatrix", dyn.}
-  ##  
-  ##  cublasStatus 
-  ##  cublasSetVectorAsync ( int n, int elemSize, const void *x, int incx, 
-  ##                        void *y, int incy, cudaStream_t stream );
-  ## 
+  ##
+  ##  cublasStatus
+  ##  `cublasSetVectorAsync ( int n, int elemSize, const void *x, int incx,`
+  ##                        `void *y, int incy, cudaStream_t stream );`
+  ##
   ##  cublasSetVectorAsync has the same functionnality as cublasSetVector
   ##  but the transfer is done asynchronously within the CUDA stream passed
   ##  in parameter.
-  ## 
+  ##
   ##  Return Values
   ##  -------------
   ##  CUBLAS_STATUS_NOT_INITIALIZED  if CUBLAS library not been initialized
   ##  CUBLAS_STATUS_INVALID_VALUE    if incx, incy, or elemSize <= 0
-  ##  CUBLAS_STATUS_MAPPING_ERROR    if an error occurred accessing GPU memory   
+  ##  CUBLAS_STATUS_MAPPING_ERROR    if an error occurred accessing GPU memory
   ##  CUBLAS_STATUS_SUCCESS          if the operation completed successfully
-  ## 
+  ##
   proc cublasSetVectorAsync*(n: cint; elemSize: cint; hostPtr: pointer; incx: cint;
                             devicePtr: pointer; incy: cint; stream: cudaStream_t): cublasStatus_t {.
       cdecl, importc: "cublasSetVectorAsync", dyn.}
-  ##  
-  ##  cublasStatus 
-  ##  cublasGetVectorAsync( int n, int elemSize, const void *x, int incx, 
-  ##                        void *y, int incy, cudaStream_t stream)
-  ##  
+  ##
+  ##  cublasStatus
+  ##  `cublasGetVectorAsync( int n, int elemSize, const void *x, int incx,`
+  ##                        `void *y, int incy, cudaStream_t stream)`
+  ##
   ##  cublasGetVectorAsync has the same functionnality as cublasGetVector
   ##  but the transfer is done asynchronously within the CUDA stream passed
   ##  in parameter.
-  ## 
+  ##
   ##  Return Values
   ##  -------------
   ##  CUBLAS_STATUS_NOT_INITIALIZED  if CUBLAS library not been initialized
   ##  CUBLAS_STATUS_INVALID_VALUE    if incx, incy, or elemSize <= 0
-  ##  CUBLAS_STATUS_MAPPING_ERROR    if an error occurred accessing GPU memory   
+  ##  CUBLAS_STATUS_MAPPING_ERROR    if an error occurred accessing GPU memory
   ##  CUBLAS_STATUS_SUCCESS          if the operation completed successfully
-  ## 
+  ##
   proc cublasGetVectorAsync*(n: cint; elemSize: cint; devicePtr: pointer; incx: cint;
                             hostPtr: pointer; incy: cint; stream: cudaStream_t): cublasStatus_t {.
       cdecl, importc: "cublasGetVectorAsync", dyn.}
-  ## 
-  ##  cublasStatus_t 
-  ##  cublasSetMatrixAsync (int rows, int cols, int elemSize, const void *A, 
-  ##                        int lda, void *B, int ldb, cudaStream_t stream)
-  ## 
+  ##
+  ##  cublasStatus_t
+  ##  `cublasSetMatrixAsync (int rows, int cols, int elemSize, const void *A,`
+  ##                        `int lda, void *B, int ldb, cudaStream_t stream)`
+  ##
   ##  cublasSetMatrixAsync has the same functionnality as cublasSetMatrix
   ##  but the transfer is done asynchronously within the CUDA stream passed
   ##  in parameter.
-  ## 
-  ##  Return Values 
+  ##
+  ##  Return Values
   ##  -------------
   ##  CUBLAS_STATUS_NOT_INITIALIZED  if CUBLAS library has not been initialized
-  ##  CUBLAS_STATUS_INVALID_VALUE    if rows or cols < 0, or elemSize, lda, or 
+  ##  CUBLAS_STATUS_INVALID_VALUE    if rows or cols < 0, or elemSize, lda, or
   ##                                 ldb <= 0
   ##  CUBLAS_STATUS_MAPPING_ERROR    if error occurred accessing GPU memory
   ##  CUBLAS_STATUS_SUCCESS          if the operation completed successfully
-  ## 
+  ##
   proc cublasSetMatrixAsync*(rows: cint; cols: cint; elemSize: cint; A: pointer;
                             lda: cint; B: pointer; ldb: cint; stream: cudaStream_t): cublasStatus_t {.
       cdecl, importc: "cublasSetMatrixAsync", dyn.}
-  ## 
-  ##  cublasStatus_t 
-  ##  cublasGetMatrixAsync (int rows, int cols, int elemSize, const void *A, 
-  ##                        int lda, void *B, int ldb, cudaStream_t stream)
-  ## 
+  ##
+  ##  cublasStatus_t
+  ##  `cublasGetMatrixAsync (int rows, int cols, int elemSize, const void *A,`
+  ##                        `int lda, void *B, int ldb, cudaStream_t stream)`
+  ##
   ##  cublasGetMatrixAsync has the same functionnality as cublasGetMatrix
   ##  but the transfer is done asynchronously within the CUDA stream passed
   ##  in parameter.
-  ## 
-  ##  Return Values 
+  ##
+  ##  Return Values
   ##  -------------
   ##  CUBLAS_STATUS_NOT_INITIALIZED  if CUBLAS library has not been initialized
   ##  CUBLAS_STATUS_INVALID_VALUE    if rows, cols, eleSize, lda, or ldb <= 0
   ##  CUBLAS_STATUS_MAPPING_ERROR    if error occurred accessing GPU memory
   ##  CUBLAS_STATUS_SUCCESS          if the operation completed successfully
-  ## 
+  ##
   proc cublasGetMatrixAsync*(rows: cint; cols: cint; elemSize: cint; A: pointer;
                             lda: cint; B: pointer; ldb: cint; stream: cudaStream_t): cublasStatus_t {.
       cdecl, importc: "cublasGetMatrixAsync", dyn.}
   proc cublasXerbla*(srName: cstring; info: cint) {.cdecl, importc: "cublasXerbla",
       dyn.}
-  ##  ---------------- CUBLAS BLAS1 functions ----------------
+  ##  CUBLAS BLAS1 functions
   proc cublasNrm2Ex*(handle: cublasHandle_t; n: cint; x: pointer; xType: cudaDataType;
                     incx: cint; result: pointer; resultType: cudaDataType;
                     executionType: cudaDataType): cublasStatus_t {.cdecl,

--- a/nimcuda/cuda_occupancy.nim
+++ b/nimcuda/cuda_occupancy.nim
@@ -262,7 +262,7 @@ type
 ##  The suggested block size and the minimum number of blocks needed to achieve
 ##  the maximum occupancy are returned through blockSize and minGridSize.
 ##
-##  If *blockSize is 0, then the given combination cannot run on the device.
+##  If `*blockSize` is 0, then the given combination cannot run on the device.
 ##
 ##  ERRORS
 ##
@@ -311,7 +311,7 @@ type
 ##  The suggested block size and the minimum number of blocks needed to achieve
 ##  the maximum occupancy are returned through blockSize and minGridSize.
 ##
-##  If *blockSize is 0, then the given combination cannot run on the device.
+##  If `*blockSize` is 0, then the given combination cannot run on the device.
 ##
 ##  ERRORS
 ##
@@ -471,7 +471,7 @@ proc cudaOccSMemPerMultiprocessor*(limit: ptr csize;
                          ##
       bytes = (sharedMemPerMultiprocessorHigh + sharedMemPerMultiprocessorLow) div
           2
-  of 5, 6: 
+  of 5, 6:
     ##  Maxwell and Pascal have dedicated shared memory.
     ##
     bytes = sharedMemPerMultiprocessorHigh

--- a/nimcuda/cuda_runtime_api.nim
+++ b/nimcuda/cuda_runtime_api.nim
@@ -14,15 +14,15 @@ else:
 import
   vector_types, driver_types, surface_types, texture_types
 
-## 
+##
 ##  Copyright 1993-2012 NVIDIA Corporation.  All rights reserved.
-## 
+##
 ##  NOTICE TO LICENSEE:
-## 
+##
 ##  This source code and/or documentation ("Licensed Deliverables") are
 ##  subject to NVIDIA intellectual property rights under U.S. and
 ##  international Copyright laws.
-## 
+##
 ##  These Licensed Deliverables contained herein is PROPRIETARY and
 ##  CONFIDENTIAL to NVIDIA and is being provided under the terms and
 ##  conditions of a form of NVIDIA software license agreement by and
@@ -31,7 +31,7 @@ import
 ##  the contrary in the License Agreement, reproduction or disclosure
 ##  of the Licensed Deliverables to any third party without the express
 ##  written consent of NVIDIA is prohibited.
-## 
+##
 ##  NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
 ##  LICENSE AGREEMENT, NVIDIA MAKES NO REPRESENTATION ABOUT THE
 ##  SUITABILITY OF THESE LICENSED DELIVERABLES FOR ANY PURPOSE.  IT IS
@@ -46,7 +46,7 @@ import
 ##  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 ##  ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
 ##  OF THESE LICENSED DELIVERABLES.
-## 
+##
 ##  U.S. Government End Users.  These Licensed Deliverables are a
 ##  "commercial item" as that term is defined at 48 C.F.R. 2.101 (OCT
 ##  1995), consisting of "commercial computer software" and "commercial
@@ -56,12 +56,12 @@ import
 ##  48 C.F.R. 227.7202-1 through 227.7202-4 (JUNE 1995), all
 ##  U.S. Government End Users acquire the Licensed Deliverables with
 ##  only those rights set forth herein.
-## 
+##
 ##  Any use of the Licensed Deliverables in individual and commercial
 ##  software must include, in the user documentation and internal
 ##  comments to the code, the above Disclaimer and U.S. Government End
 ##  Users Notice.
-## 
+##
 
 when not defined(CUDA_RUNTIME_API_H):
   const
@@ -69,7 +69,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ## *
   ##  \latexonly
   ##  \page sync_async API synchronization behavior
-  ## 
+  ##
   ##  \section memcpy_sync_async_behavior Memcpy
   ##  The API provides memcpy/memset functions in both synchronous and asynchronous forms,
   ##  the latter having an \e "Async" suffix. This is a misnomer as each function
@@ -77,60 +77,60 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  passed to the function. In the reference documentation, each memcpy function is
   ##  categorized as \e synchronous or \e asynchronous, corresponding to the definitions
   ##  below.
-  ## 
+  ##
   ##  \subsection MemcpySynchronousBehavior Synchronous
-  ## 
+  ##
   ##  <ol>
   ##  <li> For transfers from pageable host memory to device memory, a stream sync is performed
   ##  before the copy is initiated. The function will return once the pageable
   ##  buffer has been copied to the staging memory for DMA transfer to device memory,
   ##  but the DMA to final destination may not have completed.
-  ## 
+  ##
   ##  <li> For transfers from pinned host memory to device memory, the function is synchronous
   ##  with respect to the host.
-  ## 
+  ##
   ##  <li> For transfers from device to either pageable or pinned host memory, the function returns
   ##  only once the copy has completed.
-  ## 
+  ##
   ##  <li> For transfers from device memory to device memory, no host-side synchronization is
   ##  performed.
-  ## 
+  ##
   ##  <li> For transfers from any host memory to any host memory, the function is fully
   ##  synchronous with respect to the host.
   ##  </ol>
-  ## 
+  ##
   ##  \subsection MemcpyAsynchronousBehavior Asynchronous
-  ## 
+  ##
   ##  <ol>
   ##  <li> For transfers from device memory to pageable host memory, the function
   ##  will return only once the copy has completed.
-  ## 
+  ##
   ##  <li> For transfers from any host memory to any host memory, the function is fully
   ##  synchronous with respect to the host.
-  ## 
+  ##
   ##  <li> For all other transfers, the function is fully asynchronous. If pageable
   ##  memory must first be staged to pinned memory, this will be handled
   ##  asynchronously with a worker thread.
   ##  </ol>
-  ## 
+  ##
   ##  \section memset_sync_async_behavior Memset
   ##  The cudaMemset functions are asynchronous with respect to the host
   ##  except when the target memory is pinned host memory. The \e Async
   ##  versions are always asynchronous with respect to the host.
-  ## 
+  ##
   ##  \section kernel_launch_details Kernel Launches
   ##  Kernel launches are asynchronous with respect to the host. Details of
   ##  concurrent kernel execution and data transfers can be found in the CUDA
   ##  Programmers Guide.
-  ## 
+  ##
   ##  \endlatexonly
-  ## 
+  ##
   ## *
   ##  There are two levels for the runtime API.
-  ## 
+  ##
   ##  The C API (<i>cuda_runtime_api.h</i>) is
   ##  a C-style interface that does not require compiling with \p nvcc.
-  ## 
+  ##
   ##  The \ref CUDART_HIGHLEVEL "C++ API" (<i>cuda_runtime.h</i>) is a
   ##  C++-style interface built on top of the C API. It wraps some of the
   ##  C API routines, using overloading, references and default arguments.
@@ -140,85 +140,85 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  These wrappers require the use of \p nvcc because they depend on code being
   ##  generated by the compiler. For example, the execution configuration syntax
   ##  to invoke kernels is only available in source code compiled with \p nvcc.
-  ## 
+  ##
   ## * CUDA Runtime API Version
   const
     CUDART_VERSION* = 8000
   ## *
   ##  \defgroup CUDART_DEVICE Device Management
-  ## 
+  ##
   ##  ___MANBRIEF___ device management functions of the CUDA runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the device management functions of the CUDA runtime
   ##  application programming interface.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Destroy all allocations and reset all state on the current device
   ##  in the current process.
-  ## 
+  ##
   ##  Explicitly destroys and cleans up all resources associated with the current
   ##  device in the current process.  Any subsequent API call to this device will
   ##  reinitialize the device.
-  ## 
+  ##
   ##  Note that this function will reset the device immediately.  It is the caller's
   ##  responsibility to ensure that the device is not being accessed by any
   ##  other host threads from the process when this function is called.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceSynchronize
-  ## 
+  ##
   proc cudaDeviceReset*(): cudaError_t {.cdecl, importc: "cudaDeviceReset",
                                       dyn.}
   ## *
   ##  \brief Wait for compute device to finish
-  ## 
+  ##
   ##  Blocks until the device has completed all preceding requested tasks.
   ##  ::cudaDeviceSynchronize() returns an error if one of the preceding tasks
   ##  has failed. If the ::cudaDeviceScheduleBlockingSync flag was set for
   ##  this device, the host thread will block until the device has finished
   ##  its work.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceReset
-  ## 
+  ##
   proc cudaDeviceSynchronize*(): cudaError_t {.cdecl,
       importc: "cudaDeviceSynchronize", dyn.}
   ## *
   ##  \brief Set resource limits
-  ## 
+  ##
   ##  Setting \p limit to \p value is a request by the application to update
   ##  the current limit maintained by the device.  The driver is free to
   ##  modify the requested value to meet h/w requirements (this could be
   ##  clamping to minimum or maximum values, rounding up to nearest element
   ##  size, etc).  The application can use ::cudaDeviceGetLimit() to find out
   ##  exactly what the limit has been set to.
-  ## 
+  ##
   ##  Setting each ::cudaLimit has its own specific restrictions, so each is
   ##  discussed here.
-  ## 
+  ##
   ##  - ::cudaLimitStackSize controls the stack size in bytes of each GPU thread.
-  ## 
+  ##
   ##  - ::cudaLimitPrintfFifoSize controls the size in bytes of the shared FIFO
   ##    used by the ::printf() and ::fprintf() device system calls. Setting
   ##    ::cudaLimitPrintfFifoSize must not be performed after launching any kernel
   ##    that uses the ::printf() or ::fprintf() device system calls - in such case
   ##    ::cudaErrorInvalidValue will be returned.
-  ## 
+  ##
   ##  - ::cudaLimitMallocHeapSize controls the size in bytes of the heap used by
   ##    the ::malloc() and ::free() device system calls. Setting
   ##    ::cudaLimitMallocHeapSize must not be performed after launching any kernel
   ##    that uses the ::malloc() or ::free() device system calls - in such case
   ##    ::cudaErrorInvalidValue will be returned.
-  ## 
+  ##
   ##  - ::cudaLimitDevRuntimeSyncDepth controls the maximum nesting depth of a
   ##    grid at which a thread can safely call ::cudaDeviceSynchronize(). Setting
   ##    this limit must be performed before any launch of a kernel that uses the
@@ -235,7 +235,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    higher. Attempting to set this limit on devices of compute capability less
   ##    than 3.5 will result in the error ::cudaErrorUnsupportedLimit being
   ##    returned.
-  ## 
+  ##
   ##  - ::cudaLimitDevRuntimePendingLaunchCount controls the maximum number of
   ##    outstanding device runtime launches that can be made from the current
   ##    device. A grid is outstanding from the point of launch up until the grid
@@ -252,25 +252,25 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    higher. Attempting to set this limit on devices of compute capability less
   ##    than 3.5 will result in the error ::cudaErrorUnsupportedLimit being
   ##    returned.
-  ## 
+  ##
   ##  \param limit - Limit to set
   ##  \param value - Size of limit
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorUnsupportedLimit,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorMemoryAllocation
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceGetLimit
-  ## 
+  ##
   proc cudaDeviceSetLimit*(limit: cudaLimit; value: csize): cudaError_t {.cdecl,
       importc: "cudaDeviceSetLimit", dyn.}
   ## *
   ##  \brief Returns resource limits
-  ## 
-  ##  Returns in \p *pValue the current size of \p limit.  The supported
+  ##
+  ##  `Returns in \p *pValue the current size of \p limit.  The supported`
   ##  ::cudaLimit values are:
   ##  - ::cudaLimitStackSize: stack size in bytes of each GPU thread;
   ##  - ::cudaLimitPrintfFifoSize: size in bytes of the shared FIFO used by the
@@ -282,177 +282,177 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    to wait on child grid launches to complete.
   ##  - ::cudaLimitDevRuntimePendingLaunchCount: maximum number of outstanding
   ##    device runtime launches.
-  ## 
+  ##
   ##  \param limit  - Limit to query
   ##  \param pValue - Returned size of the limit
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorUnsupportedLimit,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceSetLimit
-  ## 
+  ##
   proc cudaDeviceGetLimit*(pValue: ptr csize; limit: cudaLimit): cudaError_t {.cdecl,
       importc: "cudaDeviceGetLimit", dyn.}
   ## *
   ##  \brief Returns the preferred cache configuration for the current device.
-  ## 
+  ##
   ##  On devices where the L1 cache and shared memory use the same hardware
   ##  resources, this returns through \p pCacheConfig the preferred cache
   ##  configuration for the current device. This is only a preference. The
   ##  runtime will use the requested configuration if possible, but it is free to
   ##  choose a different configuration if required to execute functions.
-  ## 
+  ##
   ##  This will return a \p pCacheConfig of ::cudaFuncCachePreferNone on devices
   ##  where the size of the L1 cache and shared memory are fixed.
-  ## 
+  ##
   ##  The supported cache configurations are:
   ##  - ::cudaFuncCachePreferNone: no preference for shared memory or L1 (default)
   ##  - ::cudaFuncCachePreferShared: prefer larger shared memory and smaller L1 cache
   ##  - ::cudaFuncCachePreferL1: prefer larger L1 cache and smaller shared memory
   ##  - ::cudaFuncCachePreferEqual: prefer equal size L1 cache and shared memory
-  ## 
+  ##
   ##  \param pCacheConfig - Returned cache configuration
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInitializationError
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa cudaDeviceSetCacheConfig,
-  ##  \ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",
-  ##  \ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C++ API)"
-  ## 
+  ##  `\ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",`
+  ##  `\ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C++ API)"`
+  ##
   proc cudaDeviceGetCacheConfig*(pCacheConfig: ptr cudaFuncCache): cudaError_t {.
       cdecl, importc: "cudaDeviceGetCacheConfig", dyn.}
   ## *
   ##  \brief Returns numerical values that correspond to the least and
   ##  greatest stream priorities.
-  ## 
-  ##  Returns in \p *leastPriority and \p *greatestPriority the numerical values that correspond
+  ##
+  ##  `Returns in \p *leastPriority and \p *greatestPriority the numerical values that correspond`
   ##  to the least and greatest stream priorities respectively. Stream priorities
   ##  follow a convention where lower numbers imply greater priorities. The range of
-  ##  meaningful stream priorities is given by [\p *greatestPriority, \p *leastPriority].
+  ##  `meaningful stream priorities is given by [\p *greatestPriority, \p *leastPriority].`
   ##  If the user attempts to create a stream with a priority value that is
   ##  outside the the meaningful range as specified by this API, the priority is
-  ##  automatically clamped down or up to either \p *leastPriority or \p *greatestPriority
+  ##  `automatically clamped down or up to either \p *leastPriority or \p *greatestPriority`
   ##  respectively. See ::cudaStreamCreateWithPriority for details on creating a
   ##  priority stream.
-  ##  A NULL may be passed in for \p *leastPriority or \p *greatestPriority if the value
+  ##  `A NULL may be passed in for \p *leastPriority or \p *greatestPriority if the value`
   ##  is not desired.
-  ## 
-  ##  This function will return '0' in both \p *leastPriority and \p *greatestPriority if
+  ##
+  ##  `This function will return '0' in both \p *leastPriority and \p *greatestPriority if`
   ##  the current context's device does not support stream priorities
   ##  (see ::cudaDeviceGetAttribute).
-  ## 
+  ##
   ##  \param leastPriority    - Pointer to an int in which the numerical value for least
   ##                            stream priority is returned
   ##  \param greatestPriority - Pointer to an int in which the numerical value for greatest
   ##                            stream priority is returned
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaStreamCreateWithPriority,
   ##  ::cudaStreamGetPriority
-  ## 
+  ##
   proc cudaDeviceGetStreamPriorityRange*(leastPriority: ptr cint;
                                         greatestPriority: ptr cint): cudaError_t {.
       cdecl, importc: "cudaDeviceGetStreamPriorityRange", dyn.}
   ## *
   ##  \brief Sets the preferred cache configuration for the current device.
-  ## 
+  ##
   ##  On devices where the L1 cache and shared memory use the same hardware
   ##  resources, this sets through \p cacheConfig the preferred cache
   ##  configuration for the current device. This is only a preference. The
   ##  runtime will use the requested configuration if possible, but it is free to
   ##  choose a different configuration if required to execute the function. Any
   ##  function preference set via
-  ##  \ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)"
+  ##  `\ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)"`
   ##  or
-  ##  \ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C++ API)"
+  ##  `\ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C++ API)"`
   ##  will be preferred over this device-wide setting. Setting the device-wide
   ##  cache configuration to ::cudaFuncCachePreferNone will cause subsequent
   ##  kernel launches to prefer to not change the cache configuration unless
   ##  required to launch the kernel.
-  ## 
+  ##
   ##  This setting does nothing on devices where the size of the L1 cache and
   ##  shared memory are fixed.
-  ## 
+  ##
   ##  Launching a kernel with a different preference than the most recent
   ##  preference setting may insert a device-side synchronization point.
-  ## 
+  ##
   ##  The supported cache configurations are:
   ##  - ::cudaFuncCachePreferNone: no preference for shared memory or L1 (default)
   ##  - ::cudaFuncCachePreferShared: prefer larger shared memory and smaller L1 cache
   ##  - ::cudaFuncCachePreferL1: prefer larger L1 cache and smaller shared memory
   ##  - ::cudaFuncCachePreferEqual: prefer equal size L1 cache and shared memory
-  ## 
+  ##
   ##  \param cacheConfig - Requested cache configuration
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInitializationError
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceGetCacheConfig,
-  ##  \ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",
-  ##  \ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C++ API)"
-  ## 
+  ##  `\ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",`
+  ##  `\ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C++ API)"`
+  ##
   proc cudaDeviceSetCacheConfig*(cacheConfig: cudaFuncCache): cudaError_t {.cdecl,
       importc: "cudaDeviceSetCacheConfig", dyn.}
   ## *
   ##  \brief Returns the shared memory configuration for the current device.
-  ## 
+  ##
   ##  This function will return in \p pConfig the current size of shared memory banks
   ##  on the current device. On devices with configurable shared memory banks,
   ##  ::cudaDeviceSetSharedMemConfig can be used to change this setting, so that all
   ##  subsequent kernel launches will by default use the new bank size. When
   ##  ::cudaDeviceGetSharedMemConfig is called on devices without configurable shared
   ##  memory, it will return the fixed bank size of the hardware.
-  ## 
+  ##
   ##  The returned bank configurations can be either:
   ##  - ::cudaSharedMemBankSizeFourByte - shared memory bank width is four bytes.
   ##  - ::cudaSharedMemBankSizeEightByte - shared memory bank width is eight bytes.
-  ## 
+  ##
   ##  \param pConfig - Returned cache configuration
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInitializationError
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceSetCacheConfig,
   ##  ::cudaDeviceGetCacheConfig,
   ##  ::cudaDeviceSetSharedMemConfig,
   ##  ::cudaFuncSetCacheConfig
-  ## 
+  ##
   proc cudaDeviceGetSharedMemConfig*(pConfig: ptr cudaSharedMemConfig): cudaError_t {.
       cdecl, importc: "cudaDeviceGetSharedMemConfig", dyn.}
   ## *
   ##  \brief Sets the shared memory configuration for the current device.
-  ## 
+  ##
   ##  On devices with configurable shared memory banks, this function will set
   ##  the shared memory bank size which is used for all subsequent kernel launches.
   ##  Any per-function setting of shared memory set via ::cudaFuncSetSharedMemConfig
   ##  will override the device wide setting.
-  ## 
+  ##
   ##  Changing the shared memory configuration between launches may introduce
   ##  a device side synchronization point.
-  ## 
+  ##
   ##  Changing the shared memory bank size will not increase shared memory usage
   ##  or affect occupancy of kernels, but may have major effects on performance.
   ##  Larger bank sizes will allow for greater potential bandwidth to shared memory,
   ##  but will change what kinds of accesses to shared memory will result in bank
   ##  conflicts.
-  ## 
+  ##
   ##  This function will do nothing on devices with fixed shared memory bank size.
-  ## 
+  ##
   ##  The supported bank configurations are:
   ##  - ::cudaSharedMemBankSizeDefault: set bank width the device default (currently,
   ##    four bytes)
@@ -460,101 +460,101 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    natively.
   ##  - ::cudaSharedMemBankSizeEightByte: set shared memory bank width to be eight
   ##    bytes natively.
-  ## 
+  ##
   ##  \param config - Requested cache configuration
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInitializationError
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceSetCacheConfig,
   ##  ::cudaDeviceGetCacheConfig,
   ##  ::cudaDeviceGetSharedMemConfig,
   ##  ::cudaFuncSetCacheConfig
-  ## 
+  ##
   proc cudaDeviceSetSharedMemConfig*(config: cudaSharedMemConfig): cudaError_t {.
       cdecl, importc: "cudaDeviceSetSharedMemConfig", dyn.}
   ## *
   ##  \brief Returns a handle to a compute device
-  ## 
-  ##  Returns in \p *device a device ordinal given a PCI bus ID string.
-  ## 
+  ##
+  ##  `Returns in \p *device a device ordinal given a PCI bus ID string.`
+  ##
   ##  \param device   - Returned device ordinal
-  ## 
+  ##
   ##  \param pciBusId - String in one of the following forms:
   ##  [domain]:[bus]:[device].[function]
   ##  [domain]:[bus]:[device]
   ##  [bus]:[device].[function]
   ##  where \p domain, \p bus, \p device, and \p function are all hexadecimal values
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidDevice
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceGetPCIBusId
-  ## 
+  ##
   proc cudaDeviceGetByPCIBusId*(device: ptr cint; pciBusId: cstring): cudaError_t {.
       cdecl, importc: "cudaDeviceGetByPCIBusId", dyn.}
   ## *
   ##  \brief Returns a PCI Bus Id string for the device
-  ## 
+  ##
   ##  Returns an ASCII string identifying the device \p dev in the NULL-terminated
   ##  string pointed to by \p pciBusId. \p len specifies the maximum length of the
   ##  string that may be returned.
-  ## 
+  ##
   ##  \param pciBusId - Returned identifier string for the device in the following format
   ##  [domain]:[bus]:[device].[function]
   ##  where \p domain, \p bus, \p device, and \p function are all hexadecimal values.
   ##  pciBusId should be large enough to store 13 characters including the NULL-terminator.
-  ## 
+  ##
   ##  \param len      - Maximum length of string to store in \p name
-  ## 
+  ##
   ##  \param device   - Device to get identifier string for
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidDevice
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceGetByPCIBusId
-  ## 
-  ## 
+  ##
+  ##
   proc cudaDeviceGetPCIBusId*(pciBusId: cstring; len: cint; device: cint): cudaError_t {.
       cdecl, importc: "cudaDeviceGetPCIBusId", dyn.}
   ## *
   ##  \brief Gets an interprocess handle for a previously allocated event
-  ## 
+  ##
   ##  Takes as input a previously allocated event. This event must have been
   ##  created with the ::cudaEventInterprocess and ::cudaEventDisableTiming
   ##  flags set. This opaque handle may be copied into other processes and
   ##  opened with ::cudaIpcOpenEventHandle to allow efficient hardware
   ##  synchronization between GPU work in different processes.
-  ## 
+  ##
   ##  After the event has been been opened in the importing process,
   ##  ::cudaEventRecord, ::cudaEventSynchronize, ::cudaStreamWaitEvent and
   ##  ::cudaEventQuery may be used in either process. Performing operations
   ##  on the imported event after the exported event has been freed
   ##  with ::cudaEventDestroy will result in undefined behavior.
-  ## 
+  ##
   ##  IPC functionality is restricted to devices with support for unified
   ##  addressing on Linux operating systems.
-  ## 
+  ##
   ##  \param handle - Pointer to a user allocated cudaIpcEventHandle
   ##                     in which to return the opaque event handle
   ##  \param event   - Event allocated with ::cudaEventInterprocess and
   ##                     ::cudaEventDisableTiming flags.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorMemoryAllocation,
   ##  ::cudaErrorMapBufferObjectFailed
-  ## 
+  ##
   ##  \sa
   ##  ::cudaEventCreate,
   ##  ::cudaEventDestroy,
@@ -565,31 +565,31 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaIpcGetMemHandle,
   ##  ::cudaIpcOpenMemHandle,
   ##  ::cudaIpcCloseMemHandle
-  ## 
+  ##
   proc cudaIpcGetEventHandle*(handle: ptr cudaIpcEventHandle_t; event: cudaEvent_t): cudaError_t {.
       cdecl, importc: "cudaIpcGetEventHandle", dyn.}
   ## *
   ##  \brief Opens an interprocess event handle for use in the current process
-  ## 
+  ##
   ##  Opens an interprocess event handle exported from another process with
   ##  ::cudaIpcGetEventHandle. This function returns a ::cudaEvent_t that behaves like
   ##  a locally created event with the ::cudaEventDisableTiming flag specified.
   ##  This event must be freed with ::cudaEventDestroy.
-  ## 
+  ##
   ##  Performing operations on the imported event after the exported event has
   ##  been freed with ::cudaEventDestroy will result in undefined behavior.
-  ## 
+  ##
   ##  IPC functionality is restricted to devices with support for unified
   ##  addressing on Linux operating systems.
-  ## 
+  ##
   ##  \param event - Returns the imported event
   ##  \param handle  - Interprocess handle to open
-  ## 
+  ##
   ##  \returns
   ##  ::cudaSuccess,
   ##  ::cudaErrorMapBufferObjectFailed,
   ##  ::cudaErrorInvalidResourceHandle
-  ## 
+  ##
   ##  \sa
   ##  ::cudaEventCreate,
   ##  ::cudaEventDestroy,
@@ -600,36 +600,36 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaIpcGetMemHandle,
   ##  ::cudaIpcOpenMemHandle,
   ##  ::cudaIpcCloseMemHandle
-  ## 
+  ##
   proc cudaIpcOpenEventHandle*(event: ptr cudaEvent_t; handle: cudaIpcEventHandle_t): cudaError_t {.
       cdecl, importc: "cudaIpcOpenEventHandle", dyn.}
   ## *
   ##  \brief Gets an interprocess memory handle for an existing device memory
   ##           allocation
-  ## 
+  ##
   ##  Takes a pointer to the base of an existing device memory allocation created
   ##  with ::cudaMalloc and exports it for use in another process. This is a
   ##  lightweight operation and may be called multiple times on an allocation
   ##  without adverse effects.
-  ## 
+  ##
   ##  If a region of memory is freed with ::cudaFree and a subsequent call
   ##  to ::cudaMalloc returns memory with the same device address,
   ##  ::cudaIpcGetMemHandle will return a unique handle for the
   ##  new memory.
-  ## 
+  ##
   ##  IPC functionality is restricted to devices with support for unified
   ##  addressing on Linux operating systems.
-  ## 
+  ##
   ##  \param handle - Pointer to user allocated ::cudaIpcMemHandle to return
   ##                     the handle in.
   ##  \param devPtr - Base pointer to previously allocated device memory
-  ## 
+  ##
   ##  \returns
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorMemoryAllocation,
   ##  ::cudaErrorMapBufferObjectFailed,
-  ## 
+  ##
   ##  \sa
   ##  ::cudaMalloc,
   ##  ::cudaFree,
@@ -637,47 +637,47 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaIpcOpenEventHandle,
   ##  ::cudaIpcOpenMemHandle,
   ##  ::cudaIpcCloseMemHandle
-  ## 
+  ##
   proc cudaIpcGetMemHandle*(handle: ptr cudaIpcMemHandle_t; devPtr: pointer): cudaError_t {.
       cdecl, importc: "cudaIpcGetMemHandle", dyn.}
   ## *
   ##  \brief Opens an interprocess memory handle exported from another process
   ##           and returns a device pointer usable in the local process.
-  ## 
+  ##
   ##  Maps memory exported from another process with ::cudaIpcGetMemHandle into
   ##  the current device address space. For contexts on different devices
   ##  ::cudaIpcOpenMemHandle can attempt to enable peer access between the
   ##  devices as if the user called ::cudaDeviceEnablePeerAccess. This behavior is
   ##  controlled by the ::cudaIpcMemLazyEnablePeerAccess flag.
   ##  ::cudaDeviceCanAccessPeer can determine if a mapping is possible.
-  ## 
+  ##
   ##  Contexts that may open ::cudaIpcMemHandles are restricted in the following way.
   ##  ::cudaIpcMemHandles from each device in a given process may only be opened
   ##  by one context per device per other process.
-  ## 
+  ##
   ##  Memory returned from ::cudaIpcOpenMemHandle must be freed with
   ##  ::cudaIpcCloseMemHandle.
-  ## 
+  ##
   ##  Calling ::cudaFree on an exported memory region before calling
   ##  ::cudaIpcCloseMemHandle in the importing context will result in undefined
   ##  behavior.
-  ## 
+  ##
   ##  IPC functionality is restricted to devices with support for unified
   ##  addressing on Linux operating systems.
-  ## 
+  ##
   ##  \param devPtr - Returned device pointer
   ##  \param handle - ::cudaIpcMemHandle to open
   ##  \param flags  - Flags for this operation. Must be specified as ::cudaIpcMemLazyEnablePeerAccess
-  ## 
+  ##
   ##  \returns
   ##  ::cudaSuccess,
   ##  ::cudaErrorMapBufferObjectFailed,
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorTooManyPeers
-  ## 
-  ##  \note No guarantees are made about the address returned in \p *devPtr.
+  ##
+  ##  `\note No guarantees are made about the address returned in \p *devPtr.`
   ##  In particular, multiple processes may not receive the same address for the same \p handle.
-  ## 
+  ##
   ##  \sa
   ##  ::cudaMalloc,
   ##  ::cudaFree,
@@ -687,30 +687,30 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaIpcCloseMemHandle,
   ##  ::cudaDeviceEnablePeerAccess,
   ##  ::cudaDeviceCanAccessPeer,
-  ## 
+  ##
   proc cudaIpcOpenMemHandle*(devPtr: ptr pointer; handle: cudaIpcMemHandle_t;
                             flags: cuint): cudaError_t {.cdecl,
       importc: "cudaIpcOpenMemHandle", dyn.}
   ## *
   ##  \brief Close memory mapped with cudaIpcOpenMemHandle
-  ## 
+  ##
   ##  Unmaps memory returnd by ::cudaIpcOpenMemHandle. The original allocation
   ##  in the exporting process as well as imported mappings in other processes
   ##  will be unaffected.
-  ## 
+  ##
   ##  Any resources used to enable peer access will be freed if this is the
   ##  last mapping using them.
-  ## 
+  ##
   ##  IPC functionality is restricted to devices with support for unified
   ##  addressing on Linux operating systems.
-  ## 
+  ##
   ##  \param devPtr - Device pointer returned by ::cudaIpcOpenMemHandle
-  ## 
+  ##
   ##  \returns
   ##  ::cudaSuccess,
   ##  ::cudaErrorMapBufferObjectFailed,
   ##  ::cudaErrorInvalidResourceHandle,
-  ## 
+  ##
   ##  \sa
   ##  ::cudaMalloc,
   ##  ::cudaFree,
@@ -718,250 +718,250 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaIpcOpenEventHandle,
   ##  ::cudaIpcGetMemHandle,
   ##  ::cudaIpcOpenMemHandle,
-  ## 
+  ##
   proc cudaIpcCloseMemHandle*(devPtr: pointer): cudaError_t {.cdecl,
       importc: "cudaIpcCloseMemHandle", dyn.}
   ## * @}
   ##  END CUDART_DEVICE
   ## *
   ##  \defgroup CUDART_THREAD_DEPRECATED Thread Management [DEPRECATED]
-  ## 
+  ##
   ##  ___MANBRIEF___ deprecated thread management functions of the CUDA runtime
   ##  API (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes deprecated thread management functions of the CUDA runtime
   ##  application programming interface.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Exit and clean up from CUDA launches
-  ## 
+  ##
   ##  \deprecated
-  ## 
+  ##
   ##  Note that this function is deprecated because its name does not
   ##  reflect its behavior.  Its functionality is identical to the
   ##  non-deprecated function ::cudaDeviceReset(), which should be used
   ##  instead.
-  ## 
+  ##
   ##  Explicitly destroys all cleans up all resources associated with the current
   ##  device in the current process.  Any subsequent API call to this device will
   ##  reinitialize the device.
-  ## 
+  ##
   ##  Note that this function will reset the device immediately.  It is the caller's
   ##  responsibility to ensure that the device is not being accessed by any
   ##  other host threads from the process when this function is called.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceReset
-  ## 
+  ##
   proc cudaThreadExit*(): cudaError_t {.cdecl, importc: "cudaThreadExit",
                                      dyn.}
   ## *
   ##  \brief Wait for compute device to finish
-  ## 
+  ##
   ##  \deprecated
-  ## 
+  ##
   ##  Note that this function is deprecated because its name does not
   ##  reflect its behavior.  Its functionality is similar to the
   ##  non-deprecated function ::cudaDeviceSynchronize(), which should be used
   ##  instead.
-  ## 
+  ##
   ##  Blocks until the device has completed all preceding requested tasks.
   ##  ::cudaThreadSynchronize() returns an error if one of the preceding tasks
   ##  has failed. If the ::cudaDeviceScheduleBlockingSync flag was set for
   ##  this device, the host thread will block until the device has finished
   ##  its work.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceSynchronize
-  ## 
+  ##
   proc cudaThreadSynchronize*(): cudaError_t {.cdecl,
       importc: "cudaThreadSynchronize", dyn.}
   ## *
   ##  \brief Set resource limits
-  ## 
+  ##
   ##  \deprecated
-  ## 
+  ##
   ##  Note that this function is deprecated because its name does not
   ##  reflect its behavior.  Its functionality is identical to the
   ##  non-deprecated function ::cudaDeviceSetLimit(), which should be used
   ##  instead.
-  ## 
+  ##
   ##  Setting \p limit to \p value is a request by the application to update
   ##  the current limit maintained by the device.  The driver is free to
   ##  modify the requested value to meet h/w requirements (this could be
   ##  clamping to minimum or maximum values, rounding up to nearest element
   ##  size, etc).  The application can use ::cudaThreadGetLimit() to find out
   ##  exactly what the limit has been set to.
-  ## 
+  ##
   ##  Setting each ::cudaLimit has its own specific restrictions, so each is
   ##  discussed here.
-  ## 
+  ##
   ##  - ::cudaLimitStackSize controls the stack size of each GPU thread.
-  ## 
+  ##
   ##  - ::cudaLimitPrintfFifoSize controls the size of the shared FIFO
   ##    used by the ::printf() and ::fprintf() device system calls.
   ##    Setting ::cudaLimitPrintfFifoSize must be performed before
   ##    launching any kernel that uses the ::printf() or ::fprintf() device
   ##    system calls, otherwise ::cudaErrorInvalidValue will be returned.
-  ## 
+  ##
   ##  - ::cudaLimitMallocHeapSize controls the size of the heap used
   ##    by the ::malloc() and ::free() device system calls.  Setting
   ##    ::cudaLimitMallocHeapSize must be performed before launching
   ##    any kernel that uses the ::malloc() or ::free() device system calls,
   ##    otherwise ::cudaErrorInvalidValue will be returned.
-  ## 
+  ##
   ##  \param limit - Limit to set
   ##  \param value - Size in bytes of limit
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorUnsupportedLimit,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceSetLimit
-  ## 
+  ##
   proc cudaThreadSetLimit*(limit: cudaLimit; value: csize): cudaError_t {.cdecl,
       importc: "cudaThreadSetLimit", dyn.}
   ## *
   ##  \brief Returns resource limits
-  ## 
+  ##
   ##  \deprecated
-  ## 
+  ##
   ##  Note that this function is deprecated because its name does not
   ##  reflect its behavior.  Its functionality is identical to the
   ##  non-deprecated function ::cudaDeviceGetLimit(), which should be used
   ##  instead.
-  ## 
-  ##  Returns in \p *pValue the current size of \p limit.  The supported
+  ##
+  ##  `Returns in \p *pValue the current size of \p limit.  The supported`
   ##  ::cudaLimit values are:
   ##  - ::cudaLimitStackSize: stack size of each GPU thread;
   ##  - ::cudaLimitPrintfFifoSize: size of the shared FIFO used by the
   ##    ::printf() and ::fprintf() device system calls.
   ##  - ::cudaLimitMallocHeapSize: size of the heap used by the
   ##    ::malloc() and ::free() device system calls;
-  ## 
+  ##
   ##  \param limit  - Limit to query
   ##  \param pValue - Returned size in bytes of limit
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorUnsupportedLimit,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceGetLimit
-  ## 
+  ##
   proc cudaThreadGetLimit*(pValue: ptr csize; limit: cudaLimit): cudaError_t {.cdecl,
       importc: "cudaThreadGetLimit", dyn.}
   ## *
   ##  \brief Returns the preferred cache configuration for the current device.
-  ## 
+  ##
   ##  \deprecated
-  ## 
+  ##
   ##  Note that this function is deprecated because its name does not
   ##  reflect its behavior.  Its functionality is identical to the
   ##  non-deprecated function ::cudaDeviceGetCacheConfig(), which should be
   ##  used instead.
-  ## 
+  ##
   ##  On devices where the L1 cache and shared memory use the same hardware
   ##  resources, this returns through \p pCacheConfig the preferred cache
   ##  configuration for the current device. This is only a preference. The
   ##  runtime will use the requested configuration if possible, but it is free to
   ##  choose a different configuration if required to execute functions.
-  ## 
+  ##
   ##  This will return a \p pCacheConfig of ::cudaFuncCachePreferNone on devices
   ##  where the size of the L1 cache and shared memory are fixed.
-  ## 
+  ##
   ##  The supported cache configurations are:
   ##  - ::cudaFuncCachePreferNone: no preference for shared memory or L1 (default)
   ##  - ::cudaFuncCachePreferShared: prefer larger shared memory and smaller L1 cache
   ##  - ::cudaFuncCachePreferL1: prefer larger L1 cache and smaller shared memory
-  ## 
+  ##
   ##  \param pCacheConfig - Returned cache configuration
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInitializationError
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa cudaDeviceGetCacheConfig
-  ## 
+  ##
   proc cudaThreadGetCacheConfig*(pCacheConfig: ptr cudaFuncCache): cudaError_t {.
       cdecl, importc: "cudaThreadGetCacheConfig", dyn.}
   ## *
   ##  \brief Sets the preferred cache configuration for the current device.
-  ## 
+  ##
   ##  \deprecated
-  ## 
+  ##
   ##  Note that this function is deprecated because its name does not
   ##  reflect its behavior.  Its functionality is identical to the
   ##  non-deprecated function ::cudaDeviceSetCacheConfig(), which should be
   ##  used instead.
-  ## 
+  ##
   ##  On devices where the L1 cache and shared memory use the same hardware
   ##  resources, this sets through \p cacheConfig the preferred cache
   ##  configuration for the current device. This is only a preference. The
   ##  runtime will use the requested configuration if possible, but it is free to
   ##  choose a different configuration if required to execute the function. Any
   ##  function preference set via
-  ##  \ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)"
+  ##  `\ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)"`
   ##  or
-  ##  \ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C++ API)"
+  ##  `\ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C++ API)"`
   ##  will be preferred over this device-wide setting. Setting the device-wide
   ##  cache configuration to ::cudaFuncCachePreferNone will cause subsequent
   ##  kernel launches to prefer to not change the cache configuration unless
   ##  required to launch the kernel.
-  ## 
+  ##
   ##  This setting does nothing on devices where the size of the L1 cache and
   ##  shared memory are fixed.
-  ## 
+  ##
   ##  Launching a kernel with a different preference than the most recent
   ##  preference setting may insert a device-side synchronization point.
-  ## 
+  ##
   ##  The supported cache configurations are:
   ##  - ::cudaFuncCachePreferNone: no preference for shared memory or L1 (default)
   ##  - ::cudaFuncCachePreferShared: prefer larger shared memory and smaller L1 cache
   ##  - ::cudaFuncCachePreferL1: prefer larger L1 cache and smaller shared memory
-  ## 
+  ##
   ##  \param cacheConfig - Requested cache configuration
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInitializationError
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceSetCacheConfig
-  ## 
+  ##
   proc cudaThreadSetCacheConfig*(cacheConfig: cudaFuncCache): cudaError_t {.cdecl,
       importc: "cudaThreadSetCacheConfig", dyn.}
   ## * @}
   ##  END CUDART_THREAD_DEPRECATED
   ## *
   ##  \defgroup CUDART_ERROR Error Handling
-  ## 
+  ##
   ##  ___MANBRIEF___ error handling functions of the CUDA runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the error handling functions of the CUDA runtime
   ##  application programming interface.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Returns the last error from a runtime call
-  ## 
+  ##
   ##  Returns the last error that has been produced by any of the runtime calls
   ##  in the same host thread and resets it to ::cudaSuccess.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorMissingConfiguration,
@@ -991,18 +991,18 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorSetOnActiveProcess,
   ##  ::cudaErrorStartupFailure,
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaPeekAtLastError, ::cudaGetErrorName, ::cudaGetErrorString, ::cudaError
-  ## 
+  ##
   proc cudaGetLastError*(): cudaError_t {.cdecl, importc: "cudaGetLastError",
                                        dyn.}
   ## *
   ##  \brief Returns the last error from a runtime call
-  ## 
+  ##
   ##  Returns the last error that has been produced by any of the runtime calls
   ##  in the same host thread. Note that this call does not reset the error to
   ##  ::cudaSuccess like ::cudaGetLastError().
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorMissingConfiguration,
@@ -1032,75 +1032,75 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorSetOnActiveProcess,
   ##  ::cudaErrorStartupFailure,
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaGetLastError, ::cudaGetErrorName, ::cudaGetErrorString, ::cudaError
-  ## 
+  ##
   proc cudaPeekAtLastError*(): cudaError_t {.cdecl, importc: "cudaPeekAtLastError",
       dyn.}
   ## *
   ##  \brief Returns the string representation of an error code enum name
-  ## 
+  ##
   ##  Returns a string containing the name of an error code in the enum.  If the error
   ##  code is not recognized, "unrecognized error code" is returned.
-  ## 
+  ##
   ##  \param error - Error code to convert to string
-  ## 
+  ##
   ##  \return
-  ##  \p char* pointer to a NULL-terminated string
-  ## 
+  ##  `\p char* pointer to a NULL-terminated string`
+  ##
   ##  \sa ::cudaGetErrorString, ::cudaGetLastError, ::cudaPeekAtLastError, ::cudaError
-  ## 
+  ##
   proc cudaGetErrorName*(error: cudaError_t): cstring {.cdecl,
       importc: "cudaGetErrorName", dyn.}
   ## *
   ##  \brief Returns the description string for an error code
-  ## 
+  ##
   ##  Returns the description string for an error code.  If the error
   ##  code is not recognized, "unrecognized error code" is returned.
-  ## 
+  ##
   ##  \param error - Error code to convert to string
-  ## 
+  ##
   ##  \return
-  ##  \p char* pointer to a NULL-terminated string
-  ## 
+  ##  `\p char* pointer to a NULL-terminated string`
+  ##
   ##  \sa ::cudaGetErrorName, ::cudaGetLastError, ::cudaPeekAtLastError, ::cudaError
-  ## 
+  ##
   proc cudaGetErrorString*(error: cudaError_t): cstring {.cdecl,
       importc: "cudaGetErrorString", dyn.}
   ## * @}
   ##  END CUDART_ERROR
   ## *
   ##  \addtogroup CUDART_DEVICE
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Returns the number of compute-capable devices
-  ## 
-  ##  Returns in \p *count the number of devices with compute capability greater
+  ##
+  ##  `Returns in \p *count the number of devices with compute capability greater`
   ##  or equal to 2.0 that are available for execution.  If there is no such
   ##  device then ::cudaGetDeviceCount() will return ::cudaErrorNoDevice.
   ##  If no driver can be loaded to determine if any such devices exist then
   ##  ::cudaGetDeviceCount() will return ::cudaErrorInsufficientDriver.
-  ## 
+  ##
   ##  \param count - Returns the number of devices with compute capability
   ##  greater or equal to 2.0
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorNoDevice,
   ##  ::cudaErrorInsufficientDriver
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaGetDevice, ::cudaSetDevice, ::cudaGetDeviceProperties,
   ##  ::cudaChooseDevice
-  ## 
+  ##
   proc cudaGetDeviceCount*(count: ptr cint): cudaError_t {.cdecl,
       importc: "cudaGetDeviceCount", dyn.}
   ## *
   ##  \brief Returns information about the compute-device
-  ## 
-  ##  Returns in \p *prop the properties of device \p dev. The ::cudaDeviceProp
+  ##
+  ##  `Returns in \p *prop the properties of device \p dev. The ::cudaDeviceProp`
   ##  structure is defined as:
   ##  \code
   ##     struct cudaDeviceProp {
@@ -1330,23 +1330,23 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    coherently accessing pageable memory without calling cudaHostRegister on it, and 0 otherwise.
   ##  - \ref ::cudaDeviceProp::concurrentManagedAccess "concurrentManagedAccess" is 1 if the device can
   ##    coherently access managed memory concurrently with the CPU, and 0 otherwise.
-  ## 
+  ##
   ##  \param prop   - Properties for the specified device
   ##  \param device - Device number to get properties for
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidDevice
-  ## 
+  ##
   ##  \sa ::cudaGetDeviceCount, ::cudaGetDevice, ::cudaSetDevice, ::cudaChooseDevice,
   ##  ::cudaDeviceGetAttribute
-  ## 
+  ##
   proc cudaGetDeviceProperties*(prop: ptr cudaDeviceProp; device: cint): cudaError_t {.
       cdecl, importc: "cudaGetDeviceProperties", dyn.}
   ## *
   ##  \brief Returns information about the device
-  ## 
-  ##  Returns in \p *value the integer value of the attribute \p attr on device
+  ##
+  ##  `Returns in \p *value the integer value of the attribute \p attr on device`
   ##  \p device. The supported attributes are:
   ##  - ::cudaDevAttrMaxThreadsPerBlock: Maximum number of threads per block;
   ##  - ::cudaDevAttrMaxBlockDimX: Maximum x-dimension of a block;
@@ -1499,26 +1499,26 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    Compute Preemption, 0 if not.
   ##  - ::cudaDevAttrCanUseHostPointerForRegisteredMem: 1 if the device can access host
   ##    registered memory at the same virtual address as the CPU, and 0 otherwise.
-  ## 
+  ##
   ##  \param value  - Returned device attribute value
   ##  \param attr   - Device attribute to query
   ##  \param device - Device number to query
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidDevice,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaGetDeviceCount, ::cudaGetDevice, ::cudaSetDevice, ::cudaChooseDevice,
   ##  ::cudaGetDeviceProperties
-  ## 
+  ##
   proc cudaDeviceGetAttribute*(value: ptr cint; attr: cudaDeviceAttr; device: cint): cudaError_t {.
       cdecl, importc: "cudaDeviceGetAttribute", dyn.}
   ## *
   ##  \brief Queries attributes of the link between two devices.
-  ## 
-  ##  Returns in \p *value the value of the requested attribute \p attrib of the
+  ##
+  ##  `Returns in \p *value the value of the requested attribute \p attrib of the`
   ##  link between \p srcDevice and \p dstDevice. The supported attributes are:
   ##  - ::CudaDevP2PAttrPerformanceRank: A relative value indicating the
   ##    performance of the link between two devices. Lower value means better
@@ -1526,56 +1526,56 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  - ::CudaDevP2PAttrAccessSupported: 1 if peer access is enabled.
   ##  - ::CudaDevP2PAttrNativeAtomicSupported: 1 if native atomic operations over
   ##    the link are supported.
-  ## 
+  ##
   ##  Returns ::cudaErrorInvalidDevice if \p srcDevice or \p dstDevice are not valid
   ##  or if they represent the same device.
-  ## 
+  ##
   ##  Returns ::cudaErrorInvalidValue if \p attrib is not valid or if \p value is
   ##  a null pointer.
-  ## 
+  ##
   ##  \param value         - Returned value of the requested attribute
   ##  \param attrib        - The requested attribute of the link between \p srcDevice and \p dstDevice.
   ##  \param srcDevice     - The source device of the target link.
   ##  \param dstDevice     - The destination device of the target link.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidDevice,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaCtxEnablePeerAccess,
   ##  ::cudaCtxDisablePeerAccess,
   ##  ::cudaCtxCanAccessPeer
-  ## 
+  ##
   proc cudaDeviceGetP2PAttribute*(value: ptr cint; attr: cudaDeviceP2PAttr;
                                  srcDevice: cint; dstDevice: cint): cudaError_t {.
       cdecl, importc: "cudaDeviceGetP2PAttribute", dyn.}
   ## *
   ##  \brief Select compute-device which best matches criteria
-  ## 
-  ##  Returns in \p *device the device which has properties that best match
-  ##  \p *prop.
-  ## 
+  ##
+  ##  `Returns in \p *device the device which has properties that best match`
+  ##  `\p *prop.`
+  ##
   ##  \param device - Device with best match
   ##  \param prop   - Desired device properties
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaGetDeviceCount, ::cudaGetDevice, ::cudaSetDevice,
   ##  ::cudaGetDeviceProperties
-  ## 
+  ##
   proc cudaChooseDevice*(device: ptr cint; prop: ptr cudaDeviceProp): cudaError_t {.
       cdecl, importc: "cudaChooseDevice", dyn.}
   ## *
   ##  \brief Set device to be used for GPU executions
-  ## 
+  ##
   ##  Sets \p device as the current device for the calling host thread.
   ##  Valid device id's are 0 to (::cudaGetDeviceCount() - 1).
-  ## 
+  ##
   ##  Any device memory subsequently allocated from this host thread
   ##  using ::cudaMalloc(), ::cudaMallocPitch() or ::cudaMallocArray()
   ##  will be physically resident on \p device.  Any host memory allocated
@@ -1585,45 +1585,45 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  be associated with \p device.  Any kernels launched from this host
   ##  thread using the <<<>>> operator or ::cudaLaunchKernel() will be executed
   ##  on \p device.
-  ## 
+  ##
   ##  This call may be made from any host thread, to any device, and at
   ##  any time.  This function will do no synchronization with the previous
   ##  or new device, and should be considered a very low overhead call.
-  ## 
+  ##
   ##  \param device - Device on which the active host thread should execute the
   ##  device code.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidDevice,
   ##  ::cudaErrorDeviceAlreadyInUse
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaGetDeviceCount, ::cudaGetDevice, ::cudaGetDeviceProperties,
   ##  ::cudaChooseDevice
-  ## 
+  ##
   proc cudaSetDevice*(device: cint): cudaError_t {.cdecl, importc: "cudaSetDevice",
       dyn.}
   ## *
   ##  \brief Returns which device is currently being used
-  ## 
-  ##  Returns in \p *device the current device for the calling host thread.
-  ## 
+  ##
+  ##  `Returns in \p *device the current device for the calling host thread.`
+  ##
   ##  \param device - Returns the device on which the active host thread
   ##  executes the device code.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaGetDeviceCount, ::cudaSetDevice, ::cudaGetDeviceProperties,
   ##  ::cudaChooseDevice
-  ## 
+  ##
   proc cudaGetDevice*(device: ptr cint): cudaError_t {.cdecl,
       importc: "cudaGetDevice", dyn.}
   ## *
   ##  \brief Set a list of devices that can be used for CUDA
-  ## 
+  ##
   ##  Sets a list of devices for CUDA execution in priority order using
   ##  \p device_arr. The parameter \p len specifies the number of elements in the
   ##  list.  CUDA will try devices from the list sequentially until it finds one
@@ -1634,41 +1634,41 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  this function will return ::cudaErrorInvalidDevice. If \p len is not 0 and
   ##  \p device_arr is NULL or if \p len exceeds the number of devices in
   ##  the system, then ::cudaErrorInvalidValue is returned.
-  ## 
+  ##
   ##  \param device_arr - List of devices to try
   ##  \param len        - Number of devices in specified list
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidDevice
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaGetDeviceCount, ::cudaSetDevice, ::cudaGetDeviceProperties,
   ##  ::cudaSetDeviceFlags,
   ##  ::cudaChooseDevice
-  ## 
+  ##
   proc cudaSetValidDevices*(device_arr: ptr cint; len: cint): cudaError_t {.cdecl,
       importc: "cudaSetValidDevices", dyn.}
   ## *
   ##  \brief Sets flags to be used for device executions
-  ## 
+  ##
   ##  Records \p flags as the flags to use when initializing the current
   ##  device.  If no device has been made current to the calling thread,
   ##  then \p flags will be applied to the initialization of any device
   ##  initialized by the calling host thread, unless that device has had
   ##  its initialization flags set explicitly by this or any host thread.
-  ## 
+  ##
   ##  If the current device has been set and that device has already been
   ##  initialized then this call will fail with the error
   ##  ::cudaErrorSetOnActiveProcess.  In this case it is necessary
   ##  to reset \p device using ::cudaDeviceReset() before the device's
   ##  initialization flags may be set.
-  ## 
+  ##
   ##  The two LSBs of the \p flags parameter can be used to control how the CPU
   ##  thread interacts with the OS scheduler when waiting for results from the
   ##  device.
-  ## 
+  ##
   ##  - ::cudaDeviceScheduleAuto: The default value if the \p flags parameter is
   ##  zero, uses a heuristic based on the number of active CUDA contexts in the
   ##  process \p C and the number of logical processors in the system \p P. If
@@ -1698,23 +1698,23 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  after resizing local memory for a kernel. This can prevent thrashing by
   ##  local memory allocations when launching many kernels with high local
   ##  memory usage at the cost of potentially increased memory usage.
-  ## 
+  ##
   ##  \param flags - Parameters for device operation
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidDevice,
   ##  ::cudaErrorSetOnActiveProcess
-  ## 
+  ##
   ##  \sa ::cudaGetDeviceFlags, ::cudaGetDeviceCount, ::cudaGetDevice, ::cudaGetDeviceProperties,
   ##  ::cudaSetDevice, ::cudaSetValidDevices,
   ##  ::cudaChooseDevice
-  ## 
+  ##
   proc cudaSetDeviceFlags*(flags: cuint): cudaError_t {.cdecl,
       importc: "cudaSetDeviceFlags", dyn.}
   ## *
   ##  \brief Gets the flags for the current device
-  ## 
+  ##
   ##  Returns in \p flags the flags for the current device.  If there is a
   ##  current device for the calling thread, and the device has been initialized
   ##  or flags have been set on that device specifically, the flags for the
@@ -1723,7 +1723,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  Finally, if there is no current device and no thread flags, the flags for
   ##  the first device are returned, which may be the default flags.  Compare
   ##  to the behavior of ::cudaSetDeviceFlags.
-  ## 
+  ##
   ##  Typically, the flags returned should match the behavior that will be seen
   ##  if the calling thread uses a device after this call, without any change to
   ##  the flags or current device inbetween by this or another thread.  Note that
@@ -1732,52 +1732,52 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  Additionally, when using exclusive mode, if this thread has not requested a
   ##  specific device, it may use a device other than the first device, contrary
   ##  to the assumption made by this function.
-  ## 
+  ##
   ##  If a context has been created via the driver API and is current to the
   ##  calling thread, the flags for that context are always returned.
-  ## 
+  ##
   ##  Flags returned by this function may specifically include ::cudaDeviceMapHost
   ##  even though it is not accepted by ::cudaSetDeviceFlags because it is
   ##  implicit in runtime API flags.  The reason for this is that the current
   ##  context may have been created via the driver API in which case the flag is
   ##  not implicit and may be unset.
-  ## 
+  ##
   ##  \param flags - Pointer to store the device flags
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidDevice
-  ## 
+  ##
   ##  \sa ::cudaGetDevice, ::cudaGetDeviceProperties,
   ##  ::cudaSetDevice, ::cudaSetDeviceFlags
-  ## 
+  ##
   proc cudaGetDeviceFlags*(flags: ptr cuint): cudaError_t {.cdecl,
       importc: "cudaGetDeviceFlags", dyn.}
   ## * @}
   ##  END CUDART_DEVICE
   ## *
   ##  \defgroup CUDART_STREAM Stream Management
-  ## 
+  ##
   ##  ___MANBRIEF___ stream management functions of the CUDA runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the stream management functions of the CUDA runtime
   ##  application programming interface.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Create an asynchronous stream
-  ## 
+  ##
   ##  Creates a new asynchronous stream.
-  ## 
+  ##
   ##  \param pStream - Pointer to new stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaStreamCreateWithPriority,
   ##  ::cudaStreamCreateWithFlags,
   ##  ::cudaStreamGetPriority,
@@ -1787,27 +1787,27 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaStreamWaitEvent,
   ##  ::cudaStreamAddCallback,
   ##  ::cudaStreamDestroy
-  ## 
+  ##
   proc cudaStreamCreate*(pStream: ptr cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaStreamCreate", dyn.}
   ## *
   ##  \brief Create an asynchronous stream
-  ## 
+  ##
   ##  Creates a new asynchronous stream.  The \p flags argument determines the
   ##  behaviors of the stream.  Valid values for \p flags are
   ##  - ::cudaStreamDefault: Default stream creation flag.
   ##  - ::cudaStreamNonBlocking: Specifies that work running in the created
   ##    stream may run concurrently with work in stream 0 (the NULL stream), and that
   ##    the created stream should perform no implicit synchronization with stream 0.
-  ## 
+  ##
   ##  \param pStream - Pointer to new stream identifier
   ##  \param flags   - Parameters for stream creation
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaStreamCreate,
   ##  ::cudaStreamCreateWithPriority,
   ##  ::cudaStreamGetFlags,
@@ -1816,40 +1816,40 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaStreamWaitEvent,
   ##  ::cudaStreamAddCallback,
   ##  ::cudaStreamDestroy
-  ## 
+  ##
   proc cudaStreamCreateWithFlags*(pStream: ptr cudaStream_t; flags: cuint): cudaError_t {.
       cdecl, importc: "cudaStreamCreateWithFlags", dyn.}
   ## *
   ##  \brief Create an asynchronous stream with the specified priority
-  ## 
+  ##
   ##  Creates a stream with the specified priority and returns a handle in \p pStream.
   ##  This API alters the scheduler priority of work in the stream. Work in a higher
   ##  priority stream may preempt work already executing in a low priority stream.
-  ## 
+  ##
   ##  \p priority follows a convention where lower numbers represent higher priorities.
   ##  '0' represents default priority. The range of meaningful numerical priorities can
   ##  be queried using ::cudaDeviceGetStreamPriorityRange. If the specified priority is
   ##  outside the numerical range returned by ::cudaDeviceGetStreamPriorityRange,
   ##  it will automatically be clamped to the lowest or the highest number in the range.
-  ## 
+  ##
   ##  \param pStream  - Pointer to new stream identifier
   ##  \param flags    - Flags for stream creation. See ::cudaStreamCreateWithFlags for a list of valid flags that can be passed
   ##  \param priority - Priority of the stream. Lower numbers represent higher priorities.
   ##                    See ::cudaDeviceGetStreamPriorityRange for more information about
   ##                    the meaningful stream priorities that can be passed.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \note Stream priorities are supported only on GPUs
   ##  with compute capability 3.5 or higher.
-  ## 
+  ##
   ##  \note In the current implementation, only compute kernels launched in
   ##  priority streams are affected by the stream's priority. Stream priorities have
   ##  no effect on host-to-device and device-to-host memory operations.
-  ## 
+  ##
   ##  \sa ::cudaStreamCreate,
   ##  ::cudaStreamCreateWithFlags,
   ##  ::cudaDeviceGetStreamPriorityRange,
@@ -1859,106 +1859,106 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaStreamAddCallback,
   ##  ::cudaStreamSynchronize,
   ##  ::cudaStreamDestroy
-  ## 
+  ##
   proc cudaStreamCreateWithPriority*(pStream: ptr cudaStream_t; flags: cuint;
                                     priority: cint): cudaError_t {.cdecl,
       importc: "cudaStreamCreateWithPriority", dyn.}
   ## *
   ##  \brief Query the priority of a stream
-  ## 
+  ##
   ##  Query the priority of a stream. The priority is returned in in \p priority.
   ##  Note that if the stream was created with a priority outside the meaningful
   ##  numerical range returned by ::cudaDeviceGetStreamPriorityRange,
   ##  this function returns the clamped priority.
   ##  See ::cudaStreamCreateWithPriority for details about priority clamping.
-  ## 
+  ##
   ##  \param hStream    - Handle to the stream to be queried
   ##  \param priority   - Pointer to a signed integer in which the stream's priority is returned
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidResourceHandle
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaStreamCreateWithPriority,
   ##  ::cudaDeviceGetStreamPriorityRange,
   ##  ::cudaStreamGetFlags
-  ## 
+  ##
   proc cudaStreamGetPriority*(hStream: cudaStream_t; priority: ptr cint): cudaError_t {.
       cdecl, importc: "cudaStreamGetPriority", dyn.}
   ## *
   ##  \brief Query the flags of a stream
-  ## 
+  ##
   ##  Query the flags of a stream. The flags are returned in \p flags.
   ##  See ::cudaStreamCreateWithFlags for a list of valid flags.
-  ## 
+  ##
   ##  \param hStream - Handle to the stream to be queried
   ##  \param flags   - Pointer to an unsigned integer in which the stream's flags are returned
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidResourceHandle
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaStreamCreateWithPriority,
   ##  ::cudaStreamCreateWithFlags,
   ##  ::cudaStreamGetPriority
-  ## 
+  ##
   proc cudaStreamGetFlags*(hStream: cudaStream_t; flags: ptr cuint): cudaError_t {.
       cdecl, importc: "cudaStreamGetFlags", dyn.}
   ## *
   ##  \brief Destroys and cleans up an asynchronous stream
-  ## 
+  ##
   ##  Destroys and cleans up the asynchronous stream specified by \p stream.
-  ## 
+  ##
   ##  In case the device is still doing work in the stream \p stream
   ##  when ::cudaStreamDestroy() is called, the function will return immediately
   ##  and the resources associated with \p stream will be released automatically
   ##  once the device has completed all work in \p stream.
-  ## 
+  ##
   ##  \param stream - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidResourceHandle
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaStreamCreate, ::cudaStreamCreateWithFlags, ::cudaStreamQuery, ::cudaStreamWaitEvent, ::cudaStreamSynchronize, ::cudaStreamAddCallback
-  ## 
+  ##
   proc cudaStreamDestroy*(stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaStreamDestroy", dyn.}
   ## *
   ##  \brief Make a compute stream wait on an event
-  ## 
+  ##
   ##  Makes all future work submitted to \p stream wait until \p event reports
   ##  completion before beginning execution.  This synchronization will be
   ##  performed efficiently on the device.  The event \p event may
   ##  be from a different context than \p stream, in which case this function
   ##  will perform cross-device synchronization.
-  ## 
+  ##
   ##  The stream \p stream will wait only for the completion of the most recent
   ##  host call to ::cudaEventRecord() on \p event.  Once this call has returned,
   ##  any functions (including ::cudaEventRecord() and ::cudaEventDestroy()) may be
   ##  called on \p event again, and the subsequent calls will not have any effect
   ##  on \p stream.
-  ## 
+  ##
   ##  If ::cudaEventRecord() has not been called on \p event, this call acts as if
   ##  the record has already completed, and so is a functional no-op.
-  ## 
+  ##
   ##  \param stream - Stream to wait
   ##  \param event  - Event to wait on
   ##  \param flags  - Parameters for the operation (must be 0)
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidResourceHandle
   ##  \note_null_stream
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaStreamCreate, ::cudaStreamCreateWithFlags, ::cudaStreamQuery, ::cudaStreamSynchronize, ::cudaStreamAddCallback, ::cudaStreamDestroy
-  ## 
+  ##
   proc cudaStreamWaitEvent*(stream: cudaStream_t; event: cudaEvent_t; flags: cuint): cudaError_t {.
       cdecl, importc: "cudaStreamWaitEvent", dyn.}
   ## *
@@ -1966,28 +1966,28 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \param stream The stream as passed to ::cudaStreamAddCallback, may be NULL.
   ##  \param status ::cudaSuccess or any persistent error on the stream.
   ##  \param userData User parameter provided at registration.
-  ## 
+  ##
   type
     cudaStreamCallback_t* = proc (stream: cudaStream_t; status: cudaError_t;
                                userData: pointer) {.cdecl.}
   ## *
   ##  \brief Add a callback to a compute stream
-  ## 
+  ##
   ##  Adds a callback to be called on the host after all currently enqueued
   ##  items in the stream have completed.  For each
   ##  cudaStreamAddCallback call, a callback will be executed exactly once.
   ##  The callback will block later work in the stream until it is finished.
-  ## 
+  ##
   ##  The callback may be passed ::cudaSuccess or an error code.  In the event
   ##  of a device error, all subsequently executed callbacks will receive an
   ##  appropriate ::cudaError_t.
-  ## 
+  ##
   ##  Callbacks must not make any CUDA API calls.  Attempting to use CUDA APIs
   ##  will result in ::cudaErrorNotPermitted.  Callbacks must not perform any
   ##  synchronization that may depend on outstanding device work or other callbacks
   ##  that are not mandated to run earlier.  Callbacks without a mandated order
   ##  (in independent streams) execute in undefined order and may be serialized.
-  ## 
+  ##
   ##  For the purposes of Unified Memory, callback execution makes a number of
   ##  guarantees:
   ##  <ul>
@@ -2010,81 +2010,81 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    stream synchronization can be done by signaling from a callback at the
   ##    end of the stream.</li>
   ##  </ul>
-  ## 
+  ##
   ##  \param stream   - Stream to add callback to
   ##  \param callback - The function to call once preceding stream operations are complete
   ##  \param userData - User specified data to be passed to the callback function
   ##  \param flags    - Reserved for future use, must be 0
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorNotSupported
   ##  \note_null_stream
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaStreamCreate, ::cudaStreamCreateWithFlags, ::cudaStreamQuery, ::cudaStreamSynchronize, ::cudaStreamWaitEvent, ::cudaStreamDestroy, ::cudaMallocManaged, ::cudaStreamAttachMemAsync
-  ## 
+  ##
   proc cudaStreamAddCallback*(stream: cudaStream_t; callback: cudaStreamCallback_t;
                              userData: pointer; flags: cuint): cudaError_t {.cdecl,
       importc: "cudaStreamAddCallback", dyn.}
   ## *
   ##  \brief Waits for stream tasks to complete
-  ## 
+  ##
   ##  Blocks until \p stream has completed all operations. If the
   ##  ::cudaDeviceScheduleBlockingSync flag was set for this device,
   ##  the host thread will block until the stream is finished with
   ##  all of its tasks.
-  ## 
+  ##
   ##  \param stream - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidResourceHandle
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaStreamCreate, ::cudaStreamCreateWithFlags, ::cudaStreamQuery, ::cudaStreamWaitEvent, ::cudaStreamAddCallback, ::cudaStreamDestroy
-  ## 
+  ##
   proc cudaStreamSynchronize*(stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaStreamSynchronize", dyn.}
   ## *
   ##  \brief Queries an asynchronous stream for completion status
-  ## 
+  ##
   ##  Returns ::cudaSuccess if all operations in \p stream have
   ##  completed, or ::cudaErrorNotReady if not.
-  ## 
+  ##
   ##  For the purposes of Unified Memory, a return value of ::cudaSuccess
   ##  is equivalent to having called ::cudaStreamSynchronize().
-  ## 
+  ##
   ##  \param stream - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorNotReady,
   ##  ::cudaErrorInvalidResourceHandle
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaStreamCreate, ::cudaStreamCreateWithFlags, ::cudaStreamWaitEvent, ::cudaStreamSynchronize, ::cudaStreamAddCallback, ::cudaStreamDestroy
-  ## 
+  ##
   proc cudaStreamQuery*(stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaStreamQuery", dyn.}
   ## *
   ##  \brief Attach memory to a stream asynchronously
-  ## 
+  ##
   ##  Enqueues an operation in \p stream to specify stream association of
   ##  \p length bytes of memory starting from \p devPtr. This function is a
   ##  stream-ordered operation, meaning that it is dependent on, and will
   ##  only take effect when, previous work in stream has completed. Any
   ##  previous association is automatically replaced.
-  ## 
+  ##
   ##  \p devPtr must point to an address within managed memory space declared
   ##  using the __managed__ keyword or allocated with ::cudaMallocManaged.
-  ## 
+  ##
   ##  \p length must be zero, to indicate that the entire allocation's
   ##  stream association is being changed.  Currently, it's not possible
   ##  to change stream association for a portion of an allocation. The default
   ##  value for \p length is zero.
-  ## 
+  ##
   ##  The stream association is specified using \p flags which must be
   ##  one of ::cudaMemAttachGlobal, ::cudaMemAttachHost or ::cudaMemAttachSingle.
   ##  The default value for \p flags is ::cudaMemAttachSingle
@@ -2099,44 +2099,44 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  from \p stream. It is illegal to attach singly to the NULL stream, because the
   ##  NULL stream is a virtual global stream and not a specific stream. An error will
   ##  be returned in this case.
-  ## 
+  ##
   ##  When memory is associated with a single stream, the Unified Memory system will
   ##  allow CPU access to this memory region so long as all operations in \p stream
   ##  have completed, regardless of whether other streams are active. In effect,
   ##  this constrains exclusive ownership of the managed memory region by
   ##  an active GPU to per-stream activity instead of whole-GPU activity.
-  ## 
+  ##
   ##  Accessing memory on the device from streams that are not associated with
   ##  it will produce undefined results. No error checking is performed by the
   ##  Unified Memory system to ensure that kernels launched into other streams
   ##  do not access this region.
-  ## 
+  ##
   ##  It is a program's responsibility to order calls to ::cudaStreamAttachMemAsync
   ##  via events, synchronization or other means to ensure legal access to memory
   ##  at all times. Data visibility and coherency will be changed appropriately
   ##  for all kernels which follow a stream-association change.
-  ## 
+  ##
   ##  If \p stream is destroyed while data is associated with it, the association is
   ##  removed and the association reverts to the default visibility of the allocation
   ##  as specified at ::cudaMallocManaged. For __managed__ variables, the default
   ##  association is always ::cudaMemAttachGlobal. Note that destroying a stream is an
   ##  asynchronous operation, and as a result, the change to default association won't
   ##  happen until all work in the stream has completed.
-  ## 
+  ##
   ##  \param stream  - Stream in which to enqueue the attach operation
   ##  \param devPtr  - Pointer to memory (must be a pointer to managed memory)
   ##  \param length  - Length of memory (must be zero, defaults to zero)
   ##  \param flags   - Must be one of ::cudaMemAttachGlobal, ::cudaMemAttachHost or ::cudaMemAttachSingle (defaults to ::cudaMemAttachSingle)
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorNotReady,
   ##  ::cudaErrorInvalidValue
   ##  ::cudaErrorInvalidResourceHandle
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaStreamCreate, ::cudaStreamCreateWithFlags, ::cudaStreamWaitEvent, ::cudaStreamSynchronize, ::cudaStreamAddCallback, ::cudaStreamDestroy, ::cudaMallocManaged
-  ## 
+  ##
   proc cudaStreamAttachMemAsync*(stream: cudaStream_t; devPtr: pointer;
                                 length: csize; flags: cuint): cudaError_t {.cdecl,
       importc: "cudaStreamAttachMemAsync", dyn.}
@@ -2144,22 +2144,22 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  END CUDART_STREAM
   ## *
   ##  \defgroup CUDART_EVENT Event Management
-  ## 
+  ##
   ##  ___MANBRIEF___ event management functions of the CUDA runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the event management functions of the CUDA runtime
   ##  application programming interface.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Creates an event object
-  ## 
+  ##
   ##  Creates an event object using ::cudaEventDefault.
-  ## 
+  ##
   ##  \param event - Newly created event
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInitializationError,
@@ -2167,17 +2167,17 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorLaunchFailure,
   ##  ::cudaErrorMemoryAllocation
   ##  \notefnerr
-  ## 
-  ##  \sa \ref ::cudaEventCreate(cudaEvent_t*, unsigned int) "cudaEventCreate (C++ API)",
+  ##
+  ##  `\sa \ref ::cudaEventCreate(cudaEvent_t*, unsigned int) "cudaEventCreate (C++ API)",`
   ##  ::cudaEventCreateWithFlags, ::cudaEventRecord, ::cudaEventQuery,
   ##  ::cudaEventSynchronize, ::cudaEventDestroy, ::cudaEventElapsedTime,
   ##  ::cudaStreamWaitEvent
-  ## 
+  ##
   proc cudaEventCreate*(event: ptr cudaEvent_t): cudaError_t {.cdecl,
       importc: "cudaEventCreate", dyn.}
   ## *
   ##  \brief Creates an event object with the specified flags
-  ## 
+  ##
   ##  Creates an event object with the specified flags. Valid flags include:
   ##  - ::cudaEventDefault: Default event creation flag.
   ##  - ::cudaEventBlockingSync: Specifies that event should use blocking
@@ -2191,10 +2191,10 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  - ::cudaEventInterprocess: Specifies that the created event may be used as an
   ##    interprocess event by ::cudaIpcGetEventHandle(). ::cudaEventInterprocess must
   ##    be specified along with ::cudaEventDisableTiming.
-  ## 
+  ##
   ##  \param event - Newly created event
   ##  \param flags - Flags for new event
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInitializationError,
@@ -2202,28 +2202,28 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorLaunchFailure,
   ##  ::cudaErrorMemoryAllocation
   ##  \notefnerr
-  ## 
-  ##  \sa \ref ::cudaEventCreate(cudaEvent_t*) "cudaEventCreate (C API)",
+  ##
+  ##  `\sa \ref ::cudaEventCreate(cudaEvent_t*) "cudaEventCreate (C API)",`
   ##  ::cudaEventSynchronize, ::cudaEventDestroy, ::cudaEventElapsedTime,
   ##  ::cudaStreamWaitEvent
-  ## 
+  ##
   proc cudaEventCreateWithFlags*(event: ptr cudaEvent_t; flags: cuint): cudaError_t {.
       cdecl, importc: "cudaEventCreateWithFlags", dyn.}
   ## *
   ##  \brief Records an event
-  ## 
+  ##
   ##  Records an event. See note about NULL stream behavior. Since operation
   ##  is asynchronous, ::cudaEventQuery() or ::cudaEventSynchronize() must
   ##  be used to determine when the event has actually been recorded.
-  ## 
+  ##
   ##  If ::cudaEventRecord() has previously been called on \p event, then this
   ##  call will overwrite any existing state in \p event.  Any subsequent calls
   ##  which examine the status of \p event will only examine the completion of
   ##  this most recent call to ::cudaEventRecord().
-  ## 
+  ##
   ##  \param event  - Event to record
   ##  \param stream - Stream in which to record event
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -2232,31 +2232,31 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorLaunchFailure
   ##  \note_null_stream
   ##  \notefnerr
-  ## 
-  ##  \sa \ref ::cudaEventCreate(cudaEvent_t*) "cudaEventCreate (C API)",
+  ##
+  ##  `\sa \ref ::cudaEventCreate(cudaEvent_t*) "cudaEventCreate (C API)",`
   ##  ::cudaEventCreateWithFlags, ::cudaEventQuery,
   ##  ::cudaEventSynchronize, ::cudaEventDestroy, ::cudaEventElapsedTime,
   ##  ::cudaStreamWaitEvent
-  ## 
+  ##
   proc cudaEventRecord*(event: cudaEvent_t; stream: cudaStream_t): cudaError_t {.
       cdecl, importc: "cudaEventRecord", dyn.}
   ## *
   ##  \brief Queries an event's status
-  ## 
+  ##
   ##  Query the status of all device work preceding the most recent call to
   ##  ::cudaEventRecord() (in the appropriate compute streams, as specified by the
   ##  arguments to ::cudaEventRecord()).
-  ## 
+  ##
   ##  If this work has successfully been completed by the device, or if
   ##  ::cudaEventRecord() has not been called on \p event, then ::cudaSuccess is
   ##  returned. If this work has not yet been completed by the device then
   ##  ::cudaErrorNotReady is returned.
-  ## 
+  ##
   ##  For the purposes of Unified Memory, a return value of ::cudaSuccess
   ##  is equivalent to having called ::cudaEventSynchronize().
-  ## 
+  ##
   ##  \param event - Event to query
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorNotReady,
@@ -2265,31 +2265,31 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorLaunchFailure
   ##  \notefnerr
-  ## 
-  ##  \sa \ref ::cudaEventCreate(cudaEvent_t*) "cudaEventCreate (C API)",
+  ##
+  ##  `\sa \ref ::cudaEventCreate(cudaEvent_t*) "cudaEventCreate (C API)",`
   ##  ::cudaEventCreateWithFlags, ::cudaEventRecord,
   ##  ::cudaEventSynchronize, ::cudaEventDestroy, ::cudaEventElapsedTime
-  ## 
+  ##
   proc cudaEventQuery*(event: cudaEvent_t): cudaError_t {.cdecl,
       importc: "cudaEventQuery", dyn.}
   ## *
   ##  \brief Waits for an event to complete
-  ## 
+  ##
   ##  Wait until the completion of all device work preceding the most recent
   ##  call to ::cudaEventRecord() (in the appropriate compute streams, as specified
   ##  by the arguments to ::cudaEventRecord()).
-  ## 
+  ##
   ##  If ::cudaEventRecord() has not been called on \p event, ::cudaSuccess is
   ##  returned immediately.
-  ## 
+  ##
   ##  Waiting for an event that was created with the ::cudaEventBlockingSync
   ##  flag will cause the calling CPU thread to block until the event has
   ##  been completed by the device.  If the ::cudaEventBlockingSync flag has
   ##  not been set, then the CPU thread will busy-wait until the event has
   ##  been completed by the device.
-  ## 
+  ##
   ##  \param event - Event to wait for
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInitializationError,
@@ -2297,44 +2297,44 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorLaunchFailure
   ##  \notefnerr
-  ## 
-  ##  \sa \ref ::cudaEventCreate(cudaEvent_t*) "cudaEventCreate (C API)",
+  ##
+  ##  `\sa \ref ::cudaEventCreate(cudaEvent_t*) "cudaEventCreate (C API)",`
   ##  ::cudaEventCreateWithFlags, ::cudaEventRecord,
   ##  ::cudaEventQuery, ::cudaEventDestroy, ::cudaEventElapsedTime
-  ## 
+  ##
   proc cudaEventSynchronize*(event: cudaEvent_t): cudaError_t {.cdecl,
       importc: "cudaEventSynchronize", dyn.}
   ## *
   ##  \brief Destroys an event object
-  ## 
+  ##
   ##  Destroys the event specified by \p event.
-  ## 
+  ##
   ##  In case \p event has been recorded but has not yet been completed
   ##  when ::cudaEventDestroy() is called, the function will return immediately and
   ##  the resources associated with \p event will be released automatically once
   ##  the device has completed \p event.
-  ## 
+  ##
   ##  \param event - Event to destroy
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInitializationError,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorLaunchFailure
   ##  \notefnerr
-  ## 
-  ##  \sa \ref ::cudaEventCreate(cudaEvent_t*) "cudaEventCreate (C API)",
+  ##
+  ##  `\sa \ref ::cudaEventCreate(cudaEvent_t*) "cudaEventCreate (C API)",`
   ##  ::cudaEventCreateWithFlags, ::cudaEventQuery,
   ##  ::cudaEventSynchronize, ::cudaEventRecord, ::cudaEventElapsedTime
-  ## 
+  ##
   proc cudaEventDestroy*(event: cudaEvent_t): cudaError_t {.cdecl,
       importc: "cudaEventDestroy", dyn.}
   ## *
   ##  \brief Computes the elapsed time between events
-  ## 
+  ##
   ##  Computes the elapsed time between two events (in milliseconds with a
   ##  resolution of around 0.5 microseconds).
-  ## 
+  ##
   ##  If either event was last recorded in a non-NULL stream, the resulting time
   ##  may be greater than expected (even if both used the same stream handle). This
   ##  happens because the ::cudaEventRecord() operation takes place asynchronously
@@ -2342,7 +2342,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  the two events. Any number of other different stream operations could execute
   ##  in between the two measured events, thus altering the timing in a significant
   ##  way.
-  ## 
+  ##
   ##  If ::cudaEventRecord() has not been called on either event, then
   ##  ::cudaErrorInvalidResourceHandle is returned. If ::cudaEventRecord() has been
   ##  called on both events but one or both of them has not yet been completed
@@ -2350,11 +2350,11 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  of the events), ::cudaErrorNotReady is returned. If either event was created
   ##  with the ::cudaEventDisableTiming flag, then this function will return
   ##  ::cudaErrorInvalidResourceHandle.
-  ## 
+  ##
   ##  \param ms    - Time between \p start and \p end in ms
   ##  \param start - Starting event
   ##  \param end   - Ending event
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorNotReady,
@@ -2363,56 +2363,56 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorLaunchFailure
   ##  \notefnerr
-  ## 
-  ##  \sa \ref ::cudaEventCreate(cudaEvent_t*) "cudaEventCreate (C API)",
+  ##
+  ##  `\sa \ref ::cudaEventCreate(cudaEvent_t*) "cudaEventCreate (C API)",`
   ##  ::cudaEventCreateWithFlags, ::cudaEventQuery,
   ##  ::cudaEventSynchronize, ::cudaEventDestroy, ::cudaEventRecord
-  ## 
+  ##
   proc cudaEventElapsedTime*(ms: ptr cfloat; start: cudaEvent_t; `end`: cudaEvent_t): cudaError_t {.
       cdecl, importc: "cudaEventElapsedTime", dyn.}
   ## * @}
   ##  END CUDART_EVENT
   ## *
   ##  \defgroup CUDART_EXECUTION Execution Control
-  ## 
+  ##
   ##  ___MANBRIEF___ execution control functions of the CUDA runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the execution control functions of the CUDA runtime
   ##  application programming interface.
-  ## 
+  ##
   ##  Some functions have overloaded C++ API template versions documented separately in the
   ##  \ref CUDART_HIGHLEVEL "C++ API Routines" module.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   when CUDART_VERSION >= 7000:
     ## *
     ##  \brief Launches a device function
-    ## 
+    ##
     ##  The function invokes kernel \p func on \p gridDim (\p gridDim.x × \p gridDim.y
     ##  × \p gridDim.z) grid of blocks. Each block contains \p blockDim (\p blockDim.x ×
     ##  \p blockDim.y × \p blockDim.z) threads.
-    ## 
+    ##
     ##  If the kernel has N parameters the \p args should point to array of N pointers.
     ##  Each pointer, from <tt>args[0]</tt> to <tt>args[N - 1]</tt>, point to the region
     ##  of memory from which the actual parameter will be copied.
-    ## 
+    ##
     ##  For templated functions, pass the function symbol as follows:
     ##  func_name<template_arg_0,...,template_arg_N>
-    ## 
+    ##
     ##  \p sharedMem sets the amount of dynamic shared memory that will be available to
     ##  each thread block.
-    ## 
+    ##
     ##  \p stream specifies a stream the invocation is associated to.
-    ## 
+    ##
     ##  \param func        - Device function symbol
     ##  \param gridDim     - Grid dimentions
     ##  \param blockDim    - Block dimentions
     ##  \param args        - Arguments
     ##  \param sharedMem   - Shared memory
     ##  \param stream      - Stream identifier
-    ## 
+    ##
     ##  \return
     ##  ::cudaSuccess,
     ##  ::cudaErrorInvalidDeviceFunction,
@@ -2423,63 +2423,63 @@ when not defined(CUDA_RUNTIME_API_H):
     ##  ::cudaErrorSharedObjectInitFailed
     ##  \note_null_stream
     ##  \notefnerr
-    ## 
-    ##  \ref ::cudaLaunchKernel(const T *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C++ API)"
-    ## 
+    ##
+    ##  `\ref ::cudaLaunchKernel(const T *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C++ API)"`
+    ##
     proc cudaLaunchKernel*(`func`: pointer; gridDim: dim3; blockDim: dim3;
                           args: ptr pointer; sharedMem: csize; stream: cudaStream_t): cudaError_t {.
         cdecl, importc: "cudaLaunchKernel", dyn.}
   ## *
   ##  \brief Sets the preferred cache configuration for a device function
-  ## 
+  ##
   ##  On devices where the L1 cache and shared memory use the same hardware
   ##  resources, this sets through \p cacheConfig the preferred cache configuration
   ##  for the function specified via \p func. This is only a preference. The
   ##  runtime will use the requested configuration if possible, but it is free to
   ##  choose a different configuration if required to execute \p func.
-  ## 
+  ##
   ##  \p func is a device function symbol and must be declared as a
   ##  \c __global__ function. If the specified function does not exist,
   ##  then ::cudaErrorInvalidDeviceFunction is returned. For templated functions,
   ##  pass the function symbol as follows: func_name<template_arg_0,...,template_arg_N>
-  ## 
+  ##
   ##  This setting does nothing on devices where the size of the L1 cache and
   ##  shared memory are fixed.
-  ## 
+  ##
   ##  Launching a kernel with a different preference than the most recent
   ##  preference setting may insert a device-side synchronization point.
-  ## 
+  ##
   ##  The supported cache configurations are:
   ##  - ::cudaFuncCachePreferNone: no preference for shared memory or L1 (default)
   ##  - ::cudaFuncCachePreferShared: prefer larger shared memory and smaller L1 cache
   ##  - ::cudaFuncCachePreferL1: prefer larger L1 cache and smaller shared memory
   ##  - ::cudaFuncCachePreferEqual: prefer equal size L1 cache and shared memory
-  ## 
+  ##
   ##  \param func        - Device function symbol
   ##  \param cacheConfig - Requested cache configuration
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInitializationError,
   ##  ::cudaErrorInvalidDeviceFunction
   ##  \notefnerr
   ##  \note_string_api_deprecation2
-  ## 
+  ##
   ##  \sa ::cudaConfigureCall,
-  ##  \ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C++ API)",
-  ##  \ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const void*) "cudaFuncGetAttributes (C API)",
-  ##  \ref ::cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C API)",
+  ##  `\ref ::cudaFuncSetCacheConfig(T*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C++ API)",`
+  ##  `\ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const void*) "cudaFuncGetAttributes (C API)",`
+  ##  `\ref ::cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C API)",`
   ##  ::cudaSetDoubleForDevice,
   ##  ::cudaSetDoubleForHost,
-  ##  \ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)",
+  ##  `\ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)",`
   ##  ::cudaThreadGetCacheConfig,
   ##  ::cudaThreadSetCacheConfig
-  ## 
+  ##
   proc cudaFuncSetCacheConfig*(`func`: pointer; cacheConfig: cudaFuncCache): cudaError_t {.
       cdecl, importc: "cudaFuncSetCacheConfig", dyn.}
   ## *
   ##  \brief Sets the shared memory configuration for a device function
-  ## 
+  ##
   ##  On devices with configurable shared memory banks, this function will
   ##  force all subsequent launches of the specified device function to have
   ##  the given shared memory bank size configuration. On any given launch of the
@@ -2487,22 +2487,22 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  changed if needed to suit the function's preferred configuration. Changes in
   ##  shared memory configuration between subsequent launches of functions,
   ##  may introduce a device side synchronization point.
-  ## 
+  ##
   ##  Any per-function setting of shared memory bank size set via
   ##  ::cudaFuncSetSharedMemConfig will override the device wide setting set by
   ##  ::cudaDeviceSetSharedMemConfig.
-  ## 
+  ##
   ##  Changing the shared memory bank size will not increase shared memory usage
   ##  or affect occupancy of kernels, but may have major effects on performance.
   ##  Larger bank sizes will allow for greater potential bandwidth to shared memory,
   ##  but will change what kinds of accesses to shared memory will result in bank
   ##  conflicts.
-  ## 
+  ##
   ##  This function will do nothing on devices with fixed shared memory bank size.
-  ## 
+  ##
   ##  For templated functions, pass the function symbol as follows:
   ##  func_name<template_arg_0,...,template_arg_N>
-  ## 
+  ##
   ##  The supported bank configurations are:
   ##  - ::cudaSharedMemBankSizeDefault: use the device's shared memory configuration
   ##    when launching this function.
@@ -2510,10 +2510,10 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    four bytes natively when launching this function.
   ##  - ::cudaSharedMemBankSizeEightByte: set shared memory bank width to be eight
   ##    bytes natively when launching this function.
-  ## 
+  ##
   ##  \param func   - Device function symbol
   ##  \param config - Requested shared memory configuration
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInitializationError,
@@ -2521,94 +2521,94 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorInvalidValue,
   ##  \notefnerr
   ##  \note_string_api_deprecation2
-  ## 
+  ##
   ##  \sa ::cudaConfigureCall,
   ##  ::cudaDeviceSetSharedMemConfig,
   ##  ::cudaDeviceGetSharedMemConfig,
   ##  ::cudaDeviceSetCacheConfig,
   ##  ::cudaDeviceGetCacheConfig,
   ##  ::cudaFuncSetCacheConfig
-  ## 
+  ##
   proc cudaFuncSetSharedMemConfig*(`func`: pointer; config: cudaSharedMemConfig): cudaError_t {.
       cdecl, importc: "cudaFuncSetSharedMemConfig", dyn.}
   ## *
   ##  \brief Find out attributes for a given function
-  ## 
+  ##
   ##  This function obtains the attributes of a function specified via \p func.
   ##  \p func is a device function symbol and must be declared as a
   ##  \c __global__ function. The fetched attributes are placed in \p attr.
   ##  If the specified function does not exist, then
   ##  ::cudaErrorInvalidDeviceFunction is returned. For templated functions, pass
   ##  the function symbol as follows: func_name<template_arg_0,...,template_arg_N>
-  ## 
+  ##
   ##  Note that some function attributes such as
   ##  \ref ::cudaFuncAttributes::maxThreadsPerBlock "maxThreadsPerBlock"
   ##  may vary based on the device that is currently being used.
-  ## 
+  ##
   ##  \param attr - Return pointer to function's attributes
   ##  \param func - Device function symbol
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInitializationError,
   ##  ::cudaErrorInvalidDeviceFunction
   ##  \notefnerr
   ##  \note_string_api_deprecation2
-  ## 
+  ##
   ##  \sa ::cudaConfigureCall,
-  ##  \ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",
-  ##  \ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, T*) "cudaFuncGetAttributes (C++ API)",
-  ##  \ref ::cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C API)",
+  ##  `\ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",`
+  ##  `\ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, T*) "cudaFuncGetAttributes (C++ API)",`
+  ##  `\ref ::cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C API)",`
   ##  ::cudaSetDoubleForDevice,
   ##  ::cudaSetDoubleForHost,
-  ##  \ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)"
-  ## 
+  ##  `\ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)"`
+  ##
   proc cudaFuncGetAttributes*(attr: ptr cudaFuncAttributes; `func`: pointer): cudaError_t {.
       cdecl, importc: "cudaFuncGetAttributes", dyn.}
   ## *
   ##  \brief Converts a double argument to be executed on a device
-  ## 
+  ##
   ##  \param d - Double to convert
-  ## 
+  ##
   ##  \deprecated This function is deprecated as of CUDA 7.5
-  ## 
+  ##
   ##  Converts the double value of \p d to an internal float representation if
   ##  the device does not support double arithmetic. If the device does natively
   ##  support doubles, then this function does nothing.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess
   ##  \notefnerr
-  ## 
-  ##  \ref ::cudaLaunch(const void*) "cudaLaunch (C API)",
-  ##  \ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",
-  ##  \ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const void*) "cudaFuncGetAttributes (C API)",
+  ##
+  ##  `\ref ::cudaLaunch(const void*) "cudaLaunch (C API)",`
+  ##  `\ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",`
+  ##  `\ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const void*) "cudaFuncGetAttributes (C API)",`
   ##  ::cudaSetDoubleForHost,
-  ##  \ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)"
-  ## 
+  ##  `\ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)"`
+  ##
   proc cudaSetDoubleForDevice*(d: ptr cdouble): cudaError_t {.cdecl,
       importc: "cudaSetDoubleForDevice", dyn.}
   ## *
   ##  \brief Converts a double argument after execution on a device
-  ## 
+  ##
   ##  \deprecated This function is deprecated as of CUDA 7.5
-  ## 
+  ##
   ##  Converts the double value of \p d from a potentially internal float
   ##  representation if the device does not support double arithmetic. If the
   ##  device does natively support doubles, then this function does nothing.
-  ## 
+  ##
   ##  \param d - Double to convert
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess
   ##  \notefnerr
-  ## 
-  ##  \ref ::cudaLaunch(const void*) "cudaLaunch (C API)",
-  ##  \ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",
-  ##  \ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const void*) "cudaFuncGetAttributes (C API)",
+  ##
+  ##  `\ref ::cudaLaunch(const void*) "cudaLaunch (C API)",`
+  ##  `\ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",`
+  ##  `\ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const void*) "cudaFuncGetAttributes (C API)",`
   ##  ::cudaSetDoubleForDevice,
-  ##  \ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)"
-  ## 
+  ##  `\ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)"`
+  ##
   proc cudaSetDoubleForHost*(d: ptr cdouble): cudaError_t {.cdecl,
       importc: "cudaSetDoubleForHost", dyn.}
   ## * @}
@@ -2616,37 +2616,37 @@ when not defined(CUDA_RUNTIME_API_H):
   when CUDART_VERSION >= 6050:
     ## *
     ##  \defgroup CUDART_OCCUPANCY Occupancy
-    ## 
+    ##
     ##  ___MANBRIEF___ occupancy calculation functions of the CUDA runtime API
     ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-    ## 
+    ##
     ##  This section describes the occupancy calculation functions of the CUDA runtime
     ##  application programming interface.
-    ## 
+    ##
     ##  Besides the occupancy calculator functions
     ##  (\ref ::cudaOccupancyMaxActiveBlocksPerMultiprocessor and \ref ::cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags),
     ##  there are also C++ only occupancy-based launch configuration functions documented in
     ##  \ref CUDART_HIGHLEVEL "C++ API Routines" module.
-    ## 
+    ##
     ##  See
-    ##  \ref ::cudaOccupancyMaxPotentialBlockSize(int*, int*, T, size_t, int) "cudaOccupancyMaxPotentialBlockSize (C++ API)",
-    ##  \ref ::cudaOccupancyMaxPotentialBlockSizeWithFlags(int*, int*, T, size_t, int, unsigned int) "cudaOccupancyMaxPotentialBlockSize (C++ API)",
-    ##  \ref ::cudaOccupancyMaxPotentialBlockSizeVariableSMem(int*, int*, T, UnaryFunction, int) "cudaOccupancyMaxPotentialBlockSizeVariableSMem (C++ API)",
-    ##  \ref ::cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags(int*, int*, T, UnaryFunction, int, unsigned int) "cudaOccupancyMaxPotentialBlockSizeVariableSMem (C++ API)",
-    ## 
+    ##  `\ref ::cudaOccupancyMaxPotentialBlockSize(int*, int*, T, size_t, int) "cudaOccupancyMaxPotentialBlockSize (C++ API)",`
+    ##  `\ref ::cudaOccupancyMaxPotentialBlockSizeWithFlags(int*, int*, T, size_t, int, unsigned int) "cudaOccupancyMaxPotentialBlockSize (C++ API)",`
+    ##  `\ref ::cudaOccupancyMaxPotentialBlockSizeVariableSMem(int*, int*, T, UnaryFunction, int) "cudaOccupancyMaxPotentialBlockSizeVariableSMem (C++ API)",`
+    ##  `\ref ::cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags(int*, int*, T, UnaryFunction, int, unsigned int) "cudaOccupancyMaxPotentialBlockSizeVariableSMem (C++ API)",`
+    ##
     ##  @{
-    ## 
+    ##
     ## *
     ##  \brief Returns occupancy for a device function
-    ## 
-    ##  Returns in \p *numBlocks the maximum number of active blocks per
+    ##
+    ##  `Returns in \p *numBlocks the maximum number of active blocks per`
     ##  streaming multiprocessor for the device function.
-    ## 
+    ##
     ##  \param numBlocks       - Returned occupancy
     ##  \param func            - Kernel function for which occupancy is calculated
     ##  \param blockSize       - Block size the kernel is intended to be launched with
     ##  \param dynamicSMemSize - Per-block dynamic shared memory usage intended, in bytes
-    ## 
+    ##
     ##  \return
     ##  ::cudaSuccess,
     ##  ::cudaErrorCudartUnloading,
@@ -2656,28 +2656,28 @@ when not defined(CUDA_RUNTIME_API_H):
     ##  ::cudaErrorInvalidValue,
     ##  ::cudaErrorUnknown,
     ##  \notefnerr
-    ## 
+    ##
     ##  \sa ::cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags,
-    ##  \ref ::cudaOccupancyMaxPotentialBlockSize(int*, int*, T, size_t, int) "cudaOccupancyMaxPotentialBlockSize (C++ API)",
-    ##  \ref ::cudaOccupancyMaxPotentialBlockSizeWithFlags(int*, int*, T, size_t, int, unsigned int) "cudaOccupancyMaxPotentialBlockSizeWithFlags (C++ API)",
-    ##  \ref ::cudaOccupancyMaxPotentialBlockSizeVariableSMem(int*, int*, T, UnaryFunction, int) "cudaOccupancyMaxPotentialBlockSizeVariableSMem (C++ API)"
-    ##  \ref ::cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags(int*, int*, T, UnaryFunction, int, unsigned int) "cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags (C++ API)"
-    ## 
+    ##  `\ref ::cudaOccupancyMaxPotentialBlockSize(int*, int*, T, size_t, int) "cudaOccupancyMaxPotentialBlockSize (C++ API)",`
+    ##  `\ref ::cudaOccupancyMaxPotentialBlockSizeWithFlags(int*, int*, T, size_t, int, unsigned int) "cudaOccupancyMaxPotentialBlockSizeWithFlags (C++ API)",`
+    ##  `\ref ::cudaOccupancyMaxPotentialBlockSizeVariableSMem(int*, int*, T, UnaryFunction, int) "cudaOccupancyMaxPotentialBlockSizeVariableSMem (C++ API)"`
+    ##  `\ref ::cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags(int*, int*, T, UnaryFunction, int, unsigned int) "cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags (C++ API)"`
+    ##
     proc cudaOccupancyMaxActiveBlocksPerMultiprocessor*(numBlocks: ptr cint;
         `func`: pointer; blockSize: cint; dynamicSMemSize: csize): cudaError_t {.cdecl,
         importc: "cudaOccupancyMaxActiveBlocksPerMultiprocessor", dyn.}
     when CUDART_VERSION >= 7000:
       ## *
       ##  \brief Returns occupancy for a device function with the specified flags
-      ## 
-      ##  Returns in \p *numBlocks the maximum number of active blocks per
+      ##
+      ##  `Returns in \p *numBlocks the maximum number of active blocks per`
       ##  streaming multiprocessor for the device function.
-      ## 
+      ##
       ##  The \p flags parameter controls how special cases are handled. Valid flags include:
-      ## 
+      ##
       ##  - ::cudaOccupancyDefault: keeps the default behavior as
       ##    ::cudaOccupancyMaxActiveBlocksPerMultiprocessor
-      ## 
+      ##
       ##  - ::cudaOccupancyDisableCachingOverride: This flag suppresses the default behavior
       ##    on platform where global caching affects occupancy. On such platforms, if caching
       ##    is enabled, but per-block SM resource usage would result in zero occupancy, the
@@ -2685,13 +2685,13 @@ when not defined(CUDA_RUNTIME_API_H):
       ##    Setting this flag makes the occupancy calculator to return 0 in such cases.
       ##    More information can be found about this feature in the "Unified L1/Texture Cache"
       ##    section of the Maxwell tuning guide.
-      ## 
+      ##
       ##  \param numBlocks       - Returned occupancy
       ##  \param func            - Kernel function for which occupancy is calculated
       ##  \param blockSize       - Block size the kernel is intended to be launched with
       ##  \param dynamicSMemSize - Per-block dynamic shared memory usage intended, in bytes
       ##  \param flags           - Requested behavior for the occupancy calculator
-      ## 
+      ##
       ##  \return
       ##  ::cudaSuccess,
       ##  ::cudaErrorCudartUnloading,
@@ -2701,13 +2701,13 @@ when not defined(CUDA_RUNTIME_API_H):
       ##  ::cudaErrorInvalidValue,
       ##  ::cudaErrorUnknown,
       ##  \notefnerr
-      ## 
+      ##
       ##  \sa ::cudaOccupancyMaxActiveBlocksPerMultiprocessor,
-      ##  \ref ::cudaOccupancyMaxPotentialBlockSize(int*, int*, T, size_t, int) "cudaOccupancyMaxPotentialBlockSize (C++ API)",
-      ##  \ref ::cudaOccupancyMaxPotentialBlockSizeWithFlags(int*, int*, T, size_t, int, unsigned int) "cudaOccupancyMaxPotentialBlockSizeWithFlags (C++ API)",
-      ##  \ref ::cudaOccupancyMaxPotentialBlockSizeVariableSMem(int*, int*, T, UnaryFunction, int) "cudaOccupancyMaxPotentialBlockSizeVariableSMem (C++ API)"
-      ##  \ref ::cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags(int*, int*, T, UnaryFunction, int, unsigned int) "cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags (C++ API)"
-      ## 
+      ##  `\ref ::cudaOccupancyMaxPotentialBlockSize(int*, int*, T, size_t, int) "cudaOccupancyMaxPotentialBlockSize (C++ API)",`
+      ##  `\ref ::cudaOccupancyMaxPotentialBlockSizeWithFlags(int*, int*, T, size_t, int, unsigned int) "cudaOccupancyMaxPotentialBlockSizeWithFlags (C++ API)",`
+      ##  `\ref ::cudaOccupancyMaxPotentialBlockSizeVariableSMem(int*, int*, T, UnaryFunction, int) "cudaOccupancyMaxPotentialBlockSizeVariableSMem (C++ API)"`
+      ##  `\ref ::cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags(int*, int*, T, UnaryFunction, int, unsigned int) "cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags (C++ API)"`
+      ##
       proc cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags*(
           numBlocks: ptr cint; `func`: pointer; blockSize: cint;
           dynamicSMemSize: csize; flags: cuint): cudaError_t {.cdecl,
@@ -2717,95 +2717,95 @@ when not defined(CUDA_RUNTIME_API_H):
       ##  END CUDA_OCCUPANCY
   ## *
   ##  \defgroup CUDART_EXECUTION_DEPRECATED Execution Control [DEPRECATED]
-  ## 
+  ##
   ##  ___MANBRIEF___ deprecated execution control functions of the CUDA runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the deprecated execution control functions of the CUDA runtime
   ##  application programming interface.
-  ## 
+  ##
   ##  Some functions have overloaded C++ API template versions documented separately in the
   ##  \ref CUDART_HIGHLEVEL "C++ API Routines" module.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Configure a device-launch
-  ## 
+  ##
   ##  \deprecated This function is deprecated as of CUDA 7.0
-  ## 
+  ##
   ##  Specifies the grid and block dimensions for the device call to be executed
   ##  similar to the execution configuration syntax. ::cudaConfigureCall() is
   ##  stack based. Each call pushes data on top of an execution stack. This data
   ##  contains the dimension for the grid and thread blocks, together with any
   ##  arguments for the call.
-  ## 
+  ##
   ##  \param gridDim   - Grid dimensions
   ##  \param blockDim  - Block dimensions
   ##  \param sharedMem - Shared memory
   ##  \param stream    - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidConfiguration
   ##  \note_null_stream
   ##  \notefnerr
-  ## 
-  ##  \ref ::cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C API)",
-  ##  \ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",
-  ##  \ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const void*) "cudaFuncGetAttributes (C API)",
-  ##  \ref ::cudaLaunch(const void*) "cudaLaunch (C API)",
+  ##
+  ##  `\ref ::cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C API)",`
+  ##  `\ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",`
+  ##  `\ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const void*) "cudaFuncGetAttributes (C API)",`
+  ##  `\ref ::cudaLaunch(const void*) "cudaLaunch (C API)",`
   ##  ::cudaSetDoubleForDevice,
   ##  ::cudaSetDoubleForHost,
-  ##  \ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)",
-  ## 
+  ##  `\ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)",`
+  ##
   proc cudaConfigureCall*(gridDim: dim3; blockDim: dim3; sharedMem: csize;
                          stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaConfigureCall", dyn.}
   ## *
   ##  \brief Configure a device launch
-  ## 
+  ##
   ##  \deprecated This function is deprecated as of CUDA 7.0
-  ## 
+  ##
   ##  Pushes \p size bytes of the argument pointed to by \p arg at \p offset
   ##  bytes from the start of the parameter passing area, which starts at
   ##  offset 0. The arguments are stored in the top of the execution stack.
-  ##  \ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument()"
+  ##  `\ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument()"`
   ##  must be preceded by a call to ::cudaConfigureCall().
-  ## 
+  ##
   ##  \param arg    - Argument to push for a kernel launch
   ##  \param size   - Size of argument
   ##  \param offset - Offset in argument stack to push new arg
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess
   ##  \notefnerr
-  ## 
-  ##  \ref ::cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C API)",
-  ##  \ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",
-  ##  \ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const void*) "cudaFuncGetAttributes (C API)",
-  ##  \ref ::cudaLaunch(const void*) "cudaLaunch (C API)",
+  ##
+  ##  `\ref ::cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C API)",`
+  ##  `\ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",`
+  ##  `\ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const void*) "cudaFuncGetAttributes (C API)",`
+  ##  `\ref ::cudaLaunch(const void*) "cudaLaunch (C API)",`
   ##  ::cudaSetDoubleForDevice,
   ##  ::cudaSetDoubleForHost,
   ##  \ref ::cudaSetupArgument(T, size_t) "cudaSetupArgument (C++ API)",
-  ## 
+  ##
   proc cudaSetupArgument*(arg: pointer; size: csize; offset: csize): cudaError_t {.
       cdecl, importc: "cudaSetupArgument", dyn.}
   ## *
   ##  \brief Launches a device function
-  ## 
+  ##
   ##  \deprecated This function is deprecated as of CUDA 7.0
-  ## 
+  ##
   ##  Launches the function \p func on the device. The parameter \p func must
   ##  be a device function symbol. The parameter specified by \p func must be
   ##  declared as a \p __global__ function. For templated functions, pass the
   ##  function symbol as follows: func_name<template_arg_0,...,template_arg_N>
-  ##  \ref ::cudaLaunch(const void*) "cudaLaunch()" must be preceded by a call to
+  ##  `\ref ::cudaLaunch(const void*) "cudaLaunch()" must be preceded by a call to`
   ##  ::cudaConfigureCall() since it pops the data that was pushed by
   ##  ::cudaConfigureCall() from the execution stack.
-  ## 
+  ##
   ##  \param func - Device function symbol
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidDeviceFunction,
@@ -2816,40 +2816,40 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorSharedObjectInitFailed
   ##  \notefnerr
   ##  \note_string_api_deprecation_50
-  ## 
-  ##  \ref ::cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C API)",
-  ##  \ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",
-  ##  \ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const void*) "cudaFuncGetAttributes (C API)",
-  ##  \ref ::cudaLaunch(T*) "cudaLaunch (C++ API)",
+  ##
+  ##  `\ref ::cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) "cudaLaunchKernel (C API)",`
+  ##  `\ref ::cudaFuncSetCacheConfig(const void*, enum cudaFuncCache) "cudaFuncSetCacheConfig (C API)",`
+  ##  `\ref ::cudaFuncGetAttributes(struct cudaFuncAttributes*, const void*) "cudaFuncGetAttributes (C API)",`
+  ##  `\ref ::cudaLaunch(T*) "cudaLaunch (C++ API)",`
   ##  ::cudaSetDoubleForDevice,
   ##  ::cudaSetDoubleForHost,
-  ##  \ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)",
+  ##  `\ref ::cudaSetupArgument(const void*, size_t, size_t) "cudaSetupArgument (C API)",`
   ##  ::cudaThreadGetCacheConfig,
   ##  ::cudaThreadSetCacheConfig
-  ## 
+  ##
   proc cudaLaunch*(`func`: pointer): cudaError_t {.cdecl, importc: "cudaLaunch",
       dyn.}
   ## * @}
   ##  END CUDART_EXECUTION_DEPRECATED
   ## *
   ##  \defgroup CUDART_MEMORY Memory Management
-  ## 
+  ##
   ##  ___MANBRIEF___ memory management functions of the CUDA runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the memory management functions of the CUDA runtime
   ##  application programming interface.
-  ## 
+  ##
   ##  Some functions have overloaded C++ API template versions documented separately in the
   ##  \ref CUDART_HIGHLEVEL "C++ API Routines" module.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Allocates memory that will be automatically managed by the Unified Memory system
-  ## 
+  ##
   ##  Allocates \p size bytes of managed memory on the device and returns in
-  ##  \p *devPtr a pointer to the allocated memory. If the device doesn't support
+  ##  `\p *devPtr a pointer to the allocated memory. If the device doesn't support`
   ##  allocating managed memory, ::cudaErrorNotSupported is returned. Support
   ##  for managed memory can be queried using the device attribute
   ##  ::cudaDevAttrManagedMemory. The allocated memory is suitably
@@ -2857,7 +2857,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  is 0, ::cudaMallocManaged returns ::cudaErrorInvalidValue. The pointer
   ##  is valid on the CPU and on all GPUs in the system that support managed memory.
   ##  All accesses to this pointer must obey the Unified Memory programming model.
-  ## 
+  ##
   ##  \p flags specifies the default stream association for this allocation.
   ##  \p flags must be one of ::cudaMemAttachGlobal or ::cudaMemAttachHost. The
   ##  default value for \p flags is ::cudaMemAttachGlobal.
@@ -2866,21 +2866,21 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  allocation should not be accessed from devices that have a zero value for the
   ##  device attribute ::cudaDevAttrConcurrentManagedAccess; an explicit call to
   ##  ::cudaStreamAttachMemAsync will be required to enable access on such devices.
-  ## 
+  ##
   ##  If the association is later changed via ::cudaStreamAttachMemAsync to
   ##  a single stream, the default association, as specifed during ::cudaMallocManaged,
   ##  is restored when that stream is destroyed. For __managed__ variables, the
   ##  default association is always ::cudaMemAttachGlobal. Note that destroying a
   ##  stream is an asynchronous operation, and as a result, the change to default
   ##  association won't happen until all work in the stream has completed.
-  ## 
+  ##
   ##  Memory allocated with ::cudaMallocManaged should be released with ::cudaFree.
-  ## 
+  ##
   ##  Device memory oversubscription is possible for GPUs that have a non-zero value for the
   ##  device attribute ::cudaDevAttrConcurrentManagedAccess. Managed memory on
   ##  such GPUs may be evicted from device memory to host memory at any time by the Unified
   ##  Memory driver in order to make room for other allocations.
-  ## 
+  ##
   ##  In a multi-GPU system where all GPUs have a non-zero value for the device attribute
   ##  ::cudaDevAttrConcurrentManagedAccess, managed memory may not be populated when this
   ##  API returns and instead may be populated on access. In such systems, managed memory can
@@ -2889,14 +2889,14 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  can also guide the driver about memory usage patterns via ::cudaMemAdvise. The application
   ##  can also explicitly migrate memory to a desired processor's memory via
   ##  ::cudaMemPrefetchAsync.
-  ## 
+  ##
   ##  In a multi-GPU system where all of the GPUs have a zero value for the device attribute
   ##  ::cudaDevAttrConcurrentManagedAccess and all the GPUs have peer-to-peer support
   ##  with each other, the physical storage for managed memory is created on the GPU which is active
   ##  at the time ::cudaMallocManaged is called. All other GPUs will reference the data at reduced
   ##  bandwidth via peer mappings over the PCIe bus. The Unified Memory driver does not migrate
   ##  memory among such GPUs.
-  ## 
+  ##
   ##  In a multi-GPU system where not all GPUs have peer-to-peer support with each other and
   ##  where the value of the device attribute ::cudaDevAttrConcurrentManagedAccess
   ##  is zero for at least one of those GPUs, the location chosen for physical storage of managed
@@ -2926,124 +2926,124 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  that process, even if ::cudaDeviceReset has been called on those devices. These
   ##  environment variables are described in the CUDA programming guide under the
   ##  "CUDA environment variables" section.
-  ## 
+  ##
   ##  \param devPtr - Pointer to allocated device memory
   ##  \param size   - Requested allocation size in bytes
   ##  \param flags  - Must be either ::cudaMemAttachGlobal or ::cudaMemAttachHost (defaults to ::cudaMemAttachGlobal)
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorMemoryAllocation
   ##  ::cudaErrorNotSupported
   ##  ::cudaErrorInvalidValue
-  ## 
+  ##
   ##  \sa ::cudaMallocPitch, ::cudaFree, ::cudaMallocArray, ::cudaFreeArray,
   ##  ::cudaMalloc3D, ::cudaMalloc3DArray,
-  ##  \ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",`
   ##  ::cudaFreeHost, ::cudaHostAlloc, ::cudaDeviceGetAttribute, ::cudaStreamAttachMemAsync
-  ## 
+  ##
   proc cudaMallocManaged*(devPtr: ptr pointer; size: csize; flags: cuint): cudaError_t {.
       cdecl, importc: "cudaMallocManaged", dyn.}
   ## *
   ##  \brief Allocate memory on the device
-  ## 
+  ##
   ##  Allocates \p size bytes of linear memory on the device and returns in
-  ##  \p *devPtr a pointer to the allocated memory. The allocated memory is
+  ##  `\p *devPtr a pointer to the allocated memory. The allocated memory is`
   ##  suitably aligned for any kind of variable. The memory is not cleared.
   ##  ::cudaMalloc() returns ::cudaErrorMemoryAllocation in case of failure.
-  ## 
-  ##  The device version of ::cudaFree cannot be used with a \p *devPtr
+  ##
+  ##  `The device version of ::cudaFree cannot be used with a \p *devPtr`
   ##  allocated using the host API, and vice versa.
-  ## 
+  ##
   ##  \param devPtr - Pointer to allocated device memory
   ##  \param size   - Requested allocation size in bytes
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorMemoryAllocation
-  ## 
+  ##
   ##  \sa ::cudaMallocPitch, ::cudaFree, ::cudaMallocArray, ::cudaFreeArray,
   ##  ::cudaMalloc3D, ::cudaMalloc3DArray,
-  ##  \ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",`
   ##  ::cudaFreeHost, ::cudaHostAlloc
-  ## 
+  ##
   proc cudaMalloc*(devPtr: ptr pointer; size: csize): cudaError_t {.cdecl,
       importc: "cudaMalloc", dyn.}
   ## *
   ##  \brief Allocates page-locked memory on the host
-  ## 
+  ##
   ##  Allocates \p size bytes of host memory that is page-locked and accessible
   ##  to the device. The driver tracks the virtual memory ranges allocated with
   ##  this function and automatically accelerates calls to functions such as
-  ##  ::cudaMemcpy*(). Since the memory can be accessed directly by the device,
+  ##  `::cudaMemcpy*(). Since the memory can be accessed directly by the device,`
   ##  it can be read or written with much higher bandwidth than pageable memory
   ##  obtained with functions such as ::malloc(). Allocating excessive amounts of
   ##  memory with ::cudaMallocHost() may degrade system performance, since it
   ##  reduces the amount of memory available to the system for paging. As a
   ##  result, this function is best used sparingly to allocate staging areas for
   ##  data exchange between host and device.
-  ## 
+  ##
   ##  \param ptr  - Pointer to allocated host memory
   ##  \param size - Requested allocation size in bytes
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorMemoryAllocation
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMalloc, ::cudaMallocPitch, ::cudaMallocArray, ::cudaMalloc3D,
   ##  ::cudaMalloc3DArray, ::cudaHostAlloc, ::cudaFree, ::cudaFreeArray,
-  ##  \ref ::cudaMallocHost(void**, size_t, unsigned int) "cudaMallocHost (C++ API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t, unsigned int) "cudaMallocHost (C++ API)",`
   ##  ::cudaFreeHost, ::cudaHostAlloc
-  ## 
+  ##
   proc cudaMallocHost*(`ptr`: ptr pointer; size: csize): cudaError_t {.cdecl,
       importc: "cudaMallocHost", dyn.}
   ## *
   ##  \brief Allocates pitched memory on the device
-  ## 
-  ##  Allocates at least \p width (in bytes) * \p height bytes of linear memory
-  ##  on the device and returns in \p *devPtr a pointer to the allocated memory.
+  ##
+  ##  `Allocates at least \p width (in bytes) * \p height bytes of linear memory`
+  ##  `on the device and returns in \p *devPtr a pointer to the allocated memory.`
   ##  The function may pad the allocation to ensure that corresponding pointers
   ##  in any given row will continue to meet the alignment requirements for
   ##  coalescing as the address is updated from row to row. The pitch returned in
-  ##  \p *pitch by ::cudaMallocPitch() is the width in bytes of the allocation.
+  ##  `\p *pitch by ::cudaMallocPitch() is the width in bytes of the allocation.`
   ##  The intended usage of \p pitch is as a separate parameter of the allocation,
   ##  used to compute addresses within the 2D array. Given the row and column of
   ##  an array element of type \p T, the address is computed as:
   ##  \code
-  ##     T* pElement = (T*)((char*)BaseAddress + Row * pitch) + Column;
+  ##  `   T* pElement = (T*)((char*)BaseAddress + Row * pitch) + Column;`
   ##    \endcode
-  ## 
+  ##
   ##  For allocations of 2D arrays, it is recommended that programmers consider
   ##  performing pitch allocations using ::cudaMallocPitch(). Due to pitch
   ##  alignment restrictions in the hardware, this is especially true if the
   ##  application will be performing 2D memory copies between different regions
   ##  of device memory (whether linear memory or CUDA arrays).
-  ## 
+  ##
   ##  \param devPtr - Pointer to allocated pitched device memory
   ##  \param pitch  - Pitch for allocation
   ##  \param width  - Requested pitched allocation width (in bytes)
   ##  \param height - Requested pitched allocation height
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorMemoryAllocation
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMalloc, ::cudaFree, ::cudaMallocArray, ::cudaFreeArray,
-  ##  \ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",`
   ##  ::cudaFreeHost, ::cudaMalloc3D, ::cudaMalloc3DArray,
   ##  ::cudaHostAlloc
-  ## 
+  ##
   proc cudaMallocPitch*(devPtr: ptr pointer; pitch: ptr csize; width: csize;
                        height: csize): cudaError_t {.cdecl,
       importc: "cudaMallocPitch", dyn.}
   ## *
   ##  \brief Allocate an array on the device
-  ## 
+  ##
   ##  Allocates a CUDA array according to the ::cudaChannelFormatDesc structure
-  ##  \p desc and returns a handle to the new CUDA array in \p *array.
-  ## 
+  ##  `\p desc and returns a handle to the new CUDA array in \p *array.`
+  ##
   ##  The ::cudaChannelFormatDesc is defined as:
   ##  \code
   ##     struct cudaChannelFormatDesc {
@@ -3053,128 +3053,128 @@ when not defined(CUDA_RUNTIME_API_H):
   ##     \endcode
   ##  where ::cudaChannelFormatKind is one of ::cudaChannelFormatKindSigned,
   ##  ::cudaChannelFormatKindUnsigned, or ::cudaChannelFormatKindFloat.
-  ## 
+  ##
   ##  The \p flags parameter enables different options to be specified that affect
   ##  the allocation, as follows.
   ##  - ::cudaArrayDefault: This flag's value is defined to be 0 and provides default array allocation
   ##  - ::cudaArraySurfaceLoadStore: Allocates an array that can be read from or written to using a surface reference
   ##  - ::cudaArrayTextureGather: This flag indicates that texture gather operations will be performed on the array.
-  ## 
+  ##
   ##  \p width and \p height must meet certain size requirements. See ::cudaMalloc3DArray() for more details.
-  ## 
+  ##
   ##  \param array  - Pointer to allocated array in device memory
   ##  \param desc   - Requested channel format
   ##  \param width  - Requested array allocation width
   ##  \param height - Requested array allocation height
   ##  \param flags  - Requested properties of allocated array
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorMemoryAllocation
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMalloc, ::cudaMallocPitch, ::cudaFree, ::cudaFreeArray,
-  ##  \ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",`
   ##  ::cudaFreeHost, ::cudaMalloc3D, ::cudaMalloc3DArray,
   ##  ::cudaHostAlloc
-  ## 
+  ##
   proc cudaMallocArray*(array: ptr cudaArray_t; desc: ptr cudaChannelFormatDesc;
                        width: csize; height: csize; flags: cuint): cudaError_t {.cdecl,
       importc: "cudaMallocArray", dyn.}
   ## *
   ##  \brief Frees memory on the device
-  ## 
+  ##
   ##  Frees the memory space pointed to by \p devPtr, which must have been
   ##  returned by a previous call to ::cudaMalloc() or ::cudaMallocPitch().
   ##  Otherwise, or if ::cudaFree(\p devPtr) has already been called before,
   ##  an error is returned. If \p devPtr is 0, no operation is performed.
   ##  ::cudaFree() returns ::cudaErrorInvalidDevicePointer in case of failure.
-  ## 
-  ##  The device version of ::cudaFree cannot be used with a \p *devPtr
+  ##
+  ##  `The device version of ::cudaFree cannot be used with a \p *devPtr`
   ##  allocated using the host API, and vice versa.
-  ## 
+  ##
   ##  \param devPtr - Device pointer to memory to free
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidDevicePointer,
   ##  ::cudaErrorInitializationError
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMalloc, ::cudaMallocPitch, ::cudaMallocArray, ::cudaFreeArray,
-  ##  \ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",`
   ##  ::cudaFreeHost, ::cudaMalloc3D, ::cudaMalloc3DArray,
   ##  ::cudaHostAlloc
-  ## 
+  ##
   proc cudaFree*(devPtr: pointer): cudaError_t {.cdecl, importc: "cudaFree",
       dyn.}
   ## *
   ##  \brief Frees page-locked memory
-  ## 
+  ##
   ##  Frees the memory space pointed to by \p hostPtr, which must have been
   ##  returned by a previous call to ::cudaMallocHost() or ::cudaHostAlloc().
-  ## 
+  ##
   ##  \param ptr - Pointer to memory to free
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInitializationError
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMalloc, ::cudaMallocPitch, ::cudaFree, ::cudaMallocArray,
   ##  ::cudaFreeArray,
-  ##  \ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",`
   ##  ::cudaMalloc3D, ::cudaMalloc3DArray, ::cudaHostAlloc
-  ## 
+  ##
   proc cudaFreeHost*(`ptr`: pointer): cudaError_t {.cdecl, importc: "cudaFreeHost",
       dyn.}
   ## *
   ##  \brief Frees an array on the device
-  ## 
-  ##  Frees the CUDA array \p array, which must have been * returned by a
+  ##
+  ##  `Frees the CUDA array \p array, which must have been * returned by a`
   ##  previous call to ::cudaMallocArray(). If ::cudaFreeArray(\p array) has
   ##  already been called before, ::cudaErrorInvalidValue is returned. If
   ##  \p devPtr is 0, no operation is performed.
-  ## 
+  ##
   ##  \param array - Pointer to array to free
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInitializationError
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMalloc, ::cudaMallocPitch, ::cudaFree, ::cudaMallocArray,
-  ##  \ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",`
   ##  ::cudaFreeHost, ::cudaHostAlloc
-  ## 
+  ##
   proc cudaFreeArray*(array: cudaArray_t): cudaError_t {.cdecl,
       importc: "cudaFreeArray", dyn.}
   ## *
   ##  \brief Frees a mipmapped array on the device
-  ## 
+  ##
   ##  Frees the CUDA mipmapped array \p mipmappedArray, which must have been
   ##  returned by a previous call to ::cudaMallocMipmappedArray().
   ##  If ::cudaFreeMipmappedArray(\p mipmappedArray) has already been called before,
   ##  ::cudaErrorInvalidValue is returned.
-  ## 
+  ##
   ##  \param mipmappedArray - Pointer to mipmapped array to free
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInitializationError
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMalloc, ::cudaMallocPitch, ::cudaFree, ::cudaMallocArray,
-  ##  \ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",`
   ##  ::cudaFreeHost, ::cudaHostAlloc
-  ## 
+  ##
   proc cudaFreeMipmappedArray*(mipmappedArray: cudaMipmappedArray_t): cudaError_t {.
       cdecl, importc: "cudaFreeMipmappedArray", dyn.}
   ## *
   ##  \brief Allocates page-locked memory on the host
-  ## 
+  ##
   ##  Allocates \p size bytes of host memory that is page-locked and accessible
   ##  to the device. The driver tracks the virtual memory ranges allocated with
   ##  this function and automatically accelerates calls to functions such as
@@ -3185,7 +3185,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  of memory available to the system for paging. As a result, this function is
   ##  best used sparingly to allocate staging areas for data exchange between host
   ##  and device.
-  ## 
+  ##
   ##  The \p flags parameter enables different options to be specified that affect
   ##  the allocation, as follows.
   ##  - ::cudaHostAllocDefault: This flag's value is defined to be 0 and causes
@@ -3201,38 +3201,38 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  system configurations, but cannot be read efficiently by most CPUs.  WC
   ##  memory is a good option for buffers that will be written by the CPU and read
   ##  by the device via mapped pinned memory or host->device transfers.
-  ## 
+  ##
   ##  All of these flags are orthogonal to one another: a developer may allocate
   ##  memory that is portable, mapped and/or write-combined with no restrictions.
-  ## 
+  ##
   ##  ::cudaSetDeviceFlags() must have been called with the ::cudaDeviceMapHost
   ##  flag in order for the ::cudaHostAllocMapped flag to have any effect.
-  ## 
+  ##
   ##  The ::cudaHostAllocMapped flag may be specified on CUDA contexts for devices
   ##  that do not support mapped pinned memory. The failure is deferred to
   ##  ::cudaHostGetDevicePointer() because the memory may be mapped into other
   ##  CUDA contexts via the ::cudaHostAllocPortable flag.
-  ## 
+  ##
   ##  Memory allocated by this function must be freed with ::cudaFreeHost().
-  ## 
+  ##
   ##  \param pHost - Device pointer to allocated memory
   ##  \param size  - Requested allocation size in bytes
   ##  \param flags - Requested properties of allocated memory
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorMemoryAllocation
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaSetDeviceFlags,
-  ##  \ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",`
   ##  ::cudaFreeHost
-  ## 
+  ##
   proc cudaHostAlloc*(pHost: ptr pointer; size: csize; flags: cuint): cudaError_t {.
       cdecl, importc: "cudaHostAlloc", dyn.}
   ## *
   ##  \brief Registers an existing host memory range for use by CUDA
-  ## 
+  ##
   ##  Page-locks the memory range specified by \p ptr and \p size and maps it
   ##  for the device(s) as specified by \p flags. This memory range also is added
   ##  to the same tracking mechanism as ::cudaHostAlloc() to automatically accelerate
@@ -3243,38 +3243,38 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  of memory available to the system for paging. As a result, this function is
   ##  best used sparingly to register staging areas for data exchange between
   ##  host and device.
-  ## 
+  ##
   ##  The \p flags parameter enables different options to be specified that
   ##  affect the allocation, as follows.
-  ## 
+  ##
   ##  - ::cudaHostRegisterDefault: On a system with unified virtual addressing,
   ##    the memory will be both mapped and portable.  On a system with no unified
   ##    virtual addressing, the memory will be neither mapped nor portable.
-  ## 
+  ##
   ##  - ::cudaHostRegisterPortable: The memory returned by this call will be
   ##    considered as pinned memory by all CUDA contexts, not just the one that
   ##    performed the allocation.
-  ## 
+  ##
   ##  - ::cudaHostRegisterMapped: Maps the allocation into the CUDA address
   ##    space. The device pointer to the memory may be obtained by calling
   ##    ::cudaHostGetDevicePointer().
-  ## 
+  ##
   ##  - ::cudaHostRegisterIoMemory: The passed memory pointer is treated as
   ##    pointing to some memory-mapped I/O space, e.g. belonging to a
   ##    third-party PCIe device, and it will marked as non cache-coherent and
   ##    contiguous.
-  ## 
+  ##
   ##  All of these flags are orthogonal to one another: a developer may page-lock
   ##  memory that is portable or mapped with no restrictions.
-  ## 
+  ##
   ##  The CUDA context must have been created with the ::cudaMapHost flag in
   ##  order for the ::cudaHostRegisterMapped flag to have any effect.
-  ## 
+  ##
   ##  The ::cudaHostRegisterMapped flag may be specified on CUDA contexts for
   ##  devices that do not support mapped pinned memory. The failure is deferred
   ##  to ::cudaHostGetDevicePointer() because the memory may be mapped into
   ##  other CUDA contexts via the ::cudaHostRegisterPortable flag.
-  ## 
+  ##
   ##  For devices that have a non-zero value for the device attribute
   ##  ::cudaDevAttrCanUseHostPointerForRegisteredMem, the memory
   ##  can also be accessed from the device using the host pointer \p ptr.
@@ -3289,54 +3289,54 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  is enabled. In such systems, it is valid to access the memory using either pointer
   ##  on devices that have a non-zero value for the device attribute. Note however that
   ##  such devices should access the memory using only of the two pointers and not both.
-  ## 
+  ##
   ##  The memory page-locked by this function must be unregistered with ::cudaHostUnregister().
-  ## 
+  ##
   ##  \param ptr   - Host pointer to memory to page-lock
   ##  \param size  - Size in bytes of the address range to page-lock in bytes
   ##  \param flags - Flags for allocation request
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorMemoryAllocation,
   ##  ::cudaErrorHostMemoryAlreadyRegistered
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaHostUnregister, ::cudaHostGetFlags, ::cudaHostGetDevicePointer
-  ## 
+  ##
   proc cudaHostRegister*(`ptr`: pointer; size: csize; flags: cuint): cudaError_t {.
       cdecl, importc: "cudaHostRegister", dyn.}
   ## *
   ##  \brief Unregisters a memory range that was registered with cudaHostRegister
-  ## 
+  ##
   ##  Unmaps the memory range whose base address is specified by \p ptr, and makes
   ##  it pageable again.
-  ## 
+  ##
   ##  The base address must be the same one specified to ::cudaHostRegister().
-  ## 
+  ##
   ##  \param ptr - Host pointer to memory to unregister
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaHostUnregister
-  ## 
+  ##
   proc cudaHostUnregister*(`ptr`: pointer): cudaError_t {.cdecl,
       importc: "cudaHostUnregister", dyn.}
   ## *
   ##  \brief Passes back device pointer of mapped host memory allocated by
   ##  cudaHostAlloc or registered by cudaHostRegister
-  ## 
+  ##
   ##  Passes back the device pointer corresponding to the mapped, pinned host
   ##  buffer allocated by ::cudaHostAlloc() or registered by ::cudaHostRegister().
-  ## 
+  ##
   ##  ::cudaHostGetDevicePointer() will fail if the ::cudaDeviceMapHost flag was
   ##  not specified before deferred context creation occurred, or if called on a
   ##  device that does not support mapped, pinned memory.
-  ## 
+  ##
   ##  For devices that have a non-zero value for the device attribute
   ##  ::cudaDevAttrCanUseHostPointerForRegisteredMem, the memory
   ##  can also be accessed from the device using the host pointer \p pHost.
@@ -3351,83 +3351,83 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  is enabled. In such systems, it is valid to access the memory using either pointer
   ##  on devices that have a non-zero value for the device attribute. Note however that
   ##  such devices should access the memory using only of the two pointers and not both.
-  ## 
+  ##
   ##  \p flags provides for future releases.  For now, it must be set to 0.
-  ## 
+  ##
   ##  \param pDevice - Returned device pointer for mapped memory
   ##  \param pHost   - Requested host pointer mapping
   ##  \param flags   - Flags for extensions (must be 0 for now)
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorMemoryAllocation
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaSetDeviceFlags, ::cudaHostAlloc
-  ## 
+  ##
   proc cudaHostGetDevicePointer*(pDevice: ptr pointer; pHost: pointer; flags: cuint): cudaError_t {.
       cdecl, importc: "cudaHostGetDevicePointer", dyn.}
   ## *
   ##  \brief Passes back flags used to allocate pinned host memory allocated by
   ##  cudaHostAlloc
-  ## 
+  ##
   ##  ::cudaHostGetFlags() will fail if the input pointer does not
   ##  reside in an address range allocated by ::cudaHostAlloc().
-  ## 
+  ##
   ##  \param pFlags - Returned flags word
   ##  \param pHost - Host pointer
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaHostAlloc
-  ## 
+  ##
   proc cudaHostGetFlags*(pFlags: ptr cuint; pHost: pointer): cudaError_t {.cdecl,
       importc: "cudaHostGetFlags", dyn.}
   ## *
   ##  \brief Allocates logical 1D, 2D, or 3D memory objects on the device
-  ## 
-  ##  Allocates at least \p width * \p height * \p depth bytes of linear memory
+  ##
+  ##  `Allocates at least \p width * \p height * \p depth bytes of linear memory`
   ##  on the device and returns a ::cudaPitchedPtr in which \p ptr is a pointer
   ##  to the allocated memory. The function may pad the allocation to ensure
   ##  hardware alignment requirements are met. The pitch returned in the \p pitch
   ##  field of \p pitchedDevPtr is the width in bytes of the allocation.
-  ## 
+  ##
   ##  The returned ::cudaPitchedPtr contains additional fields \p xsize and
   ##  \p ysize, the logical width and height of the allocation, which are
   ##  equivalent to the \p width and \p height \p extent parameters provided by
   ##  the programmer during allocation.
-  ## 
+  ##
   ##  For allocations of 2D and 3D objects, it is highly recommended that
   ##  programmers perform allocations using ::cudaMalloc3D() or
   ##  ::cudaMallocPitch(). Due to alignment restrictions in the hardware, this is
   ##  especially true if the application will be performing memory copies
   ##  involving 2D or 3D objects (whether linear memory or CUDA arrays).
-  ## 
+  ##
   ##  \param pitchedDevPtr  - Pointer to allocated pitched device memory
   ##  \param extent         - Requested allocation size (\p width field in bytes)
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorMemoryAllocation
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMallocPitch, ::cudaFree, ::cudaMemcpy3D, ::cudaMemset3D,
   ##  ::cudaMalloc3DArray, ::cudaMallocArray, ::cudaFreeArray,
-  ##  \ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",`
   ##  ::cudaFreeHost, ::cudaHostAlloc, ::make_cudaPitchedPtr, ::make_cudaExtent
-  ## 
+  ##
   proc cudaMalloc3D*(pitchedDevPtr: ptr cudaPitchedPtr; extent: cudaExtent): cudaError_t {.
       cdecl, importc: "cudaMalloc3D", dyn.}
   ## *
   ##  \brief Allocate an array on the device
-  ## 
+  ##
   ##  Allocates a CUDA array according to the ::cudaChannelFormatDesc structure
-  ##  \p desc and returns a handle to the new CUDA array in \p *array.
-  ## 
+  ##  `\p desc and returns a handle to the new CUDA array in \p *array.`
+  ##
   ##  The ::cudaChannelFormatDesc is defined as:
   ##  \code
   ##     struct cudaChannelFormatDesc {
@@ -3437,9 +3437,9 @@ when not defined(CUDA_RUNTIME_API_H):
   ##     \endcode
   ##  where ::cudaChannelFormatKind is one of ::cudaChannelFormatKindSigned,
   ##  ::cudaChannelFormatKindUnsigned, or ::cudaChannelFormatKindFloat.
-  ## 
+  ##
   ##  ::cudaMalloc3DArray() can allocate the following:
-  ## 
+  ##
   ##  - A 1D array is allocated if the height and depth extents are both zero.
   ##  - A 2D array is allocated if only the depth extent is zero.
   ##  - A 3D array is allocated if all three extents are non-zero.
@@ -3458,8 +3458,8 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  a multiple of six. A cubemap layered CUDA array is a special type of 2D layered CUDA array that consists
   ##  of a collection of cubemaps. The first six layers represent the first cubemap, the next six layers form
   ##  the second cubemap, and so on.
-  ## 
-  ## 
+  ##
+  ##
   ##  The \p flags parameter enables different options to be specified that affect
   ##  the allocation, as follows.
   ##  - ::cudaArrayDefault: This flag's value is defined to be 0 and provides default array allocation
@@ -3470,19 +3470,19 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    reference.
   ##  - ::cudaArrayTextureGather: This flag indicates that texture gather operations will be performed on the CUDA
   ##    array. Texture gather can only be performed on 2D CUDA arrays.
-  ## 
+  ##
   ##  The width, height and depth extents must meet certain size requirements as listed in the following table.
   ##  All values are specified in elements.
-  ## 
+  ##
   ##  Note that 2D CUDA arrays have different size requirements if the ::cudaArrayTextureGather flag is set. In that
   ##  case, the valid range for (width, height, depth) is ((1,maxTexture2DGather[0]), (1,maxTexture2DGather[1]), 0).
-  ## 
+  ##
   ##  \xmlonly
   ##  <table outputclass="xmlonly">
   ##  <tgroup cols="3" colsep="1" rowsep="1">
-  ##  <colspec colname="c1" colwidth="1.0*"/>
-  ##  <colspec colname="c2" colwidth="3.0*"/>
-  ##  <colspec colname="c3" colwidth="3.0*"/>
+  ##  `<colspec colname="c1" colwidth="1.0*"/>`
+  ##  `<colspec colname="c2" colwidth="3.0*"/>`
+  ##  `<colspec colname="c3" colwidth="3.0*"/>`
   ##  <thead>
   ##  <row>
   ##  <entry>CUDA array type</entry>
@@ -3538,34 +3538,34 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  </tgroup>
   ##  </table>
   ##  \endxmlonly
-  ## 
+  ##
   ##  \param array  - Pointer to allocated array in device memory
   ##  \param desc   - Requested channel format
   ##  \param extent - Requested allocation size (\p width field in elements)
   ##  \param flags  - Flags for extensions
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorMemoryAllocation
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMalloc3D, ::cudaMalloc, ::cudaMallocPitch, ::cudaFree,
   ##  ::cudaFreeArray,
-  ##  \ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",`
   ##  ::cudaFreeHost, ::cudaHostAlloc,
   ##  ::make_cudaExtent
-  ## 
+  ##
   proc cudaMalloc3DArray*(array: ptr cudaArray_t; desc: ptr cudaChannelFormatDesc;
                          extent: cudaExtent; flags: cuint): cudaError_t {.cdecl,
       importc: "cudaMalloc3DArray", dyn.}
   ## *
   ##  \brief Allocate a mipmapped array on the device
-  ## 
+  ##
   ##  Allocates a CUDA mipmapped array according to the ::cudaChannelFormatDesc structure
-  ##  \p desc and returns a handle to the new CUDA mipmapped array in \p *mipmappedArray.
+  ##  `\p desc and returns a handle to the new CUDA mipmapped array in \p *mipmappedArray.`
   ##  \p numLevels specifies the number of mipmap levels to be allocated. This value is
   ##  clamped to the range [1, 1 + floor(log2(max(width, height, depth)))].
-  ## 
+  ##
   ##  The ::cudaChannelFormatDesc is defined as:
   ##  \code
   ##     struct cudaChannelFormatDesc {
@@ -3575,9 +3575,9 @@ when not defined(CUDA_RUNTIME_API_H):
   ##     \endcode
   ##  where ::cudaChannelFormatKind is one of ::cudaChannelFormatKindSigned,
   ##  ::cudaChannelFormatKindUnsigned, or ::cudaChannelFormatKindFloat.
-  ## 
+  ##
   ##  ::cudaMallocMipmappedArray() can allocate the following:
-  ## 
+  ##
   ##  - A 1D mipmapped array is allocated if the height and depth extents are both zero.
   ##  - A 2D mipmapped array is allocated if only the depth extent is zero.
   ##  - A 3D mipmapped array is allocated if all three extents are non-zero.
@@ -3595,8 +3595,8 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  a multiple of six. A cubemap layered CUDA mipmapped array is a special type of 2D layered CUDA mipmapped
   ##  array that consists of a collection of cubemap mipmapped arrays. The first six layers represent the
   ##  first cubemap mipmapped array, the next six layers form the second cubemap mipmapped array, and so on.
-  ## 
-  ## 
+  ##
+  ##
   ##  The \p flags parameter enables different options to be specified that affect
   ##  the allocation, as follows.
   ##  - ::cudaArrayDefault: This flag's value is defined to be 0 and provides default mipmapped array allocation
@@ -3608,15 +3608,15 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  - ::cudaArrayTextureGather: This flag indicates that texture gather operations will be performed on the CUDA
   ##    array. Texture gather can only be performed on 2D CUDA mipmapped arrays, and the gather operations are
   ##    performed only on the most detailed mipmap level.
-  ## 
+  ##
   ##  The width, height and depth extents must meet certain size requirements as listed in the following table.
   ##  All values are specified in elements.
-  ## 
+  ##
   ##  \xmlonly
   ##  <table outputclass="xmlonly">
   ##  <tgroup cols="2" colsep="1" rowsep="1">
-  ##  <colspec colname="c1" colwidth="1.0*"/>
-  ##  <colspec colname="c2" colwidth="3.0*"/>
+  ##  `<colspec colname="c1" colwidth="1.0*"/>`
+  ##  `<colspec colname="c2" colwidth="3.0*"/>`
   ##  <thead>
   ##  <row>
   ##  <entry>CUDA array type</entry>
@@ -3659,59 +3659,59 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  </tgroup>
   ##  </table>
   ##  \endxmlonly
-  ## 
+  ##
   ##  \param mipmappedArray  - Pointer to allocated mipmapped array in device memory
   ##  \param desc            - Requested channel format
   ##  \param extent          - Requested allocation size (\p width field in elements)
   ##  \param numLevels       - Number of mipmap levels to allocate
   ##  \param flags           - Flags for extensions
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorMemoryAllocation
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMalloc3D, ::cudaMalloc, ::cudaMallocPitch, ::cudaFree,
   ##  ::cudaFreeArray,
-  ##  \ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",`
   ##  ::cudaFreeHost, ::cudaHostAlloc,
   ##  ::make_cudaExtent
-  ## 
+  ##
   proc cudaMallocMipmappedArray*(mipmappedArray: ptr cudaMipmappedArray_t;
                                 desc: ptr cudaChannelFormatDesc;
                                 extent: cudaExtent; numLevels: cuint; flags: cuint): cudaError_t {.
       cdecl, importc: "cudaMallocMipmappedArray", dyn.}
   ## *
   ##  \brief Gets a mipmap level of a CUDA mipmapped array
-  ## 
-  ##  Returns in \p *levelArray a CUDA array that represents a single mipmap level
+  ##
+  ##  `Returns in \p *levelArray a CUDA array that represents a single mipmap level`
   ##  of the CUDA mipmapped array \p mipmappedArray.
-  ## 
+  ##
   ##  If \p level is greater than the maximum number of levels in this mipmapped array,
   ##  ::cudaErrorInvalidValue is returned.
-  ## 
+  ##
   ##  \param levelArray     - Returned mipmap level CUDA array
   ##  \param mipmappedArray - CUDA mipmapped array
   ##  \param level          - Mipmap level
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMalloc3D, ::cudaMalloc, ::cudaMallocPitch, ::cudaFree,
   ##  ::cudaFreeArray,
-  ##  \ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",
+  ##  `\ref ::cudaMallocHost(void**, size_t) "cudaMallocHost (C API)",`
   ##  ::cudaFreeHost, ::cudaHostAlloc,
   ##  ::make_cudaExtent
-  ## 
+  ##
   proc cudaGetMipmappedArrayLevel*(levelArray: ptr cudaArray_t;
                                   mipmappedArray: cudaMipmappedArray_const_t;
                                   level: cuint): cudaError_t {.cdecl,
       importc: "cudaGetMipmappedArrayLevel", dyn.}
   ## *
   ##  \brief Copies data between 3D objects
-  ## 
+  ##
   ## \code
   ## struct cudaExtent {
   ##   size_t width;
@@ -3719,14 +3719,14 @@ when not defined(CUDA_RUNTIME_API_H):
   ##   size_t depth;
   ## };
   ## struct cudaExtent make_cudaExtent(size_t w, size_t h, size_t d);
-  ## 
+  ##
   ## struct cudaPos {
   ##   size_t x;
   ##   size_t y;
   ##   size_t z;
   ## };
   ## struct cudaPos make_cudaPos(size_t x, size_t y, size_t z);
-  ## 
+  ##
   ## struct cudaMemcpy3DParms {
   ##   cudaArray_t           srcArray;
   ##   struct cudaPos        srcPos;
@@ -3738,7 +3738,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##   enum cudaMemcpyKind   kind;
   ## };
   ## \endcode
-  ## 
+  ##
   ##  ::cudaMemcpy3D() copies data betwen two 3D objects. The source and
   ##  destination objects may be in either host memory, device memory, or a CUDA
   ##  array. The source, destination, extent, and kind of copy performed is
@@ -3747,47 +3747,47 @@ when not defined(CUDA_RUNTIME_API_H):
   ## \code
   ## cudaMemcpy3DParms myParms = {0};
   ## \endcode
-  ## 
+  ##
   ##  The struct passed to ::cudaMemcpy3D() must specify one of \p srcArray or
   ##  \p srcPtr and one of \p dstArray or \p dstPtr. Passing more than one
   ##  non-zero source or destination will cause ::cudaMemcpy3D() to return an
   ##  error.
-  ## 
+  ##
   ##  The \p srcPos and \p dstPos fields are optional offsets into the source and
   ##  destination objects and are defined in units of each object's elements. The
   ##  element for a host or device pointer is assumed to be <b>unsigned char</b>.
   ##  For CUDA arrays, positions must be in the range [0, 2048) for any
   ##  dimension.
-  ## 
+  ##
   ##  The \p extent field defines the dimensions of the transferred area in
   ##  elements. If a CUDA array is participating in the copy, the extent is
   ##  defined in terms of that array's elements. If no CUDA array is
   ##  participating in the copy then the extents are defined in elements of
   ##  <b>unsigned char</b>.
-  ## 
+  ##
   ##  The \p kind field defines the direction of the copy. It must be one of
   ##  ::cudaMemcpyHostToHost, ::cudaMemcpyHostToDevice, ::cudaMemcpyDeviceToHost,
   ##  ::cudaMemcpyDeviceToDevice, or ::cudaMemcpyDefault. Passing
   ##  ::cudaMemcpyDefault is recommended, in which case the type of transfer is
   ##  inferred from the pointer values. However, ::cudaMemcpyDefault is only
   ##  allowed on systems that support unified virtual addressing.
-  ## 
+  ##
   ##  If the source and destination are both arrays, ::cudaMemcpy3D() will return
   ##  an error if they do not have the same element size.
-  ## 
+  ##
   ##  The source and destination object may not overlap. If overlapping source
   ##  and destination objects are specified, undefined behavior will result.
-  ## 
+  ##
   ##  The source object must lie entirely within the region defined by \p srcPos
   ##  and \p extent. The destination object must lie entirely within the region
   ##  defined by \p dstPos and \p extent.
-  ## 
+  ##
   ##  ::cudaMemcpy3D() returns an error if the pitch of \p srcPtr or \p dstPtr
   ##  exceeds the maximum allowed. The pitch of a ::cudaPitchedPtr allocated
   ##  with ::cudaMalloc3D() will always be valid.
-  ## 
+  ##
   ##  \param p - 3D memory copy parameters
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -3796,7 +3796,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorInvalidMemcpyDirection
   ##  \notefnerr
   ##  \note_sync
-  ## 
+  ##
   ##  \sa ::cudaMalloc3D, ::cudaMalloc3DArray, ::cudaMemset3D, ::cudaMemcpy3DAsync,
   ##  ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
@@ -3806,40 +3806,40 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync,
   ##  ::make_cudaExtent, ::make_cudaPos
-  ## 
+  ##
   proc cudaMemcpy3D*(p: ptr cudaMemcpy3DParms): cudaError_t {.cdecl,
       importc: "cudaMemcpy3D", dyn.}
   ## *
   ##  \brief Copies memory between devices
-  ## 
+  ##
   ##  Perform a 3D memory copy according to the parameters specified in
   ##  \p p.  See the definition of the ::cudaMemcpy3DPeerParms structure
   ##  for documentation of its parameters.
-  ## 
+  ##
   ##  Note that this function is synchronous with respect to the host only if
   ##  the source or destination of the transfer is host memory.  Note also
   ##  that this copy is serialized with respect to all pending and future
   ##  asynchronous work in to the current device, the copy's source device,
   ##  and the copy's destination device (use ::cudaMemcpy3DPeerAsync to avoid
   ##  this synchronization).
-  ## 
+  ##
   ##  \param p - Parameters for the memory copy
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidDevice
   ##  \notefnerr
   ##  \note_sync
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpyPeer, ::cudaMemcpyAsync, ::cudaMemcpyPeerAsync,
   ##  ::cudaMemcpy3DPeerAsync
-  ## 
+  ##
   proc cudaMemcpy3DPeer*(p: ptr cudaMemcpy3DPeerParms): cudaError_t {.cdecl,
       importc: "cudaMemcpy3DPeer", dyn.}
   ## *
   ##  \brief Copies data between 3D objects
-  ## 
+  ##
   ## \code
   ## struct cudaExtent {
   ##   size_t width;
@@ -3847,14 +3847,14 @@ when not defined(CUDA_RUNTIME_API_H):
   ##   size_t depth;
   ## };
   ## struct cudaExtent make_cudaExtent(size_t w, size_t h, size_t d);
-  ## 
+  ##
   ## struct cudaPos {
   ##   size_t x;
   ##   size_t y;
   ##   size_t z;
   ## };
   ## struct cudaPos make_cudaPos(size_t x, size_t y, size_t z);
-  ## 
+  ##
   ## struct cudaMemcpy3DParms {
   ##   cudaArray_t           srcArray;
   ##   struct cudaPos        srcPos;
@@ -3866,7 +3866,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##   enum cudaMemcpyKind   kind;
   ## };
   ## \endcode
-  ## 
+  ##
   ##  ::cudaMemcpy3DAsync() copies data betwen two 3D objects. The source and
   ##  destination objects may be in either host memory, device memory, or a CUDA
   ##  array. The source, destination, extent, and kind of copy performed is
@@ -3875,57 +3875,57 @@ when not defined(CUDA_RUNTIME_API_H):
   ## \code
   ## cudaMemcpy3DParms myParms = {0};
   ## \endcode
-  ## 
+  ##
   ##  The struct passed to ::cudaMemcpy3DAsync() must specify one of \p srcArray
   ##  or \p srcPtr and one of \p dstArray or \p dstPtr. Passing more than one
   ##  non-zero source or destination will cause ::cudaMemcpy3DAsync() to return an
   ##  error.
-  ## 
+  ##
   ##  The \p srcPos and \p dstPos fields are optional offsets into the source and
   ##  destination objects and are defined in units of each object's elements. The
   ##  element for a host or device pointer is assumed to be <b>unsigned char</b>.
   ##  For CUDA arrays, positions must be in the range [0, 2048) for any
   ##  dimension.
-  ## 
+  ##
   ##  The \p extent field defines the dimensions of the transferred area in
   ##  elements. If a CUDA array is participating in the copy, the extent is
   ##  defined in terms of that array's elements. If no CUDA array is
   ##  participating in the copy then the extents are defined in elements of
   ##  <b>unsigned char</b>.
-  ## 
+  ##
   ##  The \p kind field defines the direction of the copy. It must be one of
   ##  ::cudaMemcpyHostToHost, ::cudaMemcpyHostToDevice, ::cudaMemcpyDeviceToHost,
   ##  ::cudaMemcpyDeviceToDevice, or ::cudaMemcpyDefault. Passing
   ##  ::cudaMemcpyDefault is recommended, in which case the type of transfer is
   ##  inferred from the pointer values. However, ::cudaMemcpyDefault is only
   ##  allowed on systems that support unified virtual addressing.
-  ## 
+  ##
   ##  If the source and destination are both arrays, ::cudaMemcpy3DAsync() will
   ##  return an error if they do not have the same element size.
-  ## 
+  ##
   ##  The source and destination object may not overlap. If overlapping source
   ##  and destination objects are specified, undefined behavior will result.
-  ## 
+  ##
   ##  The source object must lie entirely within the region defined by \p srcPos
   ##  and \p extent. The destination object must lie entirely within the region
   ##  defined by \p dstPos and \p extent.
-  ## 
+  ##
   ##  ::cudaMemcpy3DAsync() returns an error if the pitch of \p srcPtr or
   ##  \p dstPtr exceeds the maximum allowed. The pitch of a
   ##  ::cudaPitchedPtr allocated with ::cudaMalloc3D() will always be valid.
-  ## 
+  ##
   ##  ::cudaMemcpy3DAsync() is asynchronous with respect to the host, so
   ##  the call may return before the copy is complete. The copy can optionally
   ##  be associated to a stream by passing a non-zero \p stream argument. If
   ##  \p kind is ::cudaMemcpyHostToDevice or ::cudaMemcpyDeviceToHost and \p stream
   ##  is non-zero, the copy may overlap with operations in other streams.
-  ## 
+  ##
   ##  The device version of this function only handles device to device copies and
   ##  cannot be given local or shared pointers.
-  ## 
+  ##
   ##  \param p      - 3D memory copy parameters
   ##  \param stream - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -3935,7 +3935,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_async
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMalloc3D, ::cudaMalloc3DArray, ::cudaMemset3D, ::cudaMemcpy3D,
   ##  ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
@@ -3945,19 +3945,19 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync,
   ##  ::make_cudaExtent, ::make_cudaPos
-  ## 
+  ##
   proc cudaMemcpy3DAsync*(p: ptr cudaMemcpy3DParms; stream: cudaStream_t): cudaError_t {.
       cdecl, importc: "cudaMemcpy3DAsync", dyn.}
   ## *
   ##  \brief Copies memory between devices asynchronously.
-  ## 
+  ##
   ##  Perform a 3D memory copy according to the parameters specified in
   ##  \p p.  See the definition of the ::cudaMemcpy3DPeerParms structure
   ##  for documentation of its parameters.
-  ## 
+  ##
   ##  \param p      - Parameters for the memory copy
   ##  \param stream - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -3965,56 +3965,56 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_async
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpyPeer, ::cudaMemcpyAsync, ::cudaMemcpyPeerAsync,
   ##  ::cudaMemcpy3DPeerAsync
-  ## 
+  ##
   proc cudaMemcpy3DPeerAsync*(p: ptr cudaMemcpy3DPeerParms; stream: cudaStream_t): cudaError_t {.
       cdecl, importc: "cudaMemcpy3DPeerAsync", dyn.}
   ## *
   ##  \brief Gets free and total device memory
-  ## 
-  ##  Returns in \p *free and \p *total respectively, the free and total amount of
+  ##
+  ##  `Returns in \p *free and \p *total respectively, the free and total amount of`
   ##  memory available for allocation by the device in bytes.
-  ## 
+  ##
   ##  \param free  - Returned free memory in bytes
   ##  \param total - Returned total memory in bytes
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInitializationError,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorLaunchFailure
   ##  \notefnerr
-  ## 
-  ## 
+  ##
+  ##
   proc cudaMemGetInfo*(free: ptr csize; total: ptr csize): cudaError_t {.cdecl,
       importc: "cudaMemGetInfo", dyn.}
   ## *
   ##  \brief Gets info about the specified cudaArray
-  ## 
-  ##  Returns in \p *desc, \p *extent and \p *flags respectively, the type, shape
+  ##
+  ##  `Returns in \p *desc, \p *extent and \p *flags respectively, the type, shape`
   ##  and flags of \p array.
-  ## 
-  ##  Any of \p *desc, \p *extent and \p *flags may be specified as NULL.
-  ## 
+  ##
+  ##  `Any of \p *desc, \p *extent and \p *flags may be specified as NULL.`
+  ##
   ##  \param desc   - Returned array type
   ##  \param extent - Returned array shape. 2D arrays will have depth of zero
   ##  \param flags  - Returned array flags
   ##  \param array  - The ::cudaArray to get info for
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
-  ## 
+  ##
+  ##
   proc cudaArrayGetInfo*(desc: ptr cudaChannelFormatDesc; extent: ptr cudaExtent;
                         flags: ptr cuint; array: cudaArray_t): cudaError_t {.cdecl,
       importc: "cudaArrayGetInfo", dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies \p count bytes from the memory area pointed to by \p src to the
   ##  memory area pointed to by \p dst, where \p kind specifies the direction
   ##  of the copy, and must be one of ::cudaMemcpyHostToHost,
@@ -4025,21 +4025,21 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  allowed on systems that support unified virtual addressing. Calling
   ##  ::cudaMemcpy() with dst and src pointers that do not match the direction of
   ##  the copy results in an undefined behavior.
-  ## 
+  ##
   ##  \param dst   - Destination memory address
   ##  \param src   - Source memory address
   ##  \param count - Size in bytes to copy
   ##  \param kind  - Type of transfer
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidDevicePointer,
   ##  ::cudaErrorInvalidMemcpyDirection
   ##  \notefnerr
-  ## 
+  ##
   ##  \note_sync
-  ## 
+  ##
   ##  \sa ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4047,45 +4047,45 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpy*(dst: pointer; src: pointer; count: csize; kind: cudaMemcpyKind): cudaError_t {.
       cdecl, importc: "cudaMemcpy", dyn.}
   ## *
   ##  \brief Copies memory between two devices
-  ## 
+  ##
   ##  Copies memory from one device to memory on another device.  \p dst is the
   ##  base device pointer of the destination memory and \p dstDevice is the
   ##  destination device.  \p src is the base device pointer of the source memory
   ##  and \p srcDevice is the source device.  \p count specifies the number of bytes
   ##  to copy.
-  ## 
+  ##
   ##  Note that this function is asynchronous with respect to the host, but
   ##  serialized with respect all pending and future asynchronous work in to the
   ##  current device, \p srcDevice, and \p dstDevice (use ::cudaMemcpyPeerAsync
   ##  to avoid this synchronization).
-  ## 
+  ##
   ##  \param dst       - Destination device pointer
   ##  \param dstDevice - Destination device
   ##  \param src       - Source device pointer
   ##  \param srcDevice - Source device
   ##  \param count     - Size of memory copy in bytes
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidDevice
   ##  \notefnerr
   ##  \note_sync
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpyAsync, ::cudaMemcpyPeerAsync,
   ##  ::cudaMemcpy3DPeerAsync
-  ## 
+  ##
   proc cudaMemcpyPeer*(dst: pointer; dstDevice: cint; src: pointer; srcDevice: cint;
                       count: csize): cudaError_t {.cdecl, importc: "cudaMemcpyPeer",
       dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies \p count bytes from the memory area pointed to by \p src to the
   ##  CUDA array \p dst starting at the upper left corner
   ##  (\p wOffset, \p hOffset), where \p kind specifies the direction
@@ -4095,14 +4095,14 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyDefault is recommended, in which case the type of transfer is
   ##  inferred from the pointer values. However, ::cudaMemcpyDefault is only
   ##  allowed on systems that support unified virtual addressing.
-  ## 
+  ##
   ##  \param dst     - Destination memory address
   ##  \param wOffset - Destination starting X offset
   ##  \param hOffset - Destination starting Y offset
   ##  \param src     - Source memory address
   ##  \param count   - Size in bytes to copy
   ##  \param kind    - Type of transfer
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4110,7 +4110,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorInvalidMemcpyDirection
   ##  \notefnerr
   ##  \note_sync
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4118,13 +4118,13 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpyToArray*(dst: cudaArray_t; wOffset: csize; hOffset: csize;
                          src: pointer; count: csize; kind: cudaMemcpyKind): cudaError_t {.
       cdecl, importc: "cudaMemcpyToArray", dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies \p count bytes from the CUDA array \p src starting at the upper
   ##  left corner (\p wOffset, hOffset) to the memory area pointed to by \p dst,
   ##  where \p kind specifies the direction of the copy, and must be one of
@@ -4133,14 +4133,14 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyDefault is recommended, in which case the type of transfer is
   ##  inferred from the pointer values. However, ::cudaMemcpyDefault is only
   ##  allowed on systems that support unified virtual addressing.
-  ## 
+  ##
   ##  \param dst     - Destination memory address
   ##  \param src     - Source memory address
   ##  \param wOffset - Source starting X offset
   ##  \param hOffset - Source starting Y offset
   ##  \param count   - Size in bytes to copy
   ##  \param kind    - Type of transfer
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4148,7 +4148,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorInvalidMemcpyDirection
   ##  \notefnerr
   ##  \note_sync
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4156,13 +4156,13 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpyFromArray*(dst: pointer; src: cudaArray_const_t; wOffset: csize;
                            hOffset: csize; count: csize; kind: cudaMemcpyKind): cudaError_t {.
       cdecl, importc: "cudaMemcpyFromArray", dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies \p count bytes from the CUDA array \p src starting at the upper
   ##  left corner (\p wOffsetSrc, \p hOffsetSrc) to the CUDA array \p dst
   ##  starting at the upper left corner (\p wOffsetDst, \p hOffsetDst) where
@@ -4172,7 +4172,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyDefault is recommended, in which case the type of transfer is
   ##  inferred from the pointer values. However, ::cudaMemcpyDefault is only
   ##  allowed on systems that support unified virtual addressing.
-  ## 
+  ##
   ##  \param dst        - Destination memory address
   ##  \param wOffsetDst - Destination starting X offset
   ##  \param hOffsetDst - Destination starting Y offset
@@ -4181,13 +4181,13 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \param hOffsetSrc - Source starting Y offset
   ##  \param count      - Size in bytes to copy
   ##  \param kind       - Type of transfer
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidMemcpyDirection
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4195,7 +4195,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpyArrayToArray*(dst: cudaArray_t; wOffsetDst: csize;
                               hOffsetDst: csize; src: cudaArray_const_t;
                               wOffsetSrc: csize; hOffsetSrc: csize; count: csize;
@@ -4203,7 +4203,7 @@ when not defined(CUDA_RUNTIME_API_H):
       importc: "cudaMemcpyArrayToArray", dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies a matrix (\p height rows of \p width bytes each) from the memory
   ##  area pointed to by \p src to the memory area pointed to by \p dst, where
   ##  \p kind specifies the direction of the copy, and must be one of
@@ -4219,7 +4219,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  not match the direction of the copy results in an undefined behavior.
   ##  ::cudaMemcpy2D() returns an error if \p dpitch or \p spitch exceeds
   ##  the maximum allowed.
-  ## 
+  ##
   ##  \param dst    - Destination memory address
   ##  \param dpitch - Pitch of destination memory
   ##  \param src    - Source memory address
@@ -4227,7 +4227,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \param width  - Width of matrix transfer (columns in bytes)
   ##  \param height - Height of matrix transfer (rows)
   ##  \param kind   - Type of transfer
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4235,7 +4235,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorInvalidDevicePointer,
   ##  ::cudaErrorInvalidMemcpyDirection
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4243,13 +4243,13 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpy2D*(dst: pointer; dpitch: csize; src: pointer; spitch: csize;
                     width: csize; height: csize; kind: cudaMemcpyKind): cudaError_t {.
       cdecl, importc: "cudaMemcpy2D", dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies a matrix (\p height rows of \p width bytes each) from the memory
   ##  area pointed to by \p src to the CUDA array \p dst starting at the
   ##  upper left corner (\p wOffset, \p hOffset) where \p kind specifies the
@@ -4264,7 +4264,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \p width must not exceed the width of the CUDA array \p dst. \p width must
   ##  not exceed \p spitch. ::cudaMemcpy2DToArray() returns an error if \p spitch
   ##  exceeds the maximum allowed.
-  ## 
+  ##
   ##  \param dst     - Destination memory address
   ##  \param wOffset - Destination starting X offset
   ##  \param hOffset - Destination starting Y offset
@@ -4273,7 +4273,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \param width   - Width of matrix transfer (columns in bytes)
   ##  \param height  - Height of matrix transfer (rows)
   ##  \param kind    - Type of transfer
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4282,7 +4282,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorInvalidMemcpyDirection
   ##  \notefnerr
   ##  \note_sync
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4290,14 +4290,14 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpy2DToArray*(dst: cudaArray_t; wOffset: csize; hOffset: csize;
                            src: pointer; spitch: csize; width: csize; height: csize;
                            kind: cudaMemcpyKind): cudaError_t {.cdecl,
       importc: "cudaMemcpy2DToArray", dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies a matrix (\p height rows of \p width bytes each) from the CUDA
   ##  array \p srcArray starting at the upper left corner
   ##  (\p wOffset, \p hOffset) to the memory area pointed to by \p dst, where
@@ -4312,7 +4312,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  the width of the CUDA array \p src. \p width must not exceed \p dpitch.
   ##  ::cudaMemcpy2DFromArray() returns an error if \p dpitch exceeds the maximum
   ##  allowed.
-  ## 
+  ##
   ##  \param dst     - Destination memory address
   ##  \param dpitch  - Pitch of destination memory
   ##  \param src     - Source memory address
@@ -4321,7 +4321,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \param width   - Width of matrix transfer (columns in bytes)
   ##  \param height  - Height of matrix transfer (rows)
   ##  \param kind    - Type of transfer
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4330,7 +4330,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaErrorInvalidMemcpyDirection
   ##  \notefnerr
   ##  \note_sync
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4338,14 +4338,14 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpy2DFromArray*(dst: pointer; dpitch: csize; src: cudaArray_const_t;
                              wOffset: csize; hOffset: csize; width: csize;
                              height: csize; kind: cudaMemcpyKind): cudaError_t {.
       cdecl, importc: "cudaMemcpy2DFromArray", dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies a matrix (\p height rows of \p width bytes each) from the CUDA
   ##  array \p srcArray starting at the upper left corner
   ##  (\p wOffsetSrc, \p hOffsetSrc) to the CUDA array \p dst starting at
@@ -4358,7 +4358,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  allowed on systems that support unified virtual addressing.
   ##  \p wOffsetDst + \p width must not exceed the width of the CUDA array \p dst.
   ##  \p wOffsetSrc + \p width must not exceed the width of the CUDA array \p src.
-  ## 
+  ##
   ##  \param dst        - Destination memory address
   ##  \param wOffsetDst - Destination starting X offset
   ##  \param hOffsetDst - Destination starting Y offset
@@ -4368,14 +4368,14 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \param width      - Width of matrix transfer (columns in bytes)
   ##  \param height     - Height of matrix transfer (rows)
   ##  \param kind       - Type of transfer
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidMemcpyDirection
   ##  \notefnerr
   ##  \note_sync
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpyToSymbol,
@@ -4383,7 +4383,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpy2DArrayToArray*(dst: cudaArray_t; wOffsetDst: csize;
                                 hOffsetDst: csize; src: cudaArray_const_t;
                                 wOffsetSrc: csize; hOffsetSrc: csize; width: csize;
@@ -4391,7 +4391,7 @@ when not defined(CUDA_RUNTIME_API_H):
       cdecl, importc: "cudaMemcpy2DArrayToArray", dyn.}
   ## *
   ##  \brief Copies data to the given symbol on the device
-  ## 
+  ##
   ##  Copies \p count bytes from the memory area pointed to by \p src
   ##  to the memory area pointed to by \p offset bytes from the start of symbol
   ##  \p symbol. The memory areas may not overlap. \p symbol is a variable that
@@ -4400,13 +4400,13 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  Passing ::cudaMemcpyDefault is recommended, in which case the type of
   ##  transfer is inferred from the pointer values. However, ::cudaMemcpyDefault
   ##  is only allowed on systems that support unified virtual addressing.
-  ## 
+  ##
   ##  \param symbol - Device symbol address
   ##  \param src    - Source memory address
   ##  \param count  - Size in bytes to copy
   ##  \param offset - Offset from start of symbol in bytes
   ##  \param kind   - Type of transfer
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4416,7 +4416,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_sync
   ##  \note_string_api_deprecation
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray,
@@ -4424,13 +4424,13 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpyToSymbol*(symbol: pointer; src: pointer; count: csize; offset: csize;
                           kind: cudaMemcpyKind): cudaError_t {.cdecl,
       importc: "cudaMemcpyToSymbol", dyn.}
   ## *
   ##  \brief Copies data from the given symbol on the device
-  ## 
+  ##
   ##  Copies \p count bytes from the memory area pointed to by \p offset bytes
   ##  from the start of symbol \p symbol to the memory area pointed to by \p dst.
   ##  The memory areas may not overlap. \p symbol is a variable that
@@ -4439,13 +4439,13 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  Passing ::cudaMemcpyDefault is recommended, in which case the type of
   ##  transfer is inferred from the pointer values. However, ::cudaMemcpyDefault
   ##  is only allowed on systems that support unified virtual addressing.
-  ## 
+  ##
   ##  \param dst    - Destination memory address
   ##  \param symbol - Device symbol address
   ##  \param count  - Size in bytes to copy
   ##  \param offset - Offset from start of symbol in bytes
   ##  \param kind   - Type of transfer
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4455,7 +4455,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_sync
   ##  \note_string_api_deprecation
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4463,13 +4463,13 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpyFromSymbol*(dst: pointer; symbol: pointer; count: csize;
                             offset: csize; kind: cudaMemcpyKind): cudaError_t {.
       cdecl, importc: "cudaMemcpyFromSymbol", dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies \p count bytes from the memory area pointed to by \p src to the
   ##  memory area pointed to by \p dst, where \p kind specifies the
   ##  direction of the copy, and must be one of ::cudaMemcpyHostToHost,
@@ -4478,26 +4478,26 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyDefault is recommended, in which case the type of transfer is
   ##  inferred from the pointer values. However, ::cudaMemcpyDefault is only
   ##  allowed on systems that support unified virtual addressing.
-  ## 
+  ##
   ##  The memory areas may not overlap. Calling ::cudaMemcpyAsync() with \p dst and
   ##  \p src pointers that do not match the direction of the copy results in an
   ##  undefined behavior.
-  ## 
+  ##
   ##  ::cudaMemcpyAsync() is asynchronous with respect to the host, so the call
   ##  may return before the copy is complete. The copy can optionally be
   ##  associated to a stream by passing a non-zero \p stream argument. If \p kind
   ##  is ::cudaMemcpyHostToDevice or ::cudaMemcpyDeviceToHost and the \p stream is
   ##  non-zero, the copy may overlap with operations in other streams.
-  ## 
+  ##
   ##  The device version of this function only handles device to device copies and
   ##  cannot be given local or shared pointers.
-  ## 
+  ##
   ##  \param dst    - Destination memory address
   ##  \param src    - Source memory address
   ##  \param count  - Size in bytes to copy
   ##  \param kind   - Type of transfer
   ##  \param stream - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4506,7 +4506,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_async
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4514,29 +4514,29 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpyAsync*(dst: pointer; src: pointer; count: csize; kind: cudaMemcpyKind;
                        stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaMemcpyAsync", dyn.}
   ## *
   ##  \brief Copies memory between two devices asynchronously.
-  ## 
+  ##
   ##  Copies memory from one device to memory on another device.  \p dst is the
   ##  base device pointer of the destination memory and \p dstDevice is the
   ##  destination device.  \p src is the base device pointer of the source memory
   ##  and \p srcDevice is the source device.  \p count specifies the number of bytes
   ##  to copy.
-  ## 
+  ##
   ##  Note that this function is asynchronous with respect to the host and all work
   ##  on other devices.
-  ## 
+  ##
   ##  \param dst       - Destination device pointer
   ##  \param dstDevice - Destination device
   ##  \param src       - Source device pointer
   ##  \param srcDevice - Source device
   ##  \param count     - Size of memory copy in bytes
   ##  \param stream    - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4544,16 +4544,16 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_async
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpyPeer, ::cudaMemcpyAsync,
   ##  ::cudaMemcpy3DPeerAsync
-  ## 
+  ##
   proc cudaMemcpyPeerAsync*(dst: pointer; dstDevice: cint; src: pointer;
                            srcDevice: cint; count: csize; stream: cudaStream_t): cudaError_t {.
       cdecl, importc: "cudaMemcpyPeerAsync", dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies \p count bytes from the memory area pointed to by \p src to the
   ##  CUDA array \p dst starting at the upper left corner
   ##  (\p wOffset, \p hOffset), where \p kind specifies the
@@ -4563,13 +4563,13 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyDefault is recommended, in which case the type of transfer is
   ##  inferred from the pointer values. However, ::cudaMemcpyDefault is only
   ##  allowed on systems that support unified virtual addressing.
-  ## 
+  ##
   ##  ::cudaMemcpyToArrayAsync() is asynchronous with respect to the host, so
   ##  the call may return before the copy is complete. The copy can optionally
   ##  be associated to a stream by passing a non-zero \p stream argument. If \p
   ##  kind is ::cudaMemcpyHostToDevice or ::cudaMemcpyDeviceToHost and \p stream
   ##  is non-zero, the copy may overlap with operations in other streams.
-  ## 
+  ##
   ##  \param dst     - Destination memory address
   ##  \param wOffset - Destination starting X offset
   ##  \param hOffset - Destination starting Y offset
@@ -4577,7 +4577,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \param count   - Size in bytes to copy
   ##  \param kind    - Type of transfer
   ##  \param stream  - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4586,7 +4586,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_async
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4594,14 +4594,14 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpyToArrayAsync*(dst: cudaArray_t; wOffset: csize; hOffset: csize;
                               src: pointer; count: csize; kind: cudaMemcpyKind;
                               stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaMemcpyToArrayAsync", dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies \p count bytes from the CUDA array \p src starting at the upper
   ##  left corner (\p wOffset, hOffset) to the memory area pointed to by \p dst,
   ##  where \p kind specifies the direction of the copy, and must be one of
@@ -4610,13 +4610,13 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyDefault is recommended, in which case the type of transfer is
   ##  inferred from the pointer values. However, ::cudaMemcpyDefault is only
   ##  allowed on systems that support unified virtual addressing.
-  ## 
+  ##
   ##  ::cudaMemcpyFromArrayAsync() is asynchronous with respect to the host, so
   ##  the call may return before the copy is complete. The copy can optionally
   ##  be associated to a stream by passing a non-zero \p stream argument. If \p
   ##  kind is ::cudaMemcpyHostToDevice or ::cudaMemcpyDeviceToHost and \p stream
   ##  is non-zero, the copy may overlap with operations in other streams.
-  ## 
+  ##
   ##  \param dst     - Destination memory address
   ##  \param src     - Source memory address
   ##  \param wOffset - Source starting X offset
@@ -4624,7 +4624,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \param count   - Size in bytes to copy
   ##  \param kind    - Type of transfer
   ##  \param stream  - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4633,7 +4633,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_async
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4641,14 +4641,14 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpyFromArrayAsync*(dst: pointer; src: cudaArray_const_t;
                                 wOffset: csize; hOffset: csize; count: csize;
                                 kind: cudaMemcpyKind; stream: cudaStream_t): cudaError_t {.
       cdecl, importc: "cudaMemcpyFromArrayAsync", dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies a matrix (\p height rows of \p width bytes each) from the memory
   ##  area pointed to by \p src to the memory area pointed to by \p dst, where
   ##  \p kind specifies the direction of the copy, and must be one of
@@ -4661,22 +4661,22 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  pointed to by \p dst and \p src, including any padding added to the end of
   ##  each row. The memory areas may not overlap. \p width must not exceed either
   ##  \p dpitch or \p spitch.
-  ## 
+  ##
   ##  Calling ::cudaMemcpy2DAsync() with \p dst and \p src pointers that do not
   ##  match the direction of the copy results in an undefined behavior.
   ##  ::cudaMemcpy2DAsync() returns an error if \p dpitch or \p spitch is greater
   ##  than the maximum allowed.
-  ## 
+  ##
   ##  ::cudaMemcpy2DAsync() is asynchronous with respect to the host, so
   ##  the call may return before the copy is complete. The copy can optionally
   ##  be associated to a stream by passing a non-zero \p stream argument. If
   ##  \p kind is ::cudaMemcpyHostToDevice or ::cudaMemcpyDeviceToHost and
   ##  \p stream is non-zero, the copy may overlap with operations in other
   ##  streams.
-  ## 
+  ##
   ##  The device version of this function only handles device to device copies and
   ##  cannot be given local or shared pointers.
-  ## 
+  ##
   ##  \param dst    - Destination memory address
   ##  \param dpitch - Pitch of destination memory
   ##  \param src    - Source memory address
@@ -4685,7 +4685,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \param height - Height of matrix transfer (rows)
   ##  \param kind   - Type of transfer
   ##  \param stream - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4695,7 +4695,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_async
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4703,14 +4703,14 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpy2DAsync*(dst: pointer; dpitch: csize; src: pointer; spitch: csize;
                          width: csize; height: csize; kind: cudaMemcpyKind;
                          stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaMemcpy2DAsync", dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies a matrix (\p height rows of \p width bytes each) from the memory
   ##  area pointed to by \p src to the CUDA array \p dst starting at the
   ##  upper left corner (\p wOffset, \p hOffset) where \p kind specifies the
@@ -4725,14 +4725,14 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \p width must not exceed the width of the CUDA array \p dst. \p width must
   ##  not exceed \p spitch. ::cudaMemcpy2DToArrayAsync() returns an error if
   ##  \p spitch exceeds the maximum allowed.
-  ## 
+  ##
   ##  ::cudaMemcpy2DToArrayAsync() is asynchronous with respect to the host, so
   ##  the call may return before the copy is complete. The copy can optionally
   ##  be associated to a stream by passing a non-zero \p stream argument. If
   ##  \p kind is ::cudaMemcpyHostToDevice or ::cudaMemcpyDeviceToHost and
   ##  \p stream is non-zero, the copy may overlap with operations in other
   ##  streams.
-  ## 
+  ##
   ##  \param dst     - Destination memory address
   ##  \param wOffset - Destination starting X offset
   ##  \param hOffset - Destination starting Y offset
@@ -4742,7 +4742,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \param height  - Height of matrix transfer (rows)
   ##  \param kind    - Type of transfer
   ##  \param stream  - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4752,7 +4752,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_async
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4760,7 +4760,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpy2DToArrayAsync*(dst: cudaArray_t; wOffset: csize; hOffset: csize;
                                 src: pointer; spitch: csize; width: csize;
                                 height: csize; kind: cudaMemcpyKind;
@@ -4768,7 +4768,7 @@ when not defined(CUDA_RUNTIME_API_H):
       importc: "cudaMemcpy2DToArrayAsync", dyn.}
   ## *
   ##  \brief Copies data between host and device
-  ## 
+  ##
   ##  Copies a matrix (\p height rows of \p width bytes each) from the CUDA
   ##  array \p srcArray starting at the upper left corner
   ##  (\p wOffset, \p hOffset) to the memory area pointed to by \p dst, where
@@ -4783,13 +4783,13 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  row. \p wOffset + \p width must not exceed the width of the CUDA array
   ##  \p src. \p width must not exceed \p dpitch. ::cudaMemcpy2DFromArrayAsync()
   ##  returns an error if \p dpitch exceeds the maximum allowed.
-  ## 
+  ##
   ##  ::cudaMemcpy2DFromArrayAsync() is asynchronous with respect to the host, so
   ##  the call may return before the copy is complete. The copy can optionally be
   ##  associated to a stream by passing a non-zero \p stream argument. If \p kind
   ##  is ::cudaMemcpyHostToDevice or ::cudaMemcpyDeviceToHost and \p stream is
   ##  non-zero, the copy may overlap with operations in other streams.
-  ## 
+  ##
   ##  \param dst     - Destination memory address
   ##  \param dpitch  - Pitch of destination memory
   ##  \param src     - Source memory address
@@ -4799,7 +4799,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \param height  - Height of matrix transfer (rows)
   ##  \param kind    - Type of transfer
   ##  \param stream  - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4809,7 +4809,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_async
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4817,7 +4817,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync, ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpy2DFromArrayAsync*(dst: pointer; dpitch: csize;
                                   src: cudaArray_const_t; wOffset: csize;
                                   hOffset: csize; width: csize; height: csize;
@@ -4825,7 +4825,7 @@ when not defined(CUDA_RUNTIME_API_H):
       cdecl, importc: "cudaMemcpy2DFromArrayAsync", dyn.}
   ## *
   ##  \brief Copies data to the given symbol on the device
-  ## 
+  ##
   ##  Copies \p count bytes from the memory area pointed to by \p src
   ##  to the memory area pointed to by \p offset bytes from the start of symbol
   ##  \p symbol. The memory areas may not overlap. \p symbol is a variable that
@@ -4834,20 +4834,20 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  Passing ::cudaMemcpyDefault is recommended, in which case the type of transfer
   ##  is inferred from the pointer values. However, ::cudaMemcpyDefault is only
   ##  allowed on systems that support unified virtual addressing.
-  ## 
+  ##
   ##  ::cudaMemcpyToSymbolAsync() is asynchronous with respect to the host, so
   ##  the call may return before the copy is complete. The copy can optionally
   ##  be associated to a stream by passing a non-zero \p stream argument. If
   ##  \p kind is ::cudaMemcpyHostToDevice and \p stream is non-zero, the copy
   ##  may overlap with operations in other streams.
-  ## 
+  ##
   ##  \param symbol - Device symbol address
   ##  \param src    - Source memory address
   ##  \param count  - Size in bytes to copy
   ##  \param offset - Offset from start of symbol in bytes
   ##  \param kind   - Type of transfer
   ##  \param stream - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4858,7 +4858,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \note_async
   ##  \note_null_stream
   ##  \note_string_api_deprecation
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4866,14 +4866,14 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyFromSymbolAsync
-  ## 
+  ##
   proc cudaMemcpyToSymbolAsync*(symbol: pointer; src: pointer; count: csize;
                                offset: csize; kind: cudaMemcpyKind;
                                stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaMemcpyToSymbolAsync", dyn.}
   ## *
   ##  \brief Copies data from the given symbol on the device
-  ## 
+  ##
   ##  Copies \p count bytes from the memory area pointed to by \p offset bytes
   ##  from the start of symbol \p symbol to the memory area pointed to by \p dst.
   ##  The memory areas may not overlap. \p symbol is a variable that resides in
@@ -4882,20 +4882,20 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  Passing ::cudaMemcpyDefault is recommended, in which case the type of transfer
   ##  is inferred from the pointer values. However, ::cudaMemcpyDefault is only
   ##  allowed on systems that support unified virtual addressing.
-  ## 
+  ##
   ##  ::cudaMemcpyFromSymbolAsync() is asynchronous with respect to the host, so
   ##  the call may return before the copy is complete. The copy can optionally be
   ##  associated to a stream by passing a non-zero \p stream argument. If \p kind
   ##  is ::cudaMemcpyDeviceToHost and \p stream is non-zero, the copy may overlap
   ##  with operations in other streams.
-  ## 
+  ##
   ##  \param dst    - Destination memory address
   ##  \param symbol - Device symbol address
   ##  \param count  - Size in bytes to copy
   ##  \param offset - Offset from start of symbol in bytes
   ##  \param kind   - Type of transfer
   ##  \param stream - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -4906,7 +4906,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \note_async
   ##  \note_null_stream
   ##  \note_string_api_deprecation
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpy2D, ::cudaMemcpyToArray,
   ##  ::cudaMemcpy2DToArray, ::cudaMemcpyFromArray, ::cudaMemcpy2DFromArray,
   ##  ::cudaMemcpyArrayToArray, ::cudaMemcpy2DArrayToArray, ::cudaMemcpyToSymbol,
@@ -4914,129 +4914,129 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaMemcpyToArrayAsync, ::cudaMemcpy2DToArrayAsync,
   ##  ::cudaMemcpyFromArrayAsync, ::cudaMemcpy2DFromArrayAsync,
   ##  ::cudaMemcpyToSymbolAsync
-  ## 
+  ##
   proc cudaMemcpyFromSymbolAsync*(dst: pointer; symbol: pointer; count: csize;
                                  offset: csize; kind: cudaMemcpyKind;
                                  stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaMemcpyFromSymbolAsync", dyn.}
   ## *
   ##  \brief Initializes or sets device memory to a value
-  ## 
+  ##
   ##  Fills the first \p count bytes of the memory area pointed to by \p devPtr
   ##  with the constant byte value \p value.
-  ## 
+  ##
   ##  Note that this function is asynchronous with respect to the host unless
   ##  \p devPtr refers to pinned host memory.
-  ## 
+  ##
   ##  \param devPtr - Pointer to device memory
   ##  \param value  - Value to set for each byte of specified memory
   ##  \param count  - Size in bytes to set
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidDevicePointer
   ##  \notefnerr
   ##  \note_memset
-  ## 
+  ##
   ##  \sa ::cudaMemset2D, ::cudaMemset3D, ::cudaMemsetAsync,
   ##  ::cudaMemset2DAsync, ::cudaMemset3DAsync
-  ## 
+  ##
   proc cudaMemset*(devPtr: pointer; value: cint; count: csize): cudaError_t {.cdecl,
       importc: "cudaMemset", dyn.}
   ## *
   ##  \brief Initializes or sets device memory to a value
-  ## 
+  ##
   ##  Sets to the specified value \p value a matrix (\p height rows of \p width
   ##  bytes each) pointed to by \p dstPtr. \p pitch is the width in bytes of the
   ##  2D array pointed to by \p dstPtr, including any padding added to the end
   ##  of each row. This function performs fastest when the pitch is one that has
   ##  been passed back by ::cudaMallocPitch().
-  ## 
+  ##
   ##  Note that this function is asynchronous with respect to the host unless
   ##  \p devPtr refers to pinned host memory.
-  ## 
+  ##
   ##  \param devPtr - Pointer to 2D device memory
   ##  \param pitch  - Pitch in bytes of 2D device memory
   ##  \param value  - Value to set for each byte of specified memory
   ##  \param width  - Width of matrix set (columns in bytes)
   ##  \param height - Height of matrix set (rows)
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidDevicePointer
   ##  \notefnerr
   ##  \note_memset
-  ## 
+  ##
   ##  \sa ::cudaMemset, ::cudaMemset3D, ::cudaMemsetAsync,
   ##  ::cudaMemset2DAsync, ::cudaMemset3DAsync
-  ## 
+  ##
   proc cudaMemset2D*(devPtr: pointer; pitch: csize; value: cint; width: csize;
                     height: csize): cudaError_t {.cdecl, importc: "cudaMemset2D",
       dyn.}
   ## *
   ##  \brief Initializes or sets device memory to a value
-  ## 
+  ##
   ##  Initializes each element of a 3D array to the specified value \p value.
   ##  The object to initialize is defined by \p pitchedDevPtr. The \p pitch field
   ##  of \p pitchedDevPtr is the width in memory in bytes of the 3D array pointed
   ##  to by \p pitchedDevPtr, including any padding added to the end of each row.
   ##  The \p xsize field specifies the logical width of each row in bytes, while
   ##  the \p ysize field specifies the height of each 2D slice in rows.
-  ## 
+  ##
   ##  The extents of the initialized region are specified as a \p width in bytes,
   ##  a \p height in rows, and a \p depth in slices.
-  ## 
+  ##
   ##  Extents with \p width greater than or equal to the \p xsize of
   ##  \p pitchedDevPtr may perform significantly faster than extents narrower
   ##  than the \p xsize. Secondarily, extents with \p height equal to the
   ##  \p ysize of \p pitchedDevPtr will perform faster than when the \p height is
   ##  shorter than the \p ysize.
-  ## 
+  ##
   ##  This function performs fastest when the \p pitchedDevPtr has been allocated
   ##  by ::cudaMalloc3D().
-  ## 
+  ##
   ##  Note that this function is asynchronous with respect to the host unless
   ##  \p pitchedDevPtr refers to pinned host memory.
-  ## 
+  ##
   ##  \param pitchedDevPtr - Pointer to pitched device memory
   ##  \param value         - Value to set for each byte of specified memory
   ##  \param extent        - Size parameters for where to set device memory (\p width field in bytes)
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidDevicePointer
   ##  \notefnerr
   ##  \note_memset
-  ## 
+  ##
   ##  \sa ::cudaMemset, ::cudaMemset2D,
   ##  ::cudaMemsetAsync, ::cudaMemset2DAsync, ::cudaMemset3DAsync,
   ##  ::cudaMalloc3D, ::make_cudaPitchedPtr,
   ##  ::make_cudaExtent
-  ## 
+  ##
   proc cudaMemset3D*(pitchedDevPtr: cudaPitchedPtr; value: cint; extent: cudaExtent): cudaError_t {.
       cdecl, importc: "cudaMemset3D", dyn.}
   ## *
   ##  \brief Initializes or sets device memory to a value
-  ## 
+  ##
   ##  Fills the first \p count bytes of the memory area pointed to by \p devPtr
   ##  with the constant byte value \p value.
-  ## 
+  ##
   ##  ::cudaMemsetAsync() is asynchronous with respect to the host, so
   ##  the call may return before the memset is complete. The operation can optionally
   ##  be associated to a stream by passing a non-zero \p stream argument.
   ##  If \p stream is non-zero, the operation may overlap with operations in other streams.
-  ## 
+  ##
   ##  The device version of this function only handles device to device copies and
   ##  cannot be given local or shared pointers.
-  ## 
+  ##
   ##  \param devPtr - Pointer to device memory
   ##  \param value  - Value to set for each byte of specified memory
   ##  \param count  - Size in bytes to set
   ##  \param stream - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -5044,37 +5044,37 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_memset
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemset, ::cudaMemset2D, ::cudaMemset3D,
   ##  ::cudaMemset2DAsync, ::cudaMemset3DAsync
-  ## 
+  ##
   proc cudaMemsetAsync*(devPtr: pointer; value: cint; count: csize;
                        stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaMemsetAsync", dyn.}
   ## *
   ##  \brief Initializes or sets device memory to a value
-  ## 
+  ##
   ##  Sets to the specified value \p value a matrix (\p height rows of \p width
   ##  bytes each) pointed to by \p dstPtr. \p pitch is the width in bytes of the
   ##  2D array pointed to by \p dstPtr, including any padding added to the end
   ##  of each row. This function performs fastest when the pitch is one that has
   ##  been passed back by ::cudaMallocPitch().
-  ## 
+  ##
   ##  ::cudaMemset2DAsync() is asynchronous with respect to the host, so
   ##  the call may return before the memset is complete. The operation can optionally
   ##  be associated to a stream by passing a non-zero \p stream argument.
   ##  If \p stream is non-zero, the operation may overlap with operations in other streams.
-  ## 
+  ##
   ##  The device version of this function only handles device to device copies and
   ##  cannot be given local or shared pointers.
-  ## 
+  ##
   ##  \param devPtr - Pointer to 2D device memory
   ##  \param pitch  - Pitch in bytes of 2D device memory
   ##  \param value  - Value to set for each byte of specified memory
   ##  \param width  - Width of matrix set (columns in bytes)
   ##  \param height - Height of matrix set (rows)
   ##  \param stream - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -5082,48 +5082,48 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_memset
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemset, ::cudaMemset2D, ::cudaMemset3D,
   ##  ::cudaMemsetAsync, ::cudaMemset3DAsync
-  ## 
+  ##
   proc cudaMemset2DAsync*(devPtr: pointer; pitch: csize; value: cint; width: csize;
                          height: csize; stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaMemset2DAsync", dyn.}
   ## *
   ##  \brief Initializes or sets device memory to a value
-  ## 
+  ##
   ##  Initializes each element of a 3D array to the specified value \p value.
   ##  The object to initialize is defined by \p pitchedDevPtr. The \p pitch field
   ##  of \p pitchedDevPtr is the width in memory in bytes of the 3D array pointed
   ##  to by \p pitchedDevPtr, including any padding added to the end of each row.
   ##  The \p xsize field specifies the logical width of each row in bytes, while
   ##  the \p ysize field specifies the height of each 2D slice in rows.
-  ## 
+  ##
   ##  The extents of the initialized region are specified as a \p width in bytes,
   ##  a \p height in rows, and a \p depth in slices.
-  ## 
+  ##
   ##  Extents with \p width greater than or equal to the \p xsize of
   ##  \p pitchedDevPtr may perform significantly faster than extents narrower
   ##  than the \p xsize. Secondarily, extents with \p height equal to the
   ##  \p ysize of \p pitchedDevPtr will perform faster than when the \p height is
   ##  shorter than the \p ysize.
-  ## 
+  ##
   ##  This function performs fastest when the \p pitchedDevPtr has been allocated
   ##  by ::cudaMalloc3D().
-  ## 
+  ##
   ##  ::cudaMemset3DAsync() is asynchronous with respect to the host, so
   ##  the call may return before the memset is complete. The operation can optionally
   ##  be associated to a stream by passing a non-zero \p stream argument.
   ##  If \p stream is non-zero, the operation may overlap with operations in other streams.
-  ## 
+  ##
   ##  The device version of this function only handles device to device copies and
   ##  cannot be given local or shared pointers.
-  ## 
+  ##
   ##  \param pitchedDevPtr - Pointer to pitched device memory
   ##  \param value         - Value to set for each byte of specified memory
   ##  \param extent        - Size parameters for where to set device memory (\p width field in bytes)
   ##  \param stream - Stream identifier
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -5131,114 +5131,114 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_memset
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemset, ::cudaMemset2D, ::cudaMemset3D,
   ##  ::cudaMemsetAsync, ::cudaMemset2DAsync,
   ##  ::cudaMalloc3D, ::make_cudaPitchedPtr,
   ##  ::make_cudaExtent
-  ## 
+  ##
   proc cudaMemset3DAsync*(pitchedDevPtr: cudaPitchedPtr; value: cint;
                          extent: cudaExtent; stream: cudaStream_t): cudaError_t {.
       cdecl, importc: "cudaMemset3DAsync", dyn.}
   ## *
   ##  \brief Finds the address associated with a CUDA symbol
-  ## 
-  ##  Returns in \p *devPtr the address of symbol \p symbol on the device.
+  ##
+  ##  `Returns in \p *devPtr the address of symbol \p symbol on the device.`
   ##  \p symbol is a variable that resides in global or constant memory space.
   ##  If \p symbol cannot be found, or if \p symbol is not declared in the
-  ##  global or constant memory space, \p *devPtr is unchanged and the error
+  ##  `global or constant memory space, \p *devPtr is unchanged and the error`
   ##  ::cudaErrorInvalidSymbol is returned.
-  ## 
+  ##
   ##  \param devPtr - Return device pointer associated with symbol
   ##  \param symbol - Device symbol address
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidSymbol
   ##  \notefnerr
   ##  \note_string_api_deprecation
-  ## 
-  ##  \sa \ref ::cudaGetSymbolAddress(void**, const T&) "cudaGetSymbolAddress (C++ API)",
-  ##  \ref ::cudaGetSymbolSize(size_t*, const void*) "cudaGetSymbolSize (C API)"
-  ## 
+  ##
+  ##  `\sa \ref ::cudaGetSymbolAddress(void**, const T&) "cudaGetSymbolAddress (C++ API)",`
+  ##  `\ref ::cudaGetSymbolSize(size_t*, const void*) "cudaGetSymbolSize (C API)"`
+  ##
   proc cudaGetSymbolAddress*(devPtr: ptr pointer; symbol: pointer): cudaError_t {.
       cdecl, importc: "cudaGetSymbolAddress", dyn.}
   ## *
   ##  \brief Finds the size of the object associated with a CUDA symbol
-  ## 
-  ##  Returns in \p *size the size of symbol \p symbol. \p symbol is a variable that
+  ##
+  ##  `Returns in \p *size the size of symbol \p symbol. \p symbol is a variable that`
   ##  resides in global or constant memory space. If \p symbol cannot be found, or
-  ##  if \p symbol is not declared in global or constant memory space, \p *size is
+  ##  `if \p symbol is not declared in global or constant memory space, \p *size is`
   ##  unchanged and the error ::cudaErrorInvalidSymbol is returned.
-  ## 
+  ##
   ##  \param size   - Size of object associated with symbol
   ##  \param symbol - Device symbol address
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidSymbol
   ##  \notefnerr
   ##  \note_string_api_deprecation
-  ## 
-  ##  \sa \ref ::cudaGetSymbolAddress(void**, const void*) "cudaGetSymbolAddress (C API)",
-  ##  \ref ::cudaGetSymbolSize(size_t*, const T&) "cudaGetSymbolSize (C++ API)"
-  ## 
+  ##
+  ##  `\sa \ref ::cudaGetSymbolAddress(void**, const void*) "cudaGetSymbolAddress (C API)",`
+  ##  `\ref ::cudaGetSymbolSize(size_t*, const T&) "cudaGetSymbolSize (C++ API)"`
+  ##
   proc cudaGetSymbolSize*(size: ptr csize; symbol: pointer): cudaError_t {.cdecl,
       importc: "cudaGetSymbolSize", dyn.}
   ## *
   ##  \brief Prefetches memory to the specified destination device
-  ## 
+  ##
   ##  Prefetches memory to the specified destination device.  \p devPtr is the
   ##  base device pointer of the memory to be prefetched and \p dstDevice is the
   ##  destination device. \p count specifies the number of bytes to copy. \p stream
   ##  is the stream in which the operation is enqueued. The memory range must refer
   ##  to managed memory allocated via ::cudaMallocManaged or declared via __managed__ variables.
-  ## 
+  ##
   ##  Passing in cudaCpuDeviceId for \p dstDevice will prefetch the data to host memory. If
   ##  \p dstDevice is a GPU, then the device attribute ::cudaDevAttrConcurrentManagedAccess
   ##  must be non-zero. Additionally, \p stream must be associated with a device that has a
   ##  non-zero value for the device attribute ::cudaDevAttrConcurrentManagedAccess.
-  ## 
+  ##
   ##  The start address and end address of the memory range will be rounded down and rounded up
   ##  respectively to be aligned to CPU page size before the prefetch operation is enqueued
   ##  in the stream.
-  ## 
+  ##
   ##  If no physical memory has been allocated for this region, then this memory region
   ##  will be populated and mapped on the destination device. If there's insufficient
   ##  memory to prefetch the desired region, the Unified Memory driver may evict pages from other
   ##  ::cudaMallocManaged allocations to host memory in order to make room. Device memory
   ##  allocated using ::cudaMalloc or ::cudaMallocArray will not be evicted.
-  ## 
+  ##
   ##  By default, any mappings to the previous location of the migrated pages are removed and
   ##  mappings for the new location are only setup on \p dstDevice. The exact behavior however
   ##  also depends on the settings applied to this memory range via ::cudaMemAdvise as described
   ##  below:
-  ## 
+  ##
   ##  If ::cudaMemAdviseSetReadMostly was set on any subset of this memory range,
   ##  then that subset will create a read-only copy of the pages on \p dstDevice.
-  ## 
+  ##
   ##  If ::cudaMemAdviseSetPreferredLocation was called on any subset of this memory
   ##  range, then the pages will be migrated to \p dstDevice even if \p dstDevice is not the
   ##  preferred location of any pages in the memory range.
-  ## 
+  ##
   ##  If ::cudaMemAdviseSetAccessedBy was called on any subset of this memory range,
   ##  then mappings to those pages from all the appropriate processors are updated to
   ##  refer to the new location if establishing such a mapping is possible. Otherwise,
   ##  those mappings are cleared.
-  ## 
+  ##
   ##  Note that this API is not required for functionality and only serves to improve performance
   ##  by allowing the application to migrate data to a suitable location before it is accessed.
   ##  Memory accesses to this range are always coherent and are allowed even when the data is
   ##  actively being migrated.
-  ## 
+  ##
   ##  Note that this function is asynchronous with respect to the host and all work
   ##  on other devices.
-  ## 
+  ##
   ##  \param devPtr    - Pointer to be prefetched
   ##  \param count     - Size in bytes
   ##  \param dstDevice - Destination device to prefetch to
   ##  \param stream    - Stream to enqueue prefetch operation
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -5246,22 +5246,22 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_async
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpyPeer, ::cudaMemcpyAsync,
   ##  ::cudaMemcpy3DPeerAsync, ::cudaMemAdvise
-  ## 
+  ##
   proc cudaMemPrefetchAsync*(devPtr: pointer; count: csize; dstDevice: cint;
                             stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaMemPrefetchAsync", dyn.}
   ## *
   ##  \brief Advise about the usage of a given memory range
-  ## 
+  ##
   ##  Advise the Unified Memory subsystem about the usage pattern for the memory range
   ##  starting at \p devPtr with a size of \p count bytes. The start address and end address of the memory
   ##  range will be rounded down and rounded up respectively to be aligned to CPU page size before the
   ##  advice is applied. The memory range must refer to managed memory allocated via ::cudaMallocManaged
   ##  or declared via __managed__ variables.
-  ## 
+  ##
   ##  The \p advice parameter can take the following values:
   ##  - ::cudaMemAdviseSetReadMostly: This implies that the data is mostly going to be read
   ##  from and only occasionally written to. Any read accesses from any processor to this region will create a
@@ -5320,12 +5320,12 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  associated with ::cudaMemAdviseSetPreferredLocation will override the policies of this advice.
   ##  - ::cudaMemAdviseUnsetAccessedBy: Undoes the effect of ::cudaMemAdviseSetAccessedBy. Any mappings to
   ##  the data from \p device may be removed at any time causing accesses to result in non-fatal page faults.
-  ## 
+  ##
   ##  \param devPtr - Pointer to memory to set the advice for
   ##  \param count  - Size in bytes of the memory range
   ##  \param advice - Advice to be applied for the specified memory range
   ##  \param device - Device to apply the advice for
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
@@ -5333,20 +5333,20 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \notefnerr
   ##  \note_async
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemcpy, ::cudaMemcpyPeer, ::cudaMemcpyAsync,
   ##  ::cudaMemcpy3DPeerAsync, ::cudaMemPrefetchAsync
-  ## 
+  ##
   proc cudaMemAdvise*(devPtr: pointer; count: csize; advice: cudaMemoryAdvise;
                      device: cint): cudaError_t {.cdecl, importc: "cudaMemAdvise",
       dyn.}
   ## *
   ##  \brief Query an attribute of a given memory range
-  ## 
+  ##
   ##  Query an attribute about the memory range starting at \p devPtr with a size of \p count bytes. The
   ##  memory range must refer to managed memory allocated via ::cudaMallocManaged or declared via
   ##  __managed__ variables.
-  ## 
+  ##
   ##  The \p attribute parameter can take the following values:
   ##  - ::cudaMemRangeAttributeReadMostly: If this attribute is specified, \p data will be interpreted
   ##  as a 32-bit integer, and \p dataSize must be 4. The result returned will be 1 if all pages in the given
@@ -5376,45 +5376,45 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  prefetched to the same location, cudaInvalidDeviceId will be returned. Note that this simply returns the
   ##  last location that the applicaton requested to prefetch the memory range to. It gives no indication as to
   ##  whether the prefetch operation to that location has completed or even begun.
-  ## 
+  ##
   ##  \param data      - A pointers to a memory location where the result
   ##                     of each attribute query will be written to.
   ##  \param dataSize  - Array containing the size of data
   ##  \param attribute - The attribute to query
   ##  \param devPtr    - Start of the range to query
   ##  \param count     - Size of the range to query
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
   ##  \note_async
   ##  \note_null_stream
-  ## 
+  ##
   ##  \sa ::cudaMemRangeGetAttributes, ::cudaMemPrefetchAsync,
   ##  ::cudaMemAdvise
-  ## 
+  ##
   proc cudaMemRangeGetAttribute*(data: pointer; dataSize: csize;
                                 attribute: cudaMemRangeAttribute; devPtr: pointer;
                                 count: csize): cudaError_t {.cdecl,
       importc: "cudaMemRangeGetAttribute", dyn.}
   ## *
   ##  \brief Query attributes of a given memory range.
-  ## 
+  ##
   ##  Query attributes of the memory range starting at \p devPtr with a size of \p count bytes. The
   ##  memory range must refer to managed memory allocated via ::cudaMallocManaged or declared via
   ##  __managed__ variables. The \p attributes array will be interpreted to have \p numAttributes
   ##  entries. The \p dataSizes array will also be interpreted to have \p numAttributes entries.
   ##  The results of the query will be stored in \p data.
-  ## 
+  ##
   ##  The list of supported attributes are given below. Please refer to ::cudaMemRangeGetAttribute for
   ##  attribute descriptions and restrictions.
-  ## 
+  ##
   ##  - ::cudaMemRangeAttributeReadMostly
   ##  - ::cudaMemRangeAttributePreferredLocation
   ##  - ::cudaMemRangeAttributeAccessedBy
   ##  - ::cudaMemRangeAttributeLastPrefetchLocation
-  ## 
+  ##
   ##  \param data          - A two-dimensional array containing pointers to memory
   ##                         locations where the result of each attribute query will be written to.
   ##  \param dataSizes     - Array containing the sizes of each result
@@ -5423,15 +5423,15 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \param numAttributes - Number of attributes to query
   ##  \param devPtr        - Start of the range to query
   ##  \param count         - Size of the range to query
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaMemRangeGetAttribute, ::cudaMemAdvise
   ##  ::cudaMemPrefetchAsync
-  ## 
+  ##
   proc cudaMemRangeGetAttributes*(data: ptr pointer; dataSizes: ptr csize;
                                  attributes: ptr cudaMemRangeAttribute;
                                  numAttributes: csize; devPtr: pointer; count: csize): cudaError_t {.
@@ -5440,67 +5440,67 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  END CUDART_MEMORY
   ## *
   ##  \defgroup CUDART_UNIFIED Unified Addressing
-  ## 
+  ##
   ##  ___MANBRIEF___ unified addressing functions of the CUDA runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the unified addressing functions of the CUDA
   ##  runtime application programming interface.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ##  \section CUDART_UNIFIED_overview Overview
-  ## 
+  ##
   ##  CUDA devices can share a unified address space with the host.
   ##  For these devices there is no distinction between a device
   ##  pointer and a host pointer -- the same pointer value may be
   ##  used to access memory from the host program and from a kernel
   ##  running on the device (with exceptions enumerated below).
-  ## 
+  ##
   ##  \section CUDART_UNIFIED_support Supported Platforms
-  ## 
+  ##
   ##  Whether or not a device supports unified addressing may be
   ##  queried by calling ::cudaGetDeviceProperties() with the device
   ##  property ::cudaDeviceProp::unifiedAddressing.
-  ## 
+  ##
   ##  Unified addressing is automatically enabled in 64-bit processes .
-  ## 
+  ##
   ##  Unified addressing is not yet supported on Windows Vista or
   ##  Windows 7 for devices that do not use the TCC driver model.
-  ## 
+  ##
   ##  \section CUDART_UNIFIED_lookup Looking Up Information from Pointer Values
-  ## 
+  ##
   ##  It is possible to look up information about the memory which backs a
   ##  pointer value.  For instance, one may want to know if a pointer points
   ##  to host or device memory.  As another example, in the case of device
   ##  memory, one may want to know on which CUDA device the memory
   ##  resides.  These properties may be queried using the function
   ##  ::cudaPointerGetAttributes()
-  ## 
+  ##
   ##  Since pointers are unique, it is not necessary to specify information
   ##  about the pointers specified to ::cudaMemcpy() and other copy functions.
   ##  The copy direction ::cudaMemcpyDefault may be used to specify that the
   ##  CUDA runtime should infer the location of the pointer from its value.
-  ## 
+  ##
   ##  \section CUDART_UNIFIED_automaphost Automatic Mapping of Host Allocated Host Memory
-  ## 
+  ##
   ##  All host memory allocated through all devices using ::cudaMallocHost() and
   ##  ::cudaHostAlloc() is always directly accessible from all devices that
   ##  support unified addressing.  This is the case regardless of whether or
   ##  not the flags ::cudaHostAllocPortable and ::cudaHostAllocMapped are
   ##  specified.
-  ## 
+  ##
   ##  The pointer value through which allocated host memory may be accessed
   ##  in kernels on all devices that support unified addressing is the same
   ##  as the pointer value through which that memory is accessed on the host.
   ##  It is not necessary to call ::cudaHostGetDevicePointer() to get the device
   ##  pointer for these allocations.
-  ## 
+  ##
   ##  Note that this is not the case for memory allocated using the flag
   ##  ::cudaHostAllocWriteCombined, as discussed below.
-  ## 
+  ##
   ##  \section CUDART_UNIFIED_autopeerregister Direct Access of Peer Memory
-  ## 
+  ##
   ##  Upon enabling direct access from a device that supports unified addressing
   ##  to another peer device that supports unified addressing using
   ##  ::cudaDeviceEnablePeerAccess() all memory allocated in the peer device using
@@ -5509,9 +5509,9 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  which any peer's memory may be accessed in the current device
   ##  is the same pointer value through which that memory may be
   ##  accessed from the peer device.
-  ## 
+  ##
   ##  \section CUDART_UNIFIED_exceptions Exceptions, Disjoint Addressing
-  ## 
+  ##
   ##  Not all memory may be accessed on devices through the same pointer
   ##  value through which they are accessed on the host.  These exceptions
   ##  are host memory registered using ::cudaHostRegister() and host memory
@@ -5520,38 +5520,38 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  memory.  The device address is guaranteed to not overlap any valid host
   ##  pointer range and is guaranteed to have the same value across all devices
   ##  that support unified addressing.
-  ## 
+  ##
   ##  This device address may be queried using ::cudaHostGetDevicePointer()
   ##  when a device using unified addressing is current.  Either the host
   ##  or the unified device pointer value may be used to refer to this memory
   ##  in ::cudaMemcpy() and similar functions using the ::cudaMemcpyDefault
   ##  memory direction.
-  ## 
-  ## 
+  ##
+  ##
   ## *
   ##  \brief Returns attributes about a specified pointer
-  ## 
-  ##  Returns in \p *attributes the attributes of the pointer \p ptr.
+  ##
+  ##  `Returns in \p *attributes the attributes of the pointer \p ptr.`
   ##  If pointer was not allocated in, mapped by or registered with context
   ##  supporting unified addressing ::cudaErrorInvalidValue is returned.
-  ## 
+  ##
   ##  The ::cudaPointerAttributes structure is defined as:
   ##  \code
   ##     struct cudaPointerAttributes {
   ##         enum cudaMemoryType memoryType;
   ##         int device;
-  ##         void *devicePointer;
-  ##         void *hostPointer;
+  ##         `void *devicePointer;`
+  ##         `void *hostPointer;`
   ##         int isManaged;
   ##     }
   ##     \endcode
   ##  In this structure, the individual fields mean
-  ## 
+  ##
   ##  - \ref ::cudaPointerAttributes::memoryType "memoryType" identifies the physical
   ##    location of the memory associated with pointer \p ptr.  It can be
   ##    ::cudaMemoryTypeHost for host memory or ::cudaMemoryTypeDevice for device
   ##    memory.
-  ## 
+  ##
   ##  - \ref ::cudaPointerAttributes::device "device" is the device against which
   ##    \p ptr was allocated.  If \p ptr has memory type ::cudaMemoryTypeDevice
   ##    then this identifies the device on which the memory referred to by \p ptr
@@ -5559,33 +5559,33 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    identifies the device which was current when the allocation was made
   ##    (and if that device is deinitialized then this allocation will vanish
   ##    with that device's state).
-  ## 
+  ##
   ##  - \ref ::cudaPointerAttributes::devicePointer "devicePointer" is
   ##    the device pointer alias through which the memory referred to by \p ptr
   ##    may be accessed on the current device.
   ##    If the memory referred to by \p ptr cannot be accessed directly by the
   ##    current device then this is NULL.
-  ## 
+  ##
   ##  - \ref ::cudaPointerAttributes::hostPointer "hostPointer" is
   ##    the host pointer alias through which the memory referred to by \p ptr
   ##    may be accessed on the host.
   ##    If the memory referred to by \p ptr cannot be accessed directly by the
   ##    host then this is NULL.
-  ## 
+  ##
   ##  - \ref ::cudaPointerAttributes::isManaged "isManaged" indicates if
   ##    the pointer \p ptr points to managed memory or not.
-  ## 
+  ##
   ##  \param attributes - Attributes for the specified pointer
   ##  \param ptr        - Pointer to get attributes for
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidDevice,
   ##  ::cudaErrorInvalidValue
-  ## 
+  ##
   ##  \sa ::cudaGetDeviceCount, ::cudaGetDevice, ::cudaSetDevice,
   ##  ::cudaChooseDevice
-  ## 
+  ##
   proc cudaPointerGetAttributes*(attributes: ptr cudaPointerAttributes;
                                 `ptr`: pointer): cudaError_t {.cdecl,
       importc: "cudaPointerGetAttributes", dyn.}
@@ -5593,152 +5593,152 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  END CUDART_UNIFIED
   ## *
   ##  \defgroup CUDART_PEER Peer Device Memory Access
-  ## 
+  ##
   ##  ___MANBRIEF___ peer device memory access functions of the CUDA runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the peer device memory access functions of the CUDA runtime
   ##  application programming interface.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Queries if a device may directly access a peer device's memory.
-  ## 
-  ##  Returns in \p *canAccessPeer a value of 1 if device \p device is capable of
+  ##
+  ##  `Returns in \p *canAccessPeer a value of 1 if device \p device is capable of`
   ##  directly accessing memory from \p peerDevice and 0 otherwise.  If direct
   ##  access of \p peerDevice from \p device is possible, then access may be
   ##  enabled by calling ::cudaDeviceEnablePeerAccess().
-  ## 
+  ##
   ##  \param canAccessPeer - Returned access capability
   ##  \param device        - Device from which allocations on \p peerDevice are to
   ##                         be directly accessed.
   ##  \param peerDevice    - Device on which the allocations to be directly accessed
   ##                         by \p device reside.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidDevice
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceEnablePeerAccess,
   ##  ::cudaDeviceDisablePeerAccess
-  ## 
+  ##
   proc cudaDeviceCanAccessPeer*(canAccessPeer: ptr cint; device: cint;
                                peerDevice: cint): cudaError_t {.cdecl,
       importc: "cudaDeviceCanAccessPeer", dyn.}
   ## *
   ##  \brief Enables direct access to memory allocations on a peer device.
-  ## 
+  ##
   ##  On success, all allocations from \p peerDevice will immediately be accessible by
   ##  the current device.  They will remain accessible until access is explicitly
   ##  disabled using ::cudaDeviceDisablePeerAccess() or either device is reset using
   ##  ::cudaDeviceReset().
-  ## 
+  ##
   ##  Note that access granted by this call is unidirectional and that in order to access
   ##  memory on the current device from \p peerDevice, a separate symmetric call
   ##  to ::cudaDeviceEnablePeerAccess() is required.
-  ## 
+  ##
   ##  Each device can support a system-wide maximum of eight peer connections.
-  ## 
+  ##
   ##  Peer access is not supported in 32 bit applications.
-  ## 
+  ##
   ##  Returns ::cudaErrorInvalidDevice if ::cudaDeviceCanAccessPeer() indicates
   ##  that the current device cannot directly access memory from \p peerDevice.
-  ## 
+  ##
   ##  Returns ::cudaErrorPeerAccessAlreadyEnabled if direct access of
   ##  \p peerDevice from the current device has already been enabled.
-  ## 
+  ##
   ##  Returns ::cudaErrorInvalidValue if \p flags is not 0.
-  ## 
+  ##
   ##  \param peerDevice  - Peer device to enable direct access to from the current device
   ##  \param flags       - Reserved for future use and must be set to 0
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidDevice,
   ##  ::cudaErrorPeerAccessAlreadyEnabled,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceCanAccessPeer,
   ##  ::cudaDeviceDisablePeerAccess
-  ## 
+  ##
   proc cudaDeviceEnablePeerAccess*(peerDevice: cint; flags: cuint): cudaError_t {.
       cdecl, importc: "cudaDeviceEnablePeerAccess", dyn.}
   ## *
   ##  \brief Disables direct access to memory allocations on a peer device.
-  ## 
+  ##
   ##  Returns ::cudaErrorPeerAccessNotEnabled if direct access to memory on
   ##  \p peerDevice has not yet been enabled from the current device.
-  ## 
+  ##
   ##  \param peerDevice - Peer device to disable direct access to
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorPeerAccessNotEnabled,
   ##  ::cudaErrorInvalidDevice
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaDeviceCanAccessPeer,
   ##  ::cudaDeviceEnablePeerAccess
-  ## 
+  ##
   proc cudaDeviceDisablePeerAccess*(peerDevice: cint): cudaError_t {.cdecl,
       importc: "cudaDeviceDisablePeerAccess", dyn.}
   ## * @}
   ##  END CUDART_PEER
-  ## * \defgroup CUDART_OPENGL OpenGL Interoperability
-  ## * \defgroup CUDART_OPENGL_DEPRECATED OpenGL Interoperability [DEPRECATED]
-  ## * \defgroup CUDART_D3D9 Direct3D 9 Interoperability
-  ## * \defgroup CUDART_D3D9_DEPRECATED Direct3D 9 Interoperability [DEPRECATED]
-  ## * \defgroup CUDART_D3D10 Direct3D 10 Interoperability
-  ## * \defgroup CUDART_D3D10_DEPRECATED Direct3D 10 Interoperability [DEPRECATED]
-  ## * \defgroup CUDART_D3D11 Direct3D 11 Interoperability
-  ## * \defgroup CUDART_D3D11_DEPRECATED Direct3D 11 Interoperability [DEPRECATED]
-  ## * \defgroup CUDART_VDPAU VDPAU Interoperability
-  ## * \defgroup CUDART_EGL EGL Interoperability
+  ## `* \defgroup CUDART_OPENGL OpenGL Interoperability`
+  ## `* \defgroup CUDART_OPENGL_DEPRECATED OpenGL Interoperability [DEPRECATED]`
+  ## `* \defgroup CUDART_D3D9 Direct3D 9 Interoperability`
+  ## `* \defgroup CUDART_D3D9_DEPRECATED Direct3D 9 Interoperability [DEPRECATED]`
+  ## `* \defgroup CUDART_D3D10 Direct3D 10 Interoperability`
+  ## `* \defgroup CUDART_D3D10_DEPRECATED Direct3D 10 Interoperability [DEPRECATED]`
+  ## `* \defgroup CUDART_D3D11 Direct3D 11 Interoperability`
+  ## `* \defgroup CUDART_D3D11_DEPRECATED Direct3D 11 Interoperability [DEPRECATED]`
+  ## `* \defgroup CUDART_VDPAU VDPAU Interoperability`
+  ## `* \defgroup CUDART_EGL EGL Interoperability`
   ## *
   ##  \defgroup CUDART_INTEROP Graphics Interoperability
-  ## 
+  ##
   ##  ___MANBRIEF___ graphics interoperability functions of the CUDA runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the graphics interoperability functions of the CUDA
   ##  runtime application programming interface.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Unregisters a graphics resource for access by CUDA
-  ## 
+  ##
   ##  Unregisters the graphics resource \p resource so it is not accessible by
   ##  CUDA unless registered again.
-  ## 
+  ##
   ##  If \p resource is invalid then ::cudaErrorInvalidResourceHandle is
   ##  returned.
-  ## 
+  ##
   ##  \param resource - Resource to unregister
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorUnknown
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa
   ##  ::cudaGraphicsD3D9RegisterResource,
   ##  ::cudaGraphicsD3D10RegisterResource,
   ##  ::cudaGraphicsD3D11RegisterResource,
   ##  ::cudaGraphicsGLRegisterBuffer,
   ##  ::cudaGraphicsGLRegisterImage
-  ## 
+  ##
   proc cudaGraphicsUnregisterResource*(resource: cudaGraphicsResource_t): cudaError_t {.
       cdecl, importc: "cudaGraphicsUnregisterResource", dyn.}
   ## *
   ##  \brief Set usage flags for mapping a graphics resource
-  ## 
+  ##
   ##  Set \p flags for mapping the graphics resource \p resource.
-  ## 
+  ##
   ##  Changes to \p flags will take effect the next time \p resource is mapped.
   ##  The \p flags argument may be any of the following:
   ##  - ::cudaGraphicsMapFlagsNone: Specifies no hints about how \p resource will
@@ -5747,136 +5747,136 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  - ::cudaGraphicsMapFlagsWriteDiscard: Specifies CUDA will not read from \p resource and will
   ##    write over the entire contents of \p resource, so none of the data
   ##    previously stored in \p resource will be preserved.
-  ## 
+  ##
   ##  If \p resource is presently mapped for access by CUDA then ::cudaErrorUnknown is returned.
   ##  If \p flags is not one of the above values then ::cudaErrorInvalidValue is returned.
-  ## 
+  ##
   ##  \param resource - Registered resource to set flags for
   ##  \param flags    - Parameters for resource mapping
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorUnknown,
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa
   ##  ::cudaGraphicsMapResources
-  ## 
+  ##
   proc cudaGraphicsResourceSetMapFlags*(resource: cudaGraphicsResource_t;
                                        flags: cuint): cudaError_t {.cdecl,
       importc: "cudaGraphicsResourceSetMapFlags", dyn.}
   ## *
   ##  \brief Map graphics resources for access by CUDA
-  ## 
+  ##
   ##  Maps the \p count graphics resources in \p resources for access by CUDA.
-  ## 
+  ##
   ##  The resources in \p resources may be accessed by CUDA until they
   ##  are unmapped. The graphics API from which \p resources were registered
   ##  should not access any resources while they are mapped by CUDA. If an
   ##  application does so, the results are undefined.
-  ## 
+  ##
   ##  This function provides the synchronization guarantee that any graphics calls
   ##  issued before ::cudaGraphicsMapResources() will complete before any subsequent CUDA
   ##  work issued in \p stream begins.
-  ## 
+  ##
   ##  If \p resources contains any duplicate entries then ::cudaErrorInvalidResourceHandle
   ##  is returned. If any of \p resources are presently mapped for access by
   ##  CUDA then ::cudaErrorUnknown is returned.
-  ## 
+  ##
   ##  \param count     - Number of resources to map
   ##  \param resources - Resources to map for CUDA
   ##  \param stream    - Stream for synchronization
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorUnknown
   ##  \note_null_stream
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa
   ##  ::cudaGraphicsResourceGetMappedPointer,
   ##  ::cudaGraphicsSubResourceGetMappedArray,
   ##  ::cudaGraphicsUnmapResources
-  ## 
+  ##
   proc cudaGraphicsMapResources*(count: cint;
                                 resources: ptr cudaGraphicsResource_t;
                                 stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaGraphicsMapResources", dyn.}
   ## *
   ##  \brief Unmap graphics resources.
-  ## 
+  ##
   ##  Unmaps the \p count graphics resources in \p resources.
-  ## 
+  ##
   ##  Once unmapped, the resources in \p resources may not be accessed by CUDA
   ##  until they are mapped again.
-  ## 
+  ##
   ##  This function provides the synchronization guarantee that any CUDA work issued
   ##  in \p stream before ::cudaGraphicsUnmapResources() will complete before any
   ##  subsequently issued graphics work begins.
-  ## 
+  ##
   ##  If \p resources contains any duplicate entries then ::cudaErrorInvalidResourceHandle
   ##  is returned. If any of \p resources are not presently mapped for access by
   ##  CUDA then ::cudaErrorUnknown is returned.
-  ## 
+  ##
   ##  \param count     - Number of resources to unmap
   ##  \param resources - Resources to unmap
   ##  \param stream    - Stream for synchronization
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorUnknown
   ##  \note_null_stream
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa
   ##  ::cudaGraphicsMapResources
-  ## 
+  ##
   proc cudaGraphicsUnmapResources*(count: cint;
                                   resources: ptr cudaGraphicsResource_t;
                                   stream: cudaStream_t): cudaError_t {.cdecl,
       importc: "cudaGraphicsUnmapResources", dyn.}
   ## *
   ##  \brief Get an device pointer through which to access a mapped graphics resource.
-  ## 
-  ##  Returns in \p *devPtr a pointer through which the mapped graphics resource
+  ##
+  ##  `Returns in \p *devPtr a pointer through which the mapped graphics resource`
   ##  \p resource may be accessed.
-  ##  Returns in \p *size the size of the memory in bytes which may be accessed from that pointer.
+  ##  `Returns in \p *size the size of the memory in bytes which may be accessed from that pointer.`
   ##  The value set in \p devPtr may change every time that \p resource is mapped.
-  ## 
+  ##
   ##  If \p resource is not a buffer then it cannot be accessed via a pointer and
   ##  ::cudaErrorUnknown is returned.
   ##  If \p resource is not mapped then ::cudaErrorUnknown is returned.
-  ##  *
+  ##  `*`
   ##  \param devPtr     - Returned pointer through which \p resource may be accessed
-  ##  \param size       - Returned size of the buffer accessible starting at \p *devPtr
+  ##  `\param size       - Returned size of the buffer accessible starting at \p *devPtr`
   ##  \param resource   - Mapped resource to access
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorUnknown
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa
   ##  ::cudaGraphicsMapResources,
   ##  ::cudaGraphicsSubResourceGetMappedArray
-  ## 
+  ##
   proc cudaGraphicsResourceGetMappedPointer*(devPtr: ptr pointer; size: ptr csize;
       resource: cudaGraphicsResource_t): cudaError_t {.cdecl,
       importc: "cudaGraphicsResourceGetMappedPointer", dyn.}
   ## *
   ##  \brief Get an array through which to access a subresource of a mapped graphics resource.
-  ## 
-  ##  Returns in \p *array an array through which the subresource of the mapped
+  ##
+  ##  `Returns in \p *array an array through which the subresource of the mapped`
   ##  graphics resource \p resource which corresponds to array index \p arrayIndex
   ##  and mipmap level \p mipLevel may be accessed.  The value set in \p array may
   ##  change every time that \p resource is mapped.
-  ## 
+  ##
   ##  If \p resource is not a texture then it cannot be accessed via an array and
   ##  ::cudaErrorUnknown is returned.
   ##  If \p arrayIndex is not a valid array index for \p resource then
@@ -5884,49 +5884,49 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  If \p mipLevel is not a valid mipmap level for \p resource then
   ##  ::cudaErrorInvalidValue is returned.
   ##  If \p resource is not mapped then ::cudaErrorUnknown is returned.
-  ## 
+  ##
   ##  \param array       - Returned array through which a subresource of \p resource may be accessed
   ##  \param resource    - Mapped resource to access
   ##  \param arrayIndex  - Array index for array textures or cubemap face
   ##                       index as defined by ::cudaGraphicsCubeFace for
   ##                       cubemap textures for the subresource to access
   ##  \param mipLevel    - Mipmap level for the subresource to access
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorUnknown
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaGraphicsResourceGetMappedPointer
-  ## 
+  ##
   proc cudaGraphicsSubResourceGetMappedArray*(array: ptr cudaArray_t;
       resource: cudaGraphicsResource_t; arrayIndex: cuint; mipLevel: cuint): cudaError_t {.
       cdecl, importc: "cudaGraphicsSubResourceGetMappedArray", dyn.}
   ## *
   ##  \brief Get a mipmapped array through which to access a mapped graphics resource.
-  ## 
-  ##  Returns in \p *mipmappedArray a mipmapped array through which the mapped
+  ##
+  ##  `Returns in \p *mipmappedArray a mipmapped array through which the mapped`
   ##  graphics resource \p resource may be accessed. The value set in \p mipmappedArray may
   ##  change every time that \p resource is mapped.
-  ## 
+  ##
   ##  If \p resource is not a texture then it cannot be accessed via an array and
   ##  ::cudaErrorUnknown is returned.
   ##  If \p resource is not mapped then ::cudaErrorUnknown is returned.
-  ## 
+  ##
   ##  \param mipmappedArray - Returned mipmapped array through which \p resource may be accessed
   ##  \param resource       - Mapped resource to access
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidResourceHandle,
   ##  ::cudaErrorUnknown
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaGraphicsResourceGetMappedPointer
-  ## 
+  ##
   proc cudaGraphicsResourceGetMappedMipmappedArray*(
       mipmappedArray: ptr cudaMipmappedArray_t; resource: cudaGraphicsResource_t): cudaError_t {.
       cdecl, importc: "cudaGraphicsResourceGetMappedMipmappedArray",
@@ -5935,44 +5935,44 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  END CUDART_INTEROP
   ## *
   ##  \defgroup CUDART_TEXTURE Texture Reference Management
-  ## 
+  ##
   ##  ___MANBRIEF___ texture reference management functions of the CUDA runtime
   ##  API (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the low level texture reference management functions
   ##  of the CUDA runtime application programming interface.
-  ## 
+  ##
   ##  Some functions have overloaded C++ API template versions documented separately in the
   ##  \ref CUDART_HIGHLEVEL "C++ API Routines" module.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Get the channel descriptor of an array
-  ## 
-  ##  Returns in \p *desc the channel descriptor of the CUDA array \p array.
-  ## 
+  ##
+  ##  `Returns in \p *desc the channel descriptor of the CUDA array \p array.`
+  ##
   ##  \param desc  - Channel format
   ##  \param array - Memory array on device
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa \ref ::cudaCreateChannelDesc(int, int, int, int, cudaChannelFormatKind) "cudaCreateChannelDesc (C API)",
   ##  ::cudaGetTextureReference,
-  ##  \ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",
-  ##  \ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",
-  ##  \ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",
-  ##  \ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)",
-  ##  \ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"
-  ## 
+  ##  `\ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",`
+  ##  `\ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",`
+  ##  `\ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",`
+  ##  `\ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)",`
+  ##  `\ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"`
+  ##
   proc cudaGetChannelDesc*(desc: ptr cudaChannelFormatDesc; array: cudaArray_const_t): cudaError_t {.
       cdecl, importc: "cudaGetChannelDesc", dyn.}
   ## *
   ##  \brief Returns a channel descriptor using the specified format
-  ## 
+  ##
   ##  Returns a channel descriptor with format \p f and number of bits of each
   ##  component \p x, \p y, \p z, and \p w.  The ::cudaChannelFormatDesc is
   ##  defined as:
@@ -5982,102 +5982,102 @@ when not defined(CUDA_RUNTIME_API_H):
   ##     enum cudaChannelFormatKind f;
   ##   };
   ##  \endcode
-  ## 
+  ##
   ##  where ::cudaChannelFormatKind is one of ::cudaChannelFormatKindSigned,
   ##  ::cudaChannelFormatKindUnsigned, or ::cudaChannelFormatKindFloat.
-  ## 
+  ##
   ##  \param x - X component
   ##  \param y - Y component
   ##  \param z - Z component
   ##  \param w - W component
   ##  \param f - Channel format
-  ## 
+  ##
   ##  \return
   ##  Channel descriptor with format \p f
-  ## 
+  ##
   ##  \sa \ref ::cudaCreateChannelDesc(void) "cudaCreateChannelDesc (C++ API)",
   ##  ::cudaGetChannelDesc, ::cudaGetTextureReference,
-  ##  \ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",
-  ##  \ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",
-  ##  \ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",
-  ##  \ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)",
-  ##  \ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"
-  ## 
+  ##  `\ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",`
+  ##  `\ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",`
+  ##  `\ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",`
+  ##  `\ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)",`
+  ##  `\ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"`
+  ##
   proc cudaCreateChannelDesc*(x: cint; y: cint; z: cint; w: cint;
                              f: cudaChannelFormatKind): cudaChannelFormatDesc {.
       cdecl, importc: "cudaCreateChannelDesc", dyn.}
   ## *
   ##  \brief Binds a memory area to a texture
-  ## 
+  ##
   ##  Binds \p size bytes of the memory area pointed to by \p devPtr to the
   ##  texture reference \p texref. \p desc describes how the memory is interpreted
   ##  when fetching values from the texture. Any memory previously bound to
   ##  \p texref is unbound.
-  ## 
+  ##
   ##  Since the hardware enforces an alignment requirement on texture base
   ##  addresses,
-  ##  \ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture()"
-  ##  returns in \p *offset a byte offset that
+  ##  `\ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture()"`
+  ##  `returns in \p *offset a byte offset that`
   ##  must be applied to texture fetches in order to read from the desired memory.
   ##  This offset must be divided by the texel size and passed to kernels that
   ##  read from the texture so they can be applied to the ::tex1Dfetch() function.
   ##  If the device memory pointer was returned from ::cudaMalloc(), the offset is
   ##  guaranteed to be 0 and NULL may be passed as the \p offset parameter.
-  ## 
+  ##
   ##  The total number of elements (or texels) in the linear address range
   ##  cannot exceed ::cudaDeviceProp::maxTexture1DLinear[0].
   ##  The number of elements is computed as (\p size / elementSize),
   ##  where elementSize is determined from \p desc.
-  ## 
+  ##
   ##  \param offset - Offset in bytes
   ##  \param texref - Texture to bind
   ##  \param devPtr - Memory area on device
   ##  \param desc   - Channel format
   ##  \param size   - Size of the memory area pointed to by devPtr
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidDevicePointer,
   ##  ::cudaErrorInvalidTexture
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa \ref ::cudaCreateChannelDesc(int, int, int, int, cudaChannelFormatKind) "cudaCreateChannelDesc (C API)",
   ##  ::cudaGetChannelDesc, ::cudaGetTextureReference,
-  ##  \ref ::cudaBindTexture(size_t*, const struct texture< T, dim, readMode>&, const void*, const struct cudaChannelFormatDesc&, size_t) "cudaBindTexture (C++ API)",
-  ##  \ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",
-  ##  \ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",
-  ##  \ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)",
-  ##  \ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"
-  ## 
+  ##  `\ref ::cudaBindTexture(size_t*, const struct texture< T, dim, readMode>&, const void*, const struct cudaChannelFormatDesc&, size_t) "cudaBindTexture (C++ API)",`
+  ##  `\ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",`
+  ##  `\ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",`
+  ##  `\ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)",`
+  ##  `\ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"`
+  ##
   proc cudaBindTexture*(offset: ptr csize; texref: ptr textureReference;
                        devPtr: pointer; desc: ptr cudaChannelFormatDesc; size: csize): cudaError_t {.
       cdecl, importc: "cudaBindTexture", dyn.}
   ## *
   ##  \brief Binds a 2D memory area to a texture
-  ## 
+  ##
   ##  Binds the 2D memory area pointed to by \p devPtr to the
   ##  texture reference \p texref. The size of the area is constrained by
   ##  \p width in texel units, \p height in texel units, and \p pitch in byte
   ##  units. \p desc describes how the memory is interpreted when fetching values
   ##  from the texture. Any memory previously bound to \p texref is unbound.
-  ## 
+  ##
   ##  Since the hardware enforces an alignment requirement on texture base
-  ##  addresses, ::cudaBindTexture2D() returns in \p *offset a byte offset that
+  ##  `addresses, ::cudaBindTexture2D() returns in \p *offset a byte offset that`
   ##  must be applied to texture fetches in order to read from the desired memory.
   ##  This offset must be divided by the texel size and passed to kernels that
   ##  read from the texture so they can be applied to the ::tex2D() function.
   ##  If the device memory pointer was returned from ::cudaMalloc(), the offset is
   ##  guaranteed to be 0 and NULL may be passed as the \p offset parameter.
-  ## 
+  ##
   ##  \p width and \p height, which are specified in elements (or texels), cannot
   ##  exceed ::cudaDeviceProp::maxTexture2DLinear[0] and ::cudaDeviceProp::maxTexture2DLinear[1]
   ##  respectively. \p pitch, which is specified in bytes, cannot exceed
   ##  ::cudaDeviceProp::maxTexture2DLinear[2].
-  ## 
+  ##
   ##  The driver returns ::cudaErrorInvalidValue if \p pitch is not a multiple of
   ##  ::cudaDeviceProp::texturePitchAlignment.
-  ## 
+  ##
   ##  \param offset - Offset in bytes
   ##  \param texref - Texture reference to bind
   ##  \param devPtr - 2D memory area on device
@@ -6085,251 +6085,251 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  \param width  - Width in texel units
   ##  \param height - Height in texel units
   ##  \param pitch  - Pitch in bytes
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidDevicePointer,
   ##  ::cudaErrorInvalidTexture
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa \ref ::cudaCreateChannelDesc(int, int, int, int, cudaChannelFormatKind) "cudaCreateChannelDesc (C API)",
   ##  ::cudaGetChannelDesc, ::cudaGetTextureReference,
-  ##  \ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",
-  ##  \ref ::cudaBindTexture2D(size_t*, const struct texture< T, dim, readMode>&, const void*, const struct cudaChannelFormatDesc&, size_t, size_t, size_t) "cudaBindTexture2D (C++ API)",
-  ##  \ref ::cudaBindTexture2D(size_t*, const struct texture<T, dim, readMode>&, const void*, size_t, size_t, size_t) "cudaBindTexture2D (C++ API, inherited channel descriptor)",
-  ##  \ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",
-  ##  \ref ::cudaUnbindTexture(const struct textureReference*) "cudaBindTextureToArray (C API)",
-  ##  \ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"
-  ## 
+  ##  `\ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",`
+  ##  `\ref ::cudaBindTexture2D(size_t*, const struct texture< T, dim, readMode>&, const void*, const struct cudaChannelFormatDesc&, size_t, size_t, size_t) "cudaBindTexture2D (C++ API)",`
+  ##  `\ref ::cudaBindTexture2D(size_t*, const struct texture<T, dim, readMode>&, const void*, size_t, size_t, size_t) "cudaBindTexture2D (C++ API, inherited channel descriptor)",`
+  ##  `\ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",`
+  ##  `\ref ::cudaUnbindTexture(const struct textureReference*) "cudaBindTextureToArray (C API)",`
+  ##  `\ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"`
+  ##
   proc cudaBindTexture2D*(offset: ptr csize; texref: ptr textureReference;
                          devPtr: pointer; desc: ptr cudaChannelFormatDesc;
                          width: csize; height: csize; pitch: csize): cudaError_t {.
       cdecl, importc: "cudaBindTexture2D", dyn.}
   ## *
   ##  \brief Binds an array to a texture
-  ## 
+  ##
   ##  Binds the CUDA array \p array to the texture reference \p texref.
   ##  \p desc describes how the memory is interpreted when fetching values from
   ##  the texture. Any CUDA array previously bound to \p texref is unbound.
-  ## 
+  ##
   ##  \param texref - Texture to bind
   ##  \param array  - Memory array on device
   ##  \param desc   - Channel format
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidDevicePointer,
   ##  ::cudaErrorInvalidTexture
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa \ref ::cudaCreateChannelDesc(int, int, int, int, cudaChannelFormatKind) "cudaCreateChannelDesc (C API)",
   ##  ::cudaGetChannelDesc, ::cudaGetTextureReference,
-  ##  \ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",
-  ##  \ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",
+  ##  `\ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",`
+  ##  `\ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",`
   ##  \ref ::cudaBindTextureToArray(const struct texture< T, dim, readMode>&, cudaArray_const_t, const struct cudaChannelFormatDesc&) "cudaBindTextureToArray (C++ API)",
-  ##  \ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)",
-  ##  \ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"
-  ## 
+  ##  `\ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)",`
+  ##  `\ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"`
+  ##
   proc cudaBindTextureToArray*(texref: ptr textureReference;
                               array: cudaArray_const_t;
                               desc: ptr cudaChannelFormatDesc): cudaError_t {.cdecl,
       importc: "cudaBindTextureToArray", dyn.}
   ## *
   ##  \brief Binds a mipmapped array to a texture
-  ## 
+  ##
   ##  Binds the CUDA mipmapped array \p mipmappedArray to the texture reference \p texref.
   ##  \p desc describes how the memory is interpreted when fetching values from
   ##  the texture. Any CUDA mipmapped array previously bound to \p texref is unbound.
-  ## 
+  ##
   ##  \param texref         - Texture to bind
   ##  \param mipmappedArray - Memory mipmapped array on device
   ##  \param desc           - Channel format
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidDevicePointer,
   ##  ::cudaErrorInvalidTexture
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa \ref ::cudaCreateChannelDesc(int, int, int, int, cudaChannelFormatKind) "cudaCreateChannelDesc (C API)",
   ##  ::cudaGetChannelDesc, ::cudaGetTextureReference,
-  ##  \ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",
-  ##  \ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",
+  ##  `\ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",`
+  ##  `\ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",`
   ##  \ref ::cudaBindTextureToArray(const struct texture< T, dim, readMode>&, cudaArray_const_t, const struct cudaChannelFormatDesc&) "cudaBindTextureToArray (C++ API)",
-  ##  \ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)",
-  ##  \ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"
-  ## 
+  ##  `\ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)",`
+  ##  `\ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"`
+  ##
   proc cudaBindTextureToMipmappedArray*(texref: ptr textureReference; mipmappedArray: cudaMipmappedArray_const_t;
                                        desc: ptr cudaChannelFormatDesc): cudaError_t {.
       cdecl, importc: "cudaBindTextureToMipmappedArray", dyn.}
   ## *
   ##  \brief Unbinds a texture
-  ## 
+  ##
   ##  Unbinds the texture bound to \p texref.
-  ## 
+  ##
   ##  \param texref - Texture to unbind
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa \ref ::cudaCreateChannelDesc(int, int, int, int, cudaChannelFormatKind) "cudaCreateChannelDesc (C API)",
   ##  ::cudaGetChannelDesc, ::cudaGetTextureReference,
-  ##  \ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",
-  ##  \ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",
-  ##  \ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",
+  ##  `\ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",`
+  ##  `\ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",`
+  ##  `\ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",`
   ##  \ref ::cudaUnbindTexture(const struct texture< T, dim, readMode>&) "cudaUnbindTexture (C++ API)",
-  ##  \ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"
-  ## 
+  ##  `\ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)"`
+  ##
   proc cudaUnbindTexture*(texref: ptr textureReference): cudaError_t {.cdecl,
       importc: "cudaUnbindTexture", dyn.}
   ## *
   ##  \brief Get the alignment offset of a texture
-  ## 
-  ##  Returns in \p *offset the offset that was returned when texture reference
+  ##
+  ##  `Returns in \p *offset the offset that was returned when texture reference`
   ##  \p texref was bound.
-  ## 
+  ##
   ##  \param offset - Offset of texture reference in bytes
   ##  \param texref - Texture to get offset of
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidTexture,
   ##  ::cudaErrorInvalidTextureBinding
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa \ref ::cudaCreateChannelDesc(int, int, int, int, cudaChannelFormatKind) "cudaCreateChannelDesc (C API)",
   ##  ::cudaGetChannelDesc, ::cudaGetTextureReference,
-  ##  \ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",
-  ##  \ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",
-  ##  \ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",
-  ##  \ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)",
-  ##  \ref ::cudaGetTextureAlignmentOffset(size_t*, const struct texture< T, dim, readMode>&) "cudaGetTextureAlignmentOffset (C++ API)"
-  ## 
+  ##  `\ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",`
+  ##  `\ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",`
+  ##  `\ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",`
+  ##  `\ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)",`
+  ##  `\ref ::cudaGetTextureAlignmentOffset(size_t*, const struct texture< T, dim, readMode>&) "cudaGetTextureAlignmentOffset (C++ API)"`
+  ##
   proc cudaGetTextureAlignmentOffset*(offset: ptr csize;
                                      texref: ptr textureReference): cudaError_t {.
       cdecl, importc: "cudaGetTextureAlignmentOffset", dyn.}
   ## *
   ##  \brief Get the texture reference associated with a symbol
-  ## 
-  ##  Returns in \p *texref the structure associated to the texture reference
+  ##
+  ##  `Returns in \p *texref the structure associated to the texture reference`
   ##  defined by symbol \p symbol.
-  ## 
+  ##
   ##  \param texref - Texture reference associated with symbol
   ##  \param symbol - Texture to get reference for
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidTexture
   ##  \notefnerr
   ##  \note_string_api_deprecation_50
-  ## 
+  ##
   ##  \sa \ref ::cudaCreateChannelDesc(int, int, int, int, cudaChannelFormatKind) "cudaCreateChannelDesc (C API)",
   ##  ::cudaGetChannelDesc,
-  ##  \ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)",
-  ##  \ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",
-  ##  \ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",
-  ##  \ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",
-  ##  \ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)"
-  ## 
+  ##  `\ref ::cudaGetTextureAlignmentOffset(size_t*, const struct textureReference*) "cudaGetTextureAlignmentOffset (C API)",`
+  ##  `\ref ::cudaBindTexture(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t) "cudaBindTexture (C API)",`
+  ##  `\ref ::cudaBindTexture2D(size_t*, const struct textureReference*, const void*, const struct cudaChannelFormatDesc*, size_t, size_t, size_t) "cudaBindTexture2D (C API)",`
+  ##  `\ref ::cudaBindTextureToArray(const struct textureReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindTextureToArray (C API)",`
+  ##  `\ref ::cudaUnbindTexture(const struct textureReference*) "cudaUnbindTexture (C API)"`
+  ##
   proc cudaGetTextureReference*(texref: ptr ptr textureReference; symbol: pointer): cudaError_t {.
       cdecl, importc: "cudaGetTextureReference", dyn.}
   ## * @}
   ##  END CUDART_TEXTURE
   ## *
   ##  \defgroup CUDART_SURFACE Surface Reference Management
-  ## 
+  ##
   ##  ___MANBRIEF___ surface reference management functions of the CUDA runtime
   ##  API (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the low level surface reference management functions
   ##  of the CUDA runtime application programming interface.
-  ## 
+  ##
   ##  Some functions have overloaded C++ API template versions documented separately in the
   ##  \ref CUDART_HIGHLEVEL "C++ API Routines" module.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Binds an array to a surface
-  ## 
+  ##
   ##  Binds the CUDA array \p array to the surface reference \p surfref.
   ##  \p desc describes how the memory is interpreted when fetching values from
   ##  the surface. Any CUDA array previously bound to \p surfref is unbound.
-  ## 
+  ##
   ##  \param surfref - Surface to bind
   ##  \param array  - Memory array on device
   ##  \param desc   - Channel format
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue,
   ##  ::cudaErrorInvalidSurface
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa \ref ::cudaBindSurfaceToArray(const struct surface< T, dim>&, cudaArray_const_t, const struct cudaChannelFormatDesc&) "cudaBindSurfaceToArray (C++ API)",
   ##  \ref ::cudaBindSurfaceToArray(const struct surface< T, dim>&, cudaArray_const_t) "cudaBindSurfaceToArray (C++ API, inherited channel descriptor)",
   ##  ::cudaGetSurfaceReference
-  ## 
+  ##
   proc cudaBindSurfaceToArray*(surfref: ptr surfaceReference;
                               array: cudaArray_const_t;
                               desc: ptr cudaChannelFormatDesc): cudaError_t {.cdecl,
       importc: "cudaBindSurfaceToArray", dyn.}
   ## *
   ##  \brief Get the surface reference associated with a symbol
-  ## 
-  ##  Returns in \p *surfref the structure associated to the surface reference
+  ##
+  ##  `Returns in \p *surfref the structure associated to the surface reference`
   ##  defined by symbol \p symbol.
-  ## 
+  ##
   ##  \param surfref - Surface reference associated with symbol
   ##  \param symbol - Surface to get reference for
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidSurface
   ##  \notefnerr
   ##  \note_string_api_deprecation_50
-  ## 
-  ##  \sa \ref ::cudaBindSurfaceToArray(const struct surfaceReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindSurfaceToArray (C API)"
-  ## 
+  ##
+  ##  `\sa \ref ::cudaBindSurfaceToArray(const struct surfaceReference*, cudaArray_const_t, const struct cudaChannelFormatDesc*) "cudaBindSurfaceToArray (C API)"`
+  ##
   proc cudaGetSurfaceReference*(surfref: ptr ptr surfaceReference; symbol: pointer): cudaError_t {.
       cdecl, importc: "cudaGetSurfaceReference", dyn.}
   ## * @}
   ##  END CUDART_SURFACE
   ## *
   ##  \defgroup CUDART_TEXTURE_OBJECT Texture Object Management
-  ## 
+  ##
   ##  ___MANBRIEF___ texture object management functions of the CUDA runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the low level texture object management functions
   ##  of the CUDA runtime application programming interface. The texture
   ##  object API is only supported on devices of compute capability 3.0 or higher.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Creates a texture object
-  ## 
+  ##
   ##  Creates a texture object and returns it in \p pTexObject. \p pResDesc describes
   ##  the data to texture from. \p pTexDesc describes how the data should be sampled.
   ##  \p pResViewDesc is an optional argument that specifies an alternate format for
   ##  the data described by \p pResDesc, and also describes the subresource region
   ##  to restrict access to when texturing. \p pResViewDesc can only be specified if
   ##  the type of resource is a CUDA array or a CUDA mipmapped array.
-  ## 
+  ##
   ##  Texture objects are only supported on devices of compute capability 3.0 or higher.
   ##  Additionally, a texture object is an opaque value, and, as such, should only be
   ##  accessed through CUDA API calls.
-  ## 
+  ##
   ##  The ::cudaResourceDesc structure is defined as:
   ##  \code
   ##         struct cudaResourceDesc {
   ## 	        enum cudaResourceType resType;
-  ## 
+  ##
   ## 	        union {
   ## 		        struct {
   ## 			        cudaArray_t array;
@@ -6337,13 +6337,13 @@ when not defined(CUDA_RUNTIME_API_H):
   ##                 struct {
   ##                     cudaMipmappedArray_t mipmap;
   ##                 } mipmap;
-  ## 		        struct {
-  ## 			        void *devPtr;
+  ## 		        structb {
+  ## 	                        `void *devPtr;`
   ## 			        struct cudaChannelFormatDesc desc;
   ## 			        size_t sizeInBytes;
   ## 		        } linear;
   ## 		        struct {
-  ## 			        void *devPtr;
+  ## 	                        `void *devPtr;`
   ## 			        struct cudaChannelFormatDesc desc;
   ## 			        size_t width;
   ## 			        size_t height;
@@ -6363,22 +6363,22 @@ when not defined(CUDA_RUNTIME_API_H):
   ##             cudaResourceTypePitch2D        = 0x03
   ##         };
   ##  \endcode
-  ## 
+  ##
   ##  \par
   ##  If ::cudaResourceDesc::resType is set to ::cudaResourceTypeArray, ::cudaResourceDesc::res::array::array
   ##  must be set to a valid CUDA array handle.
-  ## 
+  ##
   ##  \par
   ##  If ::cudaResourceDesc::resType is set to ::cudaResourceTypeMipmappedArray, ::cudaResourceDesc::res::mipmap::mipmap
   ##  must be set to a valid CUDA mipmapped array handle and ::cudaTextureDesc::normalizedCoords must be set to true.
-  ## 
+  ##
   ##  \par
   ##  If ::cudaResourceDesc::resType is set to ::cudaResourceTypeLinear, ::cudaResourceDesc::res::linear::devPtr
   ##  must be set to a valid device pointer, that is aligned to ::cudaDeviceProp::textureAlignment.
   ##  ::cudaResourceDesc::res::linear::desc describes the format and the number of components per array element. ::cudaResourceDesc::res::linear::sizeInBytes
   ##  specifies the size of the array in bytes. The total number of elements in the linear address range cannot exceed
   ##  ::cudaDeviceProp::maxTexture1DLinear. The number of elements is computed as (sizeInBytes / sizeof(desc)).
-  ## 
+  ##
   ##  \par
   ##  If ::cudaResourceDesc::resType is set to ::cudaResourceTypePitch2D, ::cudaResourceDesc::res::pitch2D::devPtr
   ##  must be set to a valid device pointer, that is aligned to ::cudaDeviceProp::textureAlignment.
@@ -6387,8 +6387,8 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  ::cudaDeviceProp::maxTexture2DLinear[0] and ::cudaDeviceProp::maxTexture2DLinear[1] respectively.
   ##  ::cudaResourceDesc::res::pitch2D::pitchInBytes specifies the pitch between two rows in bytes and has to be aligned to
   ##  ::cudaDeviceProp::texturePitchAlignment. Pitch cannot exceed ::cudaDeviceProp::maxTexture2DLinear[2].
-  ## 
-  ## 
+  ##
+  ##
   ##  The ::cudaTextureDesc struct is defined as
   ##  \code
   ##         struct cudaTextureDesc {
@@ -6417,7 +6417,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    \endcode
   ##    This is ignored if ::cudaResourceDesc::resType is ::cudaResourceTypeLinear. Also, if ::cudaTextureDesc::normalizedCoords
   ##    is set to zero, ::cudaAddressModeWrap and ::cudaAddressModeMirror won't be supported and will be switched to ::cudaAddressModeClamp.
-  ## 
+  ##
   ##  - ::cudaTextureDesc::filterMode specifies the filtering mode to be used when fetching from the texture. ::cudaTextureFilterMode is defined as:
   ##    \code
   ##         enum cudaTextureFilterMode {
@@ -6426,7 +6426,7 @@ when not defined(CUDA_RUNTIME_API_H):
   ##         };
   ##    \endcode
   ##    This is ignored if ::cudaResourceDesc::resType is ::cudaResourceTypeLinear.
-  ## 
+  ##
   ##  - ::cudaTextureDesc::readMode specifies whether integer data should be converted to floating point or not. ::cudaTextureReadMode is defined as:
   ##    \code
   ##         enum cudaTextureReadMode {
@@ -6436,9 +6436,9 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    \endcode
   ##    Note that this applies only to 8-bit and 16-bit integer formats. 32-bit integer format would not be promoted, regardless of
   ##    whether or not this ::cudaTextureDesc::readMode is set ::cudaReadModeNormalizedFloat is specified.
-  ## 
+  ##
   ##  - ::cudaTextureDesc::sRGB specifies whether sRGB to linear conversion should be performed during texture fetch.
-  ## 
+  ##
   ##  - ::cudaTextureDesc::borderColor specifies the float values of color. where:
   ##    ::cudaTextureDesc::borderColor[0] contains value of 'R',
   ##    ::cudaTextureDesc::borderColor[1] contains value of 'G',
@@ -6446,21 +6446,21 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    ::cudaTextureDesc::borderColor[3] contains value of 'A'
   ##    Note that application using integer border color values will need to <reinterpret_cast> these values to float.
   ##    The values are set only when the addressing mode specified by ::cudaTextureDesc::addressMode is cudaAddressModeBorder.
-  ## 
+  ##
   ##  - ::cudaTextureDesc::normalizedCoords specifies whether the texture coordinates will be normalized or not.
-  ## 
+  ##
   ##  - ::cudaTextureDesc::maxAnisotropy specifies the maximum anistropy ratio to be used when doing anisotropic filtering. This value will be
   ##    clamped to the range [1,16].
-  ## 
+  ##
   ##  - ::cudaTextureDesc::mipmapFilterMode specifies the filter mode when the calculated mipmap level lies between two defined mipmap levels.
-  ## 
+  ##
   ##  - ::cudaTextureDesc::mipmapLevelBias specifies the offset to be applied to the calculated mipmap level.
-  ## 
+  ##
   ##  - ::cudaTextureDesc::minMipmapLevelClamp specifies the lower end of the mipmap level range to clamp access to.
-  ## 
+  ##
   ##  - ::cudaTextureDesc::maxMipmapLevelClamp specifies the upper end of the mipmap level range to clamp access to.
-  ## 
-  ## 
+  ##
+  ##
   ##  The ::cudaResourceViewDesc struct is defined as
   ##  \code
   ##         struct cudaResourceViewDesc {
@@ -6481,44 +6481,44 @@ when not defined(CUDA_RUNTIME_API_H):
   ##    with 2 or 4 channels, depending on the block compressed format. For ex., BC1 and BC4 require the underlying CUDA array to have
   ##    a 32-bit unsigned int with 2 channels. The other BC formats require the underlying resource to have the same 32-bit unsigned int
   ##    format but with 4 channels.
-  ## 
+  ##
   ##  - ::cudaResourceViewDesc::width specifies the new width of the texture data. If the resource view format is a block
   ##    compressed format, this value has to be 4 times the original width of the resource. For non block compressed formats,
   ##    this value has to be equal to that of the original resource.
-  ## 
+  ##
   ##  - ::cudaResourceViewDesc::height specifies the new height of the texture data. If the resource view format is a block
   ##    compressed format, this value has to be 4 times the original height of the resource. For non block compressed formats,
   ##    this value has to be equal to that of the original resource.
-  ## 
+  ##
   ##  - ::cudaResourceViewDesc::depth specifies the new depth of the texture data. This value has to be equal to that of the
   ##    original resource.
-  ## 
+  ##
   ##  - ::cudaResourceViewDesc::firstMipmapLevel specifies the most detailed mipmap level. This will be the new mipmap level zero.
   ##    For non-mipmapped resources, this value has to be zero.::cudaTextureDesc::minMipmapLevelClamp and ::cudaTextureDesc::maxMipmapLevelClamp
   ##    will be relative to this value. For ex., if the firstMipmapLevel is set to 2, and a minMipmapLevelClamp of 1.2 is specified,
   ##    then the actual minimum mipmap level clamp will be 3.2.
-  ## 
+  ##
   ##  - ::cudaResourceViewDesc::lastMipmapLevel specifies the least detailed mipmap level. For non-mipmapped resources, this value
   ##    has to be zero.
-  ## 
+  ##
   ##  - ::cudaResourceViewDesc::firstLayer specifies the first layer index for layered textures. This will be the new layer zero.
   ##    For non-layered resources, this value has to be zero.
-  ## 
+  ##
   ##  - ::cudaResourceViewDesc::lastLayer specifies the last layer index for layered textures. For non-layered resources,
   ##    this value has to be zero.
-  ## 
-  ## 
+  ##
+  ##
   ##  \param pTexObject   - Texture object to create
   ##  \param pResDesc     - Resource descriptor
   ##  \param pTexDesc     - Texture descriptor
   ##  \param pResViewDesc - Resource view descriptor
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
-  ## 
+  ##
   ##  \sa ::cudaDestroyTextureObject
-  ## 
+  ##
   proc cudaCreateTextureObject*(pTexObject: ptr cudaTextureObject_t;
                                pResDesc: ptr cudaResourceDesc;
                                pTexDesc: ptr cudaTextureDesc;
@@ -6526,68 +6526,68 @@ when not defined(CUDA_RUNTIME_API_H):
       cdecl, importc: "cudaCreateTextureObject", dyn.}
   ## *
   ##  \brief Destroys a texture object
-  ## 
+  ##
   ##  Destroys the texture object specified by \p texObject.
-  ## 
+  ##
   ##  \param texObject - Texture object to destroy
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
-  ## 
+  ##
   ##  \sa ::cudaCreateTextureObject
-  ## 
+  ##
   proc cudaDestroyTextureObject*(texObject: cudaTextureObject_t): cudaError_t {.
       cdecl, importc: "cudaDestroyTextureObject", dyn.}
   ## *
   ##  \brief Returns a texture object's resource descriptor
-  ## 
+  ##
   ##  Returns the resource descriptor for the texture object specified by \p texObject.
-  ## 
+  ##
   ##  \param pResDesc  - Resource descriptor
   ##  \param texObject - Texture object
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
-  ## 
+  ##
   ##  \sa ::cudaCreateTextureObject
-  ## 
+  ##
   proc cudaGetTextureObjectResourceDesc*(pResDesc: ptr cudaResourceDesc;
                                         texObject: cudaTextureObject_t): cudaError_t {.
       cdecl, importc: "cudaGetTextureObjectResourceDesc", dyn.}
   ## *
   ##  \brief Returns a texture object's texture descriptor
-  ## 
+  ##
   ##  Returns the texture descriptor for the texture object specified by \p texObject.
-  ## 
+  ##
   ##  \param pTexDesc  - Texture descriptor
   ##  \param texObject - Texture object
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
-  ## 
+  ##
   ##  \sa ::cudaCreateTextureObject
-  ## 
+  ##
   proc cudaGetTextureObjectTextureDesc*(pTexDesc: ptr cudaTextureDesc;
                                        texObject: cudaTextureObject_t): cudaError_t {.
       cdecl, importc: "cudaGetTextureObjectTextureDesc", dyn.}
   ## *
   ##  \brief Returns a texture object's resource view descriptor
-  ## 
+  ##
   ##  Returns the resource view descriptor for the texture object specified by \p texObject.
   ##  If no resource view was specified, ::cudaErrorInvalidValue is returned.
-  ## 
+  ##
   ##  \param pResViewDesc - Resource view descriptor
   ##  \param texObject    - Texture object
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
-  ## 
+  ##
   ##  \sa ::cudaCreateTextureObject
-  ## 
+  ##
   proc cudaGetTextureObjectResourceViewDesc*(
       pResViewDesc: ptr cudaResourceViewDesc; texObject: cudaTextureObject_t): cudaError_t {.
       cdecl, importc: "cudaGetTextureObjectResourceViewDesc", dyn.}
@@ -6595,68 +6595,68 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  END CUDART_TEXTURE_OBJECT
   ## *
   ##  \defgroup CUDART_SURFACE_OBJECT Surface Object Management
-  ## 
+  ##
   ##  ___MANBRIEF___ surface object management functions of the CUDA runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the low level texture object management functions
   ##  of the CUDA runtime application programming interface. The surface object
   ##  API is only supported on devices of compute capability 3.0 or higher.
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Creates a surface object
-  ## 
+  ##
   ##  Creates a surface object and returns it in \p pSurfObject. \p pResDesc describes
   ##  the data to perform surface load/stores on. ::cudaResourceDesc::resType must be
   ##  ::cudaResourceTypeArray and  ::cudaResourceDesc::res::array::array
   ##  must be set to a valid CUDA array handle.
-  ## 
+  ##
   ##  Surface objects are only supported on devices of compute capability 3.0 or higher.
   ##  Additionally, a surface object is an opaque value, and, as such, should only be
   ##  accessed through CUDA API calls.
-  ## 
+  ##
   ##  \param pSurfObject - Surface object to create
   ##  \param pResDesc    - Resource descriptor
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
-  ## 
+  ##
   ##  \sa ::cudaDestroySurfaceObject
-  ## 
+  ##
   proc cudaCreateSurfaceObject*(pSurfObject: ptr cudaSurfaceObject_t;
                                pResDesc: ptr cudaResourceDesc): cudaError_t {.cdecl,
       importc: "cudaCreateSurfaceObject", dyn.}
   ## *
   ##  \brief Destroys a surface object
-  ## 
+  ##
   ##  Destroys the surface object specified by \p surfObject.
-  ## 
+  ##
   ##  \param surfObject - Surface object to destroy
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
-  ## 
+  ##
   ##  \sa ::cudaCreateSurfaceObject
-  ## 
+  ##
   proc cudaDestroySurfaceObject*(surfObject: cudaSurfaceObject_t): cudaError_t {.
       cdecl, importc: "cudaDestroySurfaceObject", dyn.}
   ## *
   ##  \brief Returns a surface object's resource descriptor
   ##  Returns the resource descriptor for the surface object specified by \p surfObject.
-  ## 
+  ##
   ##  \param pResDesc   - Resource descriptor
   ##  \param surfObject - Surface object
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
-  ## 
+  ##
   ##  \sa ::cudaCreateSurfaceObject
-  ## 
+  ##
   proc cudaGetSurfaceObjectResourceDesc*(pResDesc: ptr cudaResourceDesc;
                                         surfObject: cudaSurfaceObject_t): cudaError_t {.
       cdecl, importc: "cudaGetSurfaceObjectResourceDesc", dyn.}
@@ -6664,96 +6664,96 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  END CUDART_SURFACE_OBJECT
   ## *
   ##  \defgroup CUDART__VERSION Version Management
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ## *
   ##  \brief Returns the CUDA driver version
-  ## 
-  ##  Returns in \p *driverVersion the version number of the installed CUDA
+  ##
+  ##  `Returns in \p *driverVersion the version number of the installed CUDA`
   ##  driver. If no driver is installed, then 0 is returned as the driver
   ##  version (via \p driverVersion). This function automatically returns
   ##  ::cudaErrorInvalidValue if the \p driverVersion argument is NULL.
-  ## 
+  ##
   ##  \param driverVersion - Returns the CUDA driver version.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
   ##  \notefnerr
-  ## 
+  ##
   ##  \sa ::cudaRuntimeGetVersion
-  ## 
+  ##
   proc cudaDriverGetVersion*(driverVersion: ptr cint): cudaError_t {.cdecl,
       importc: "cudaDriverGetVersion", dyn.}
   ## *
   ##  \brief Returns the CUDA Runtime version
-  ## 
-  ##  Returns in \p *runtimeVersion the version number of the installed CUDA
+  ##
+  ##  `Returns in \p *runtimeVersion the version number of the installed CUDA`
   ##  Runtime. This function automatically returns ::cudaErrorInvalidValue if
   ##  the \p runtimeVersion argument is NULL.
-  ## 
+  ##
   ##  \param runtimeVersion - Returns the CUDA Runtime version.
-  ## 
+  ##
   ##  \return
   ##  ::cudaSuccess,
   ##  ::cudaErrorInvalidValue
-  ## 
+  ##
   ##  \sa ::cudaDriverGetVersion
-  ## 
+  ##
   proc cudaRuntimeGetVersion*(runtimeVersion: ptr cint): cudaError_t {.cdecl,
       importc: "cudaRuntimeGetVersion", dyn.}
   ## * @}
   ##  END CUDART__VERSION
-  ## * \cond impl_private
+  ## `* \cond impl_private`
   proc cudaGetExportTable*(ppExportTable: ptr pointer;
                           pExportTableId: ptr cudaUUID_t): cudaError_t {.cdecl,
       importc: "cudaGetExportTable", dyn.}
-  ## * \endcond impl_private
+  ## `* \endcond impl_private`
   ## *
   ##  \defgroup CUDART_HIGHLEVEL C++ API Routines
-  ## 
+  ##
   ##  ___MANBRIEF___ C++ high level API functions of the CUDA runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the C++ high level API functions of the CUDA runtime
   ##  application programming interface. To use these functions, your
   ##  application needs to be compiled with the \p nvcc compiler.
-  ## 
+  ##
   ##  \brief C++-style interface built on top of CUDA runtime API
-  ## 
+  ##
   ## *
   ##  \defgroup CUDART_DRIVER Interactions with the CUDA Driver API
-  ## 
+  ##
   ##  ___MANBRIEF___ interactions between CUDA Driver API and CUDA Runtime API
   ##  (___CURRENT_FILE___) ___ENDMANBRIEF___
-  ## 
+  ##
   ##  This section describes the interactions between the CUDA Driver API and the CUDA Runtime API
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ##  \section CUDART_CUDA_primary Primary Contexts
-  ## 
+  ##
   ##  There exists a one to one relationship between CUDA devices in the CUDA Runtime
   ##  API and ::CUcontext s in the CUDA Driver API within a process.  The specific
   ##  context which the CUDA Runtime API uses for a device is called the device's
   ##  primary context.  From the perspective of the CUDA Runtime API, a device and
   ##  its primary context are synonymous.
-  ## 
+  ##
   ##  \section CUDART_CUDA_init Initialization and Tear-Down
-  ## 
+  ##
   ##  CUDA Runtime API calls operate on the CUDA Driver API ::CUcontext which is current to
   ##  to the calling host thread.
-  ## 
+  ##
   ##  The function ::cudaSetDevice() makes the primary context for the
   ##  specified device current to the calling thread by calling ::cuCtxSetCurrent().
-  ## 
+  ##
   ##  The CUDA Runtime API will automatically initialize the primary context for
   ##  a device at the first CUDA Runtime API call which requires an active context.
   ##  If no ::CUcontext is current to the calling thread when a CUDA Runtime API call
   ##  which requires an active context is made, then the primary context for a device
   ##  will be selected, made current to the calling thread, and initialized.
-  ## 
+  ##
   ##  The context which the CUDA Runtime API initializes will be initialized using
   ##  the parameters specified by the CUDA Runtime API functions
   ##  ::cudaSetDeviceFlags(),
@@ -6766,30 +6766,30 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  called when the primary context for the specified device has already been initialized.
   ##  (or if the current device has already been initialized, in the case of
   ##  ::cudaSetDeviceFlags()).
-  ## 
+  ##
   ##  Primary contexts will remain active until they are explicitly deinitialized
   ##  using ::cudaDeviceReset().  The function ::cudaDeviceReset() will deinitialize the
   ##  primary context for the calling thread's current device immediately.  The context
   ##  will remain current to all of the threads that it was current to.  The next CUDA
   ##  Runtime API call on any thread which requires an active context will trigger the
   ##  reinitialization of that device's primary context.
-  ## 
+  ##
   ##  Note that there is no reference counting of the primary context's lifetime.  It is
   ##  recommended that the primary context not be deinitialized except just before exit
   ##  or to recover from an unspecified launch failure.
-  ## 
+  ##
   ##  \section CUDART_CUDA_context Context Interoperability
-  ## 
+  ##
   ##  Note that the use of multiple ::CUcontext s per device within a single process
   ##  will substantially degrade performance and is strongly discouraged.  Instead,
   ##  it is highly recommended that the implicit one-to-one device-to-context mapping
   ##  for the process provided by the CUDA Runtime API be used.
-  ## 
+  ##
   ##  If a non-primary ::CUcontext created by the CUDA Driver API is current to a
   ##  thread then the CUDA Runtime API calls to that thread will operate on that
   ##  ::CUcontext, with some exceptions listed below.  Interoperability between data
   ##  types is discussed in the following sections.
-  ## 
+  ##
   ##  The function ::cudaPointerGetAttributes() will return the error
   ##  ::cudaErrorIncompatibleDriverContext if the pointer being queried was allocated by a
   ##  non-primary context.  The function ::cudaDeviceEnablePeerAccess() and the rest of
@@ -6797,46 +6797,46 @@ when not defined(CUDA_RUNTIME_API_H):
   ##  To use the pointer query and peer access APIs with a context created using the
   ##  CUDA Driver API, it is necessary that the CUDA Driver API be used to access
   ##  these features.
-  ## 
+  ##
   ##  All CUDA Runtime API state (e.g, global variables' addresses and values) travels
   ##  with its underlying ::CUcontext.  In particular, if a ::CUcontext is moved from one
   ##  thread to another then all CUDA Runtime API state will move to that thread as well.
-  ## 
+  ##
   ##  Please note that attaching to legacy contexts (those with a version of 3010 as returned
   ##  by ::cuCtxGetApiVersion()) is not possible. The CUDA Runtime will return
   ##  ::cudaErrorIncompatibleDriverContext in such cases.
-  ## 
+  ##
   ##  \section CUDART_CUDA_stream Interactions between CUstream and cudaStream_t
-  ## 
+  ##
   ##  The types ::CUstream and ::cudaStream_t are identical and may be used interchangeably.
-  ## 
+  ##
   ##  \section CUDART_CUDA_event Interactions between CUevent and cudaEvent_t
-  ## 
+  ##
   ##  The types ::CUevent and ::cudaEvent_t are identical and may be used interchangeably.
-  ## 
+  ##
   ##  \section CUDART_CUDA_array Interactions between CUarray and cudaArray_t
-  ## 
-  ##  The types ::CUarray and struct ::cudaArray * represent the same data type and may be used
+  ##
+  ##  `The types ::CUarray and struct ::cudaArray * represent the same data type and may be used`
   ##  interchangeably by casting the two types between each other.
-  ## 
-  ##  In order to use a ::CUarray in a CUDA Runtime API function which takes a struct ::cudaArray *,
-  ##  it is necessary to explicitly cast the ::CUarray to a struct ::cudaArray *.
-  ## 
-  ##  In order to use a struct ::cudaArray * in a CUDA Driver API function which takes a ::CUarray,
-  ##  it is necessary to explicitly cast the struct ::cudaArray * to a ::CUarray .
-  ## 
+  ##
+  ##  `In order to use a ::CUarray in a CUDA Runtime API function which takes a struct ::cudaArray *,`
+  ##  `it is necessary to explicitly cast the ::CUarray to a struct ::cudaArray *.`
+  ##
+  ##  `In order to use a struct ::cudaArray * in a CUDA Driver API function which takes a ::CUarray,`
+  ##  `it is necessary to explicitly cast the struct ::cudaArray * to a ::CUarray .`
+  ##
   ##  \section CUDART_CUDA_graphicsResource Interactions between CUgraphicsResource and cudaGraphicsResource_t
-  ## 
+  ##
   ##  The types ::CUgraphicsResource and ::cudaGraphicsResource_t represent the same data type and may be used
   ##  interchangeably by casting the two types between each other.
-  ## 
+  ##
   ##  In order to use a ::CUgraphicsResource in a CUDA Runtime API function which takes a
   ##  ::cudaGraphicsResource_t, it is necessary to explicitly cast the ::CUgraphicsResource
   ##  to a ::cudaGraphicsResource_t.
-  ## 
+  ##
   ##  In order to use a ::cudaGraphicsResource_t in a CUDA Driver API function which takes a
   ##  ::CUgraphicsResource, it is necessary to explicitly cast the ::cudaGraphicsResource_t
   ##  to a ::CUgraphicsResource.
-  ## 
+  ##
   ##  @}
-  ## 
+  ##

--- a/nimcuda/cudnn.nim
+++ b/nimcuda/cudnn.nim
@@ -13,27 +13,27 @@ else:
   {.pragma: dyn, dynlib: libName.}
 type
   cudnnTensorStruct = object
-  
+
   cudnnConvolutionStruct = object
-  
+
   cudnnPoolingStruct = object
-  
+
   cudnnFilterStruct = object
-  
+
   cudnnLRNStruct = object
-  
+
   cudnnActivationStruct = object
-  
+
   cudnnSpatialTransformerStruct = object
-  
+
   cudnnOpTensorStruct = object
-  
+
   cudnnDropoutStruct = object
-  
+
 
 ##    cudnn : Neural Networks Library
-## 
-## 
+##
+##
 
 when not defined(CUDNN_H):
   const
@@ -47,13 +47,13 @@ when not defined(CUDNN_H):
 
   type
     cudnnContext* = object
-    
+
   type
     cudnnHandle_t* = ptr cudnnContext
   proc cudnnGetVersion*(): csize {.cdecl, importc: "cudnnGetVersion", dyn.}
-  ## 
+  ##
   ##  CUDNN return codes
-  ## 
+  ##
   type
     cudnnStatus_t* {.size: sizeof(cint).} = enum
       CUDNN_STATUS_SUCCESS = 0, CUDNN_STATUS_NOT_INITIALIZED = 1,
@@ -83,15 +83,15 @@ when not defined(CUDNN_H):
     cudnnActivationDescriptor_t* = ptr cudnnActivationStruct
     cudnnSpatialTransformerDescriptor_t* = ptr cudnnSpatialTransformerStruct
     cudnnOpTensorDescriptor_t* = ptr cudnnOpTensorStruct
-  ## 
+  ##
   ##  CUDNN data type
-  ## 
+  ##
   type
     cudnnDataType_t* {.size: sizeof(cint).} = enum
       CUDNN_DATA_FLOAT = 0, CUDNN_DATA_DOUBLE = 1, CUDNN_DATA_HALF = 2
-  ## 
+  ##
   ##  CUDNN propagate Nan
-  ## 
+  ##
   type
     cudnnNanPropagation_t* {.size: sizeof(cint).} = enum
       CUDNN_NOT_PROPAGATE_NAN = 0, CUDNN_PROPAGATE_NAN = 1
@@ -145,45 +145,45 @@ when not defined(CUDNN_H):
                                   dataType: ptr cudnnDataType_t; nbDims: ptr cint;
                                   dimA: ptr cint; strideA: ptr cint): cudnnStatus_t {.
       cdecl, importc: "cudnnGetTensorNdDescriptor", dyn.}
-  ##  PixelOffset( n, c, h, w ) = n *input_stride + c * feature_stride + h * h_stride + w * w_stride
-  ## 
+  ##  `PixelOffset( n, c, h, w ) = n *input_stride + c * feature_stride + h * h_stride + w * w_stride`
+  ##
   ##    1)Example of all images in row major order one batch of features after the other (with an optional padding on row)
   ##    input_stride :  c x h x h_stride
   ##    feature_stride : h x h_stride
   ##    h_stride  :  >= w  ( h_stride = w if no padding)
   ##    w_stride  : 1
-  ## 
-  ## 
+  ##
+  ##
   ##    2)Example of all images in row major with features maps interleaved
   ##    input_stride :  c x h x h_stride
   ##    feature_stride : 1
   ##    h_stride  :  w x c
   ##    w_stride  : c
-  ## 
+  ##
   ##    3)Example of all images in column major order one batch of features after the other (with optional padding on column)
   ##    input_stride :  c x w x w_stride
   ##    feature_stride : w x w_stride
   ##    h_stride  :  1
   ##    w_stride  :  >= h
-  ## 
-  ## 
+  ##
+  ##
   ##  Destroy an instance of Tensor4d descriptor
   proc cudnnDestroyTensorDescriptor*(tensorDesc: cudnnTensorDescriptor_t): cudnnStatus_t {.
       cdecl, importc: "cudnnDestroyTensorDescriptor", dyn.}
-  ##  Tensor layout conversion helper (y = alpha * x + beta * y)
+  ##  `Tensor layout conversion helper (y = alpha * x + beta * y)`
   proc cudnnTransformTensor*(handle: cudnnHandle_t; alpha: pointer;
                             xDesc: cudnnTensorDescriptor_t; x: pointer;
                             beta: pointer; yDesc: cudnnTensorDescriptor_t;
                             y: pointer): cudnnStatus_t {.cdecl,
       importc: "cudnnTransformTensor", dyn.}
-  ##  Tensor Bias addition : C = alpha * A + beta * C
+  ##  `Tensor Bias addition : C = alpha * A + beta * C`
   proc cudnnAddTensor*(handle: cudnnHandle_t; alpha: pointer;
                       aDesc: cudnnTensorDescriptor_t; A: pointer; beta: pointer;
                       cDesc: cudnnTensorDescriptor_t; C: pointer): cudnnStatus_t {.
       cdecl, importc: "cudnnAddTensor", dyn.}
-  ## 
+  ##
   ##  CUDNN OpTensor op type
-  ## 
+  ##
   type
     cudnnOpTensorOp_t* {.size: sizeof(cint).} = enum
       CUDNN_OP_TENSOR_ADD = 0, CUDNN_OP_TENSOR_MUL = 1, CUDNN_OP_TENSOR_MIN = 2,
@@ -202,7 +202,7 @@ when not defined(CUDNN_H):
       cdecl, importc: "cudnnGetOpTensorDescriptor", dyn.}
   proc cudnnDestroyOpTensorDescriptor*(opTensorDesc: cudnnOpTensorDescriptor_t): cudnnStatus_t {.
       cdecl, importc: "cudnnDestroyOpTensorDescriptor", dyn.}
-  ##  Tensor Bias operation : C = op( alpha1 * A, alpha2 * B ) + beta * C
+  ##  `Tensor Bias operation : C = op( alpha1 * A, alpha2 * B ) + beta * C`
   proc cudnnOpTensor*(handle: cudnnHandle_t;
                      opTensorDesc: cudnnOpTensorDescriptor_t; alpha1: pointer;
                      aDesc: cudnnTensorDescriptor_t; A: pointer; alpha2: pointer;
@@ -213,13 +213,13 @@ when not defined(CUDNN_H):
   proc cudnnSetTensor*(handle: cudnnHandle_t; yDesc: cudnnTensorDescriptor_t;
                       y: pointer; valuePtr: pointer): cudnnStatus_t {.cdecl,
       importc: "cudnnSetTensor", dyn.}
-  ##  Scale all values of a tensor by a given factor : y[i] = alpha * y[i]
+  ##  `Scale all values of a tensor by a given factor : y[i] = alpha * y[i]`
   proc cudnnScaleTensor*(handle: cudnnHandle_t; yDesc: cudnnTensorDescriptor_t;
                         y: pointer; alpha: pointer): cudnnStatus_t {.cdecl,
       importc: "cudnnScaleTensor", dyn.}
-  ## 
+  ##
   ##   convolution mode
-  ## 
+  ##
   type
     cudnnConvolutionMode_t* {.size: sizeof(cint).} = enum
       CUDNN_CONVOLUTION = 0, CUDNN_CROSS_CORRELATION = 1
@@ -380,16 +380,16 @@ when not defined(CUDNN_H):
       preference: cudnnConvolutionFwdPreference_t; memoryLimitInBytes: csize;
       algo: ptr cudnnConvolutionFwdAlgo_t): cudnnStatus_t {.cdecl,
       importc: "cudnnGetConvolutionForwardAlgorithm", dyn.}
-  ## 
+  ##
   ##   convolution algorithm (which requires potentially some workspace)
-  ## 
+  ##
   ##  Helper function to return the minimum size of the workspace to be passed to the convolution given an algo
   proc cudnnGetConvolutionForwardWorkspaceSize*(handle: cudnnHandle_t;
       xDesc: cudnnTensorDescriptor_t; wDesc: cudnnFilterDescriptor_t;
       convDesc: cudnnConvolutionDescriptor_t; yDesc: cudnnTensorDescriptor_t;
       algo: cudnnConvolutionFwdAlgo_t; sizeInBytes: ptr csize): cudnnStatus_t {.cdecl,
       importc: "cudnnGetConvolutionForwardWorkspaceSize", dyn.}
-  ##  Convolution functions: All of the form "output = alpha * Op(inputs) + beta * output"
+  ##  `Convolution functions: All of the form "output = alpha * Op(inputs) + beta * output"`
   ##  Function to perform the forward pass for batch convolution
   proc cudnnConvolutionForward*(handle: cudnnHandle_t; alpha: pointer;
                                xDesc: cudnnTensorDescriptor_t; x: pointer;
@@ -444,9 +444,9 @@ when not defined(CUDNN_H):
       preference: cudnnConvolutionBwdFilterPreference_t;
       memoryLimitInBytes: csize; algo: ptr cudnnConvolutionBwdFilterAlgo_t): cudnnStatus_t {.
       cdecl, importc: "cudnnGetConvolutionBackwardFilterAlgorithm", dyn.}
-  ## 
+  ##
   ##   convolution algorithm (which requires potentially some workspace)
-  ## 
+  ##
   ##  Helper function to return the minimum size of the workspace to be passed to the convolution given an algo
   proc cudnnGetConvolutionBackwardFilterWorkspaceSize*(handle: cudnnHandle_t;
       xDesc: cudnnTensorDescriptor_t; dyDesc: cudnnTensorDescriptor_t;
@@ -464,7 +464,7 @@ when not defined(CUDNN_H):
                                       workSpaceSizeInBytes: csize; beta: pointer;
                                       dwDesc: cudnnFilterDescriptor_t; dw: pointer): cudnnStatus_t {.
       cdecl, importc: "cudnnConvolutionBackwardFilter", dyn.}
-  ## *******************************************************
+  ## `*******************************************************`
   ##  helper function to provide the convolution algo that fit best the requirement
   type
     cudnnConvolutionBwdDataPreference_t* {.size: sizeof(cint).} = enum
@@ -524,9 +524,9 @@ when not defined(CUDNN_H):
                    x: pointer; wDesc: cudnnFilterDescriptor_t;
                    convDesc: cudnnConvolutionDescriptor_t; colBuffer: pointer): cudnnStatus_t {.
       cdecl, importc: "cudnnIm2Col", dyn.}
-  ## 
+  ##
   ##   softmax algorithm
-  ## 
+  ##
   type
     cudnnSoftmaxAlgorithm_t* {.size: sizeof(cint).} = enum
       CUDNN_SOFTMAX_FAST = 0,   ##  straightforward implementation
@@ -535,7 +535,7 @@ when not defined(CUDNN_H):
     cudnnSoftmaxMode_t* {.size: sizeof(cint).} = enum
       CUDNN_SOFTMAX_MODE_INSTANCE = 0, ##  compute the softmax over all C, H, W for each N
       CUDNN_SOFTMAX_MODE_CHANNEL = 1
-  ##  Softmax functions: All of the form "output = alpha * Op(inputs) + beta * output"
+  ##  `Softmax functions: All of the form "output = alpha * Op(inputs) + beta * output"`
   ##  Function to perform forward softmax
   proc cudnnSoftmaxForward*(handle: cudnnHandle_t; algo: cudnnSoftmaxAlgorithm_t;
                            mode: cudnnSoftmaxMode_t; alpha: pointer;
@@ -550,9 +550,9 @@ when not defined(CUDNN_H):
                             beta: pointer; dxDesc: cudnnTensorDescriptor_t;
                             dx: pointer): cudnnStatus_t {.cdecl,
       importc: "cudnnSoftmaxBackward", dyn.}
-  ## 
+  ##
   ##   pooling mode
-  ## 
+  ##
   type
     cudnnPoolingMode_t* {.size: sizeof(cint).} = enum
       CUDNN_POOLING_MAX = 0, CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING = 1, ##  count for average includes padded values
@@ -601,7 +601,7 @@ when not defined(CUDNN_H):
   ##  Destroy an instance of pooling descriptor
   proc cudnnDestroyPoolingDescriptor*(poolingDesc: cudnnPoolingDescriptor_t): cudnnStatus_t {.
       cdecl, importc: "cudnnDestroyPoolingDescriptor", dyn.}
-  ##  Pooling functions: All of the form "output = alpha * Op(inputs) + beta * output"
+  ##  `Pooling functions: All of the form "output = alpha * Op(inputs) + beta * output"`
   ##  Function to perform forward pooling
   proc cudnnPoolingForward*(handle: cudnnHandle_t;
                            poolingDesc: cudnnPoolingDescriptor_t; alpha: pointer;
@@ -617,14 +617,14 @@ when not defined(CUDNN_H):
                             beta: pointer; dxDesc: cudnnTensorDescriptor_t;
                             dx: pointer): cudnnStatus_t {.cdecl,
       importc: "cudnnPoolingBackward", dyn.}
-  ## 
+  ##
   ##  activation mode
-  ## 
+  ##
   type
     cudnnActivationMode_t* {.size: sizeof(cint).} = enum
       CUDNN_ACTIVATION_SIGMOID = 0, CUDNN_ACTIVATION_RELU = 1,
       CUDNN_ACTIVATION_TANH = 2, CUDNN_ACTIVATION_CLIPPED_RELU = 3
-  ##  Activation functions: All of the form "output = alpha * Op(inputs) + beta * output"
+  ##  `Activation functions: All of the form "output = alpha * Op(inputs) + beta * output"`
   proc cudnnCreateActivationDescriptor*(activationDesc: ptr cudnnActivationDescriptor_t): cudnnStatus_t {.
       cdecl, importc: "cudnnCreateActivationDescriptor", dyn.}
   proc cudnnSetActivationDescriptor*(activationDesc: cudnnActivationDescriptor_t;
@@ -655,10 +655,10 @@ when not defined(CUDNN_H):
                                x: pointer; beta: pointer;
                                dxDesc: cudnnTensorDescriptor_t; dx: pointer): cudnnStatus_t {.
       cdecl, importc: "cudnnActivationBackward", dyn.}
-  ##  
+  ##
   ##  Create an instance of LRN (Local Response Normalization) descriptor
   ##  Uses lrnN=5, lrnAlpha=1e-4, lrnBeta=0.75, lrnK=2.0 as defaults from Krizhevsky'12 ImageNet paper
-  ## 
+  ##
   proc cudnnCreateLRNDescriptor*(normDesc: ptr cudnnLRNDescriptor_t): cudnnStatus_t {.
       cdecl, importc: "cudnnCreateLRNDescriptor", dyn.}
   const
@@ -670,18 +670,18 @@ when not defined(CUDNN_H):
   type
     cudnnLRNMode_t* {.size: sizeof(cint).} = enum
       CUDNN_LRN_CROSS_CHANNEL_DIM1 = 0 ##  Normalize across tensor's dimA[1] dimension
-  ## 
+  ##
   ##  Uses a window [center-lookBehind, center+lookAhead], where
   ##  lookBehind = floor( (lrnN-1)/2 ), lookAhead = lrnN-lookBehind-1.
   ##  Values of double parameters cast to tensor data type.
-  ## 
+  ##
   proc cudnnSetLRNDescriptor*(normDesc: cudnnLRNDescriptor_t; lrnN: cuint;
                              lrnAlpha: cdouble; lrnBeta: cdouble; lrnK: cdouble): cudnnStatus_t {.
       cdecl, importc: "cudnnSetLRNDescriptor", dyn.}
-  ## 
+  ##
   ##  Retrieve the settings currently stored in an LRN layer descriptor
   ##  Any of the provided pointers can be NULL (no corresponding value will be returned)
-  ## 
+  ##
   proc cudnnGetLRNDescriptor*(normDesc: cudnnLRNDescriptor_t; lrnN: ptr cuint;
                              lrnAlpha: ptr cdouble; lrnBeta: ptr cdouble;
                              lrnK: ptr cdouble): cudnnStatus_t {.cdecl,
@@ -689,7 +689,7 @@ when not defined(CUDNN_H):
   ##  Destroy an instance of LRN descriptor
   proc cudnnDestroyLRNDescriptor*(lrnDesc: cudnnLRNDescriptor_t): cudnnStatus_t {.
       cdecl, importc: "cudnnDestroyLRNDescriptor", dyn.}
-  ##  LRN functions: output = alpha * normalize(x) + beta * old_y
+  ##  `LRN functions: output = alpha * normalize(x) + beta * old_y`
   ##  LRN cross-channel forward computation. Double parameters cast to tensor data type
   proc cudnnLRNCrossChannelForward*(handle: cudnnHandle_t;
                                    normDesc: cudnnLRNDescriptor_t;
@@ -711,7 +711,7 @@ when not defined(CUDNN_H):
   type
     cudnnDivNormMode_t* {.size: sizeof(cint).} = enum
       CUDNN_DIVNORM_PRECOMPUTED_MEANS = 0
-  ##  LCN/divisive normalization functions: y = alpha * normalize(x) + beta * y
+  ##  `LCN/divisive normalization functions: y = alpha * normalize(x) + beta * y`
   proc cudnnDivisiveNormalizationForward*(handle: cudnnHandle_t;
       normDesc: cudnnLRNDescriptor_t; mode: cudnnDivNormMode_t; alpha: pointer;
       xDesc: cudnnTensorDescriptor_t; x: pointer; means: pointer; temp: pointer;
@@ -736,11 +736,11 @@ when not defined(CUDNN_H):
       CUDNN_BATCHNORM_SPATIAL = 1
   const
     CUDNN_BN_MIN_EPSILON* = 1e-05
-  ## 
-  ##  Derives a tensor descriptor from layer data descriptor for BatchNormalization 
-  ##  scale, invVariance, bnBias, bnScale tensors. Use this tensor desc for 
+  ##
+  ##  Derives a tensor descriptor from layer data descriptor for BatchNormalization
+  ##  scale, invVariance, bnBias, bnScale tensors. Use this tensor desc for
   ##  bnScaleBiasMeanVarDesc and bnScaleBiasDiffDesc in Batch Normalization forward and backward functions.
-  ## 
+  ##
   proc cudnnDeriveBNTensorDescriptor*(derivedBnDesc: cudnnTensorDescriptor_t;
                                      xDesc: cudnnTensorDescriptor_t;
                                      mode: cudnnBatchNormMode_t): cudnnStatus_t {.
@@ -764,30 +764,30 @@ when not defined(CUDNN_H):
     ##                                    Dimensions for this descriptor depend on normalization mode
     ##                                    - Spatial Normalization : tensors are expected to have dims 1xCx1x1
     ##                                     (normalization is performed across NxHxW)
-    ##                                    - Per-Activation Normalization : tensors are expected to have dims of 1xCxHxW 
+    ##                                    - Per-Activation Normalization : tensors are expected to have dims of 1xCxHxW
     ##                                     (normalization is performed across N)
     ##  'Gamma' and 'Beta' respectively in Ioffe and Szegedy's paper's notation
     ##  MUST use factor=1 in the very first call of a complete training cycle.
     ##                                    Use a factor=1/(1+n) at N-th call to the function to get
     ##                                    Cumulative Moving Average (CMA) behavior
     ##                                    CMA[n] = (x[1]+...+x[n])/n
-    ##                                    Since CMA[n+1] = (n*CMA[n]+x[n+1])/(n+1) =
-    ##                                    ((n+1)*CMA[n]-CMA[n])/(n+1) + x[n+1]/(n+1) =
-    ##                                    CMA[n]*(1-1/(n+1)) + x[n+1]*1/(n+1)
-    ##  Used in Training phase only. 
-    ##                                    runningMean = newMean*factor + runningMean*(1-factor)
+    ##                                    `Since CMA[n+1] = (n*CMA[n]+x[n+1])/(n+1) =`
+    ##                                    `((n+1)*CMA[n]-CMA[n])/(n+1) + x[n+1]/(n+1) =`
+    ##                                    `CMA[n]*(1-1/(n+1)) + x[n+1]*1/(n+1)`
+    ##  Used in Training phase only.
+    ##                                    `runningMean = newMean*factor + runningMean*(1-factor)`
     ##  Output in training mode, input in inference. Is the moving average
     ##                                    of  variance[x] (factor is applied in the same way as for runningMean)
     ##  Has to be >= CUDNN_BN_MIN_EPSILON. Should be the same in forward and backward functions.
     ##  Optionally save intermediate results from the forward pass here
     ##                                    - can be reused to speed up backward pass. NULL if unused
-  ## 
-  ##  Performs Batch Normalization during Inference: 
-  ##  y[i] = bnScale[k]*(x[i]-estimatedMean[k])/sqrt(epsilon+estimatedVariance[k]) + bnBias[k]
+  ##
+  ##  Performs Batch Normalization during Inference:
+  ##  `y[i] = bnScale[k]*(x[i]-estimatedMean[k])/sqrt(epsilon+estimatedVariance[k]) + bnBias[k]`
   ##  with bnScale, bnBias, runningMean, runningInvVariance tensors indexed
   ##  according to spatial or per-activation mode. Refer to cudnnBatchNormalizationForwardTraining
   ##  above for notes on function arguments.
-  ## 
+  ##
   proc cudnnBatchNormalizationForwardInference*(handle: cudnnHandle_t;
       mode: cudnnBatchNormMode_t; alpha: pointer; beta: pointer;
       xDesc: cudnnTensorDescriptor_t; x: pointer; yDesc: cudnnTensorDescriptor_t;
@@ -904,7 +904,7 @@ when not defined(CUDNN_H):
       CUDNN_LINEAR_INPUT = 0, CUDNN_SKIP_INPUT = 1
   type
     cudnnRNNStruct* = object
-    
+
   type
     cudnnRNNDescriptor_t* = ptr cudnnRNNStruct
   proc cudnnCreateRNNDescriptor*(rnnDesc: ptr cudnnRNNDescriptor_t): cudnnStatus_t {.
@@ -1000,10 +1000,10 @@ when not defined(CUDNN_H):
                                reserveSpace: pointer;
                                reserveSpaceSizeInBytes: csize): cudnnStatus_t {.
       cdecl, importc: "cudnnRNNBackwardWeights", dyn.}
-  ##  DEPRECATED routines to be removed next release : 
+  ##  DEPRECATED routines to be removed next release :
   ##    User should use the non-suffixed version (which has the API and functionality of _v4 version)
   ##    Routines with _v3 suffix has the functionality of the non-suffixed routines in the CUDNN V4
-  ## 
+  ##
   proc cudnnSetFilter4dDescriptor_v3*(filterDesc: cudnnFilterDescriptor_t;
                                      dataType: cudnnDataType_t; k: cint; c: cint;
                                      h: cint; w: cint): cudnnStatus_t {.cdecl,

--- a/nimcuda/curand.nim
+++ b/nimcuda/curand.nim
@@ -13,25 +13,25 @@ else:
   {.pragma: dyn, dynlib: libName.}
 type
   curandDistributionShift_st = object
-  
+
   curandDistributionM2Shift_st = object
-  
+
   curandHistogramM2_st = object
-  
+
   curandDiscreteDistribution_st = object
-  
+
 
 import
   library_types, driver_types
 
 ##  Copyright 2010-2014 NVIDIA Corporation.  All rights reserved.
-## 
+##
 ##  NOTICE TO LICENSEE:
-## 
+##
 ##  The source code and/or documentation ("Licensed Deliverables") are
 ##  subject to NVIDIA intellectual property rights under U.S. and
 ##  international Copyright laws.
-## 
+##
 ##  The Licensed Deliverables contained herein are PROPRIETARY and
 ##  CONFIDENTIAL to NVIDIA and are being provided under the terms and
 ##  conditions of a form of NVIDIA software license agreement by and
@@ -40,7 +40,7 @@ import
 ##  the contrary in the License Agreement, reproduction or disclosure
 ##  of the Licensed Deliverables to any third party without the express
 ##  written consent of NVIDIA is prohibited.
-## 
+##
 ##  NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
 ##  LICENSE AGREEMENT, NVIDIA MAKES NO REPRESENTATION ABOUT THE
 ##  SUITABILITY OF THESE LICENSED DELIVERABLES FOR ANY PURPOSE.  THEY ARE
@@ -55,7 +55,7 @@ import
 ##  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 ##  ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
 ##  OF THESE LICENSED DELIVERABLES.
-## 
+##
 ##  U.S. Government End Users.  These Licensed Deliverables are a
 ##  "commercial item" as that term is defined at 48 C.F.R. 2.101 (OCT
 ##  1995), consisting of "commercial computer software" and "commercial
@@ -65,28 +65,28 @@ import
 ##  48 C.F.R. 227.7202-1 through 227.7202-4 (JUNE 1995), all
 ##  U.S. Government End Users acquire the Licensed Deliverables with
 ##  only those rights set forth herein.
-## 
+##
 ##  Any use of the Licensed Deliverables in individual and commercial
 ##  software must include, in the user documentation and internal
 ##  comments to the code, the above Disclaimer and U.S. Government End
 ##  Users Notice.
-## 
+##
 
 when not defined(CURAND_H):
   const
     CURAND_H* = true
   ## *
   ##  \defgroup HOST Host API
-  ## 
+  ##
   ##  @{
-  ## 
+  ##
   ##  CURAND Host API datatypes
-  ## *  
-  ##  @{
-  ## 
   ## *
-  ##  CURAND function call status types 
-  ## 
+  ##  @{
+  ##
+  ## *
+  ##  CURAND function call status types
+  ##
   type
     curandStatus* {.size: sizeof(cint).} = enum
       CURAND_STATUS_SUCCESS = 0, ## /< No errors
@@ -102,16 +102,16 @@ when not defined(CURAND_H):
       CURAND_STATUS_INITIALIZATION_FAILED = 203, ## /< Initialization of CUDA failed
       CURAND_STATUS_ARCH_MISMATCH = 204, ## /< Architecture mismatch, GPU does not support requested feature
       CURAND_STATUS_INTERNAL_ERROR = 999
-  ## 
+  ##
   ##  CURAND function call status types
-  ## 
+  ##
   ## * \cond UNHIDE_TYPEDEFS
   type
     curandStatus_t* = curandStatus
   ## * \endcond
   ## *
   ##  CURAND generator types
-  ## 
+  ##
   type
     curandRngType* {.size: sizeof(cint).} = enum
       CURAND_RNG_TEST = 0, CURAND_RNG_PSEUDO_DEFAULT = 100, ## /< Default pseudorandom generator
@@ -125,75 +125,75 @@ when not defined(CURAND_H):
       CURAND_RNG_QUASI_SCRAMBLED_SOBOL32 = 202, ## /< Scrambled Sobol32 quasirandom generator
       CURAND_RNG_QUASI_SOBOL64 = 203, ## /< Sobol64 quasirandom generator
       CURAND_RNG_QUASI_SCRAMBLED_SOBOL64 = 204
-  ## 
+  ##
   ##  CURAND generator types
-  ## 
+  ##
   ## * \cond UNHIDE_TYPEDEFS
   type
     curandRngType_t* = curandRngType
   ## * \endcond
   ## *
   ##  CURAND ordering of results in memory
-  ## 
+  ##
   type
     curandOrdering* {.size: sizeof(cint).} = enum
       CURAND_ORDERING_PSEUDO_BEST = 100, ## /< Best ordering for pseudorandom results
       CURAND_ORDERING_PSEUDO_DEFAULT = 101, ## /< Specific default 4096 thread sequence for pseudorandom results
       CURAND_ORDERING_PSEUDO_SEEDED = 102, ## /< Specific seeding pattern for fast lower quality pseudorandom results
       CURAND_ORDERING_QUASI_DEFAULT = 201
-  ## 
+  ##
   ##  CURAND ordering of results in memory
-  ## 
+  ##
   ## * \cond UNHIDE_TYPEDEFS
   type
     curandOrdering_t* = curandOrdering
   ## * \endcond
   ## *
   ##  CURAND choice of direction vector set
-  ## 
+  ##
   type
     curandDirectionVectorSet* {.size: sizeof(cint).} = enum
       CURAND_DIRECTION_VECTORS_32_JOEKUO6 = 101, ## /< Specific set of 32-bit direction vectors generated from polynomials recommended by S. Joe and F. Y. Kuo, for up to 20,000 dimensions
       CURAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6 = 102, ## /< Specific set of 32-bit direction vectors generated from polynomials recommended by S. Joe and F. Y. Kuo, for up to 20,000 dimensions, and scrambled
       CURAND_DIRECTION_VECTORS_64_JOEKUO6 = 103, ## /< Specific set of 64-bit direction vectors generated from polynomials recommended by S. Joe and F. Y. Kuo, for up to 20,000 dimensions
       CURAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6 = 104
-  ## 
+  ##
   ##  CURAND choice of direction vector set
-  ## 
+  ##
   ## * \cond UNHIDE_TYPEDEFS
   type
     curandDirectionVectorSet_t* = curandDirectionVectorSet
   ## * \endcond
   ## *
   ##  CURAND array of 32-bit direction vectors
-  ## 
+  ##
   ## * \cond UNHIDE_TYPEDEFS
   type
     curandDirectionVectors32_t* = array[32, cuint]
   ## * \endcond
   ## *
   ##  CURAND array of 64-bit direction vectors
-  ## 
+  ##
   ## * \cond UNHIDE_TYPEDEFS
   type
     curandDirectionVectors64_t* = array[64, culonglong]
   ## * \endcond *
   ## *
   ##  CURAND generator (opaque)
-  ## 
+  ##
   type
     curandGenerator_st* = object
-    
+
   ## *
   ##  CURAND generator
-  ## 
+  ##
   ## * \cond UNHIDE_TYPEDEFS
   type
     curandGenerator_t* = ptr curandGenerator_st
   ## * \endcond
   ## *
   ##  CURAND distribution
-  ## 
+  ##
   ## * \cond UNHIDE_TYPEDEFS
   type
     curandDistribution_st* = cdouble
@@ -202,7 +202,7 @@ when not defined(CURAND_H):
   ## * \endcond
   ## *
   ##  CURAND distribution M2
-  ## 
+  ##
   ## * \cond UNHIDE_TYPEDEFS
   type
     curandDistributionM2Shift_t* = ptr curandDistributionM2Shift_st
@@ -213,9 +213,9 @@ when not defined(CURAND_H):
     curandHistogramM2V_t* = ptr curandHistogramM2V_st
     curandDiscreteDistribution_t* = ptr curandDiscreteDistribution_st
   ## * \endcond
-  ## 
+  ##
   ##  CURAND METHOD
-  ## 
+  ##
   ## * \cond UNHIDE_ENUMS
   type
     curandMethod* {.size: sizeof(cint).} = enum
@@ -229,160 +229,160 @@ when not defined(CURAND_H):
   ## * \endcond
   ## *
   ##  @}
-  ## 
+  ##
   ## *
   ##  \brief Create new random number generator.
-  ## 
+  ##
   ##  Creates a new random number generator of type \p rng_type
-  ##  and returns it in \p *generator.
-  ## 
+  ##  `and returns it in \p *generator.`
+  ##
   ##  Legal values for \p rng_type are:
   ##  - CURAND_RNG_PSEUDO_DEFAULT
-  ##  - CURAND_RNG_PSEUDO_XORWOW 
-  ##  - CURAND_RNG_PSEUDO_MRG32K3A
-  ##  - CURAND_RNG_PSEUDO_MTGP32
-  ##  - CURAND_RNG_PSEUDO_MT19937 
-  ##  - CURAND_RNG_PSEUDO_PHILOX4_32_10
-  ##  - CURAND_RNG_QUASI_DEFAULT
-  ##  - CURAND_RNG_QUASI_SOBOL32
-  ##  - CURAND_RNG_QUASI_SCRAMBLED_SOBOL32
-  ##  - CURAND_RNG_QUASI_SOBOL64
-  ##  - CURAND_RNG_QUASI_SCRAMBLED_SOBOL64
-  ##  
-  ##  When \p rng_type is CURAND_RNG_PSEUDO_DEFAULT, the type chosen
-  ##  is CURAND_RNG_PSEUDO_XORWOW.  \n
-  ##  When \p rng_type is CURAND_RNG_QUASI_DEFAULT,
-  ##  the type chosen is CURAND_RNG_QUASI_SOBOL32.
-  ##  
-  ##  The default values for \p rng_type = CURAND_RNG_PSEUDO_XORWOW are:
-  ##  - \p seed = 0
-  ##  - \p offset = 0
-  ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
-  ## 
-  ##  The default values for \p rng_type = CURAND_RNG_PSEUDO_MRG32K3A are:
-  ##  - \p seed = 0
-  ##  - \p offset = 0
-  ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
-  ## 
-  ##  The default values for \p rng_type = CURAND_RNG_PSEUDO_MTGP32 are:
-  ##  - \p seed = 0
-  ##  - \p offset = 0
-  ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
-  ## 
-  ##  The default values for \p rng_type = CURAND_RNG_PSEUDO_MT19937 are:
-  ##  - \p seed = 0
-  ##  - \p offset = 0
-  ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
-  ## 
-  ##  * The default values for \p rng_type = CURAND_RNG_PSEUDO_PHILOX4_32_10 are:
-  ##  - \p seed = 0
-  ##  - \p offset = 0
-  ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
-  ## 
-  ##  The default values for \p rng_type = CURAND_RNG_QUASI_SOBOL32 are:
-  ##  - \p dimensions = 1
-  ##  - \p offset = 0
-  ##  - \p ordering = CURAND_ORDERING_QUASI_DEFAULT
-  ## 
-  ##  The default values for \p rng_type = CURAND_RNG_QUASI_SOBOL64 are:
-  ##  - \p dimensions = 1
-  ##  - \p offset = 0
-  ##  - \p ordering = CURAND_ORDERING_QUASI_DEFAULT
-  ## 
-  ##  The default values for \p rng_type = CURAND_RNG_QUASI_SCRAMBBLED_SOBOL32 are:
-  ##  - \p dimensions = 1
-  ##  - \p offset = 0
-  ##  - \p ordering = CURAND_ORDERING_QUASI_DEFAULT
-  ## 
-  ##  The default values for \p rng_type = CURAND_RNG_QUASI_SCRAMBLED_SOBOL64 are:
-  ##  - \p dimensions = 1
-  ##  - \p offset = 0
-  ##  - \p ordering = CURAND_ORDERING_QUASI_DEFAULT
-  ## 
-  ##  \param generator - Pointer to generator
-  ##  \param rng_type - Type of generator to create
-  ## 
-  ##  \return 
-  ##  - CURAND_STATUS_ALLOCATION_FAILED, if memory could not be allocated \n
-  ##  - CURAND_STATUS_INITIALIZATION_FAILED if there was a problem setting up the GPU \n
-  ##  - CURAND_STATUS_VERSION_MISMATCH if the header file version does not match the 
-  ##    dynamically linked library version \n
-  ##  - CURAND_STATUS_TYPE_ERROR if the value for \p rng_type is invalid \n
-  ##  - CURAND_STATUS_SUCCESS if generator was created successfully \n
-  ##  
-  ## 
-  proc curandCreateGenerator*(generator: ptr curandGenerator_t;
-                             rng_type: curandRngType_t): curandStatus_t {.cdecl,
-      importc: "curandCreateGenerator", dyn.}
-  ## *
-  ##  \brief Create new host CPU random number generator.
-  ## 
-  ##  Creates a new host CPU random number generator of type \p rng_type
-  ##  and returns it in \p *generator.
-  ## 
-  ##  Legal values for \p rng_type are:
-  ##  - CURAND_RNG_PSEUDO_DEFAULT
-  ##  - CURAND_RNG_PSEUDO_XORWOW 
+  ##  - CURAND_RNG_PSEUDO_XORWOW
   ##  - CURAND_RNG_PSEUDO_MRG32K3A
   ##  - CURAND_RNG_PSEUDO_MTGP32
   ##  - CURAND_RNG_PSEUDO_MT19937
   ##  - CURAND_RNG_PSEUDO_PHILOX4_32_10
   ##  - CURAND_RNG_QUASI_DEFAULT
   ##  - CURAND_RNG_QUASI_SOBOL32
-  ##  
+  ##  - CURAND_RNG_QUASI_SCRAMBLED_SOBOL32
+  ##  - CURAND_RNG_QUASI_SOBOL64
+  ##  - CURAND_RNG_QUASI_SCRAMBLED_SOBOL64
+  ##
   ##  When \p rng_type is CURAND_RNG_PSEUDO_DEFAULT, the type chosen
   ##  is CURAND_RNG_PSEUDO_XORWOW.  \n
   ##  When \p rng_type is CURAND_RNG_QUASI_DEFAULT,
   ##  the type chosen is CURAND_RNG_QUASI_SOBOL32.
-  ##  
+  ##
   ##  The default values for \p rng_type = CURAND_RNG_PSEUDO_XORWOW are:
   ##  - \p seed = 0
   ##  - \p offset = 0
   ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
-  ## 
+  ##
   ##  The default values for \p rng_type = CURAND_RNG_PSEUDO_MRG32K3A are:
   ##  - \p seed = 0
   ##  - \p offset = 0
   ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
-  ## 
+  ##
   ##  The default values for \p rng_type = CURAND_RNG_PSEUDO_MTGP32 are:
   ##  - \p seed = 0
   ##  - \p offset = 0
   ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
-  ## 
+  ##
   ##  The default values for \p rng_type = CURAND_RNG_PSEUDO_MT19937 are:
   ##  - \p seed = 0
   ##  - \p offset = 0
   ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
-  ## 
-  ##  * The default values for \p rng_type = CURAND_RNG_PSEUDO_PHILOX4_32_10 are:
+  ##
+  ##  `* The default values for \p rng_type = CURAND_RNG_PSEUDO_PHILOX4_32_10 are:`
   ##  - \p seed = 0
   ##  - \p offset = 0
   ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
-  ## 
+  ##
   ##  The default values for \p rng_type = CURAND_RNG_QUASI_SOBOL32 are:
   ##  - \p dimensions = 1
   ##  - \p offset = 0
   ##  - \p ordering = CURAND_ORDERING_QUASI_DEFAULT
-  ## 
+  ##
   ##  The default values for \p rng_type = CURAND_RNG_QUASI_SOBOL64 are:
   ##  - \p dimensions = 1
   ##  - \p offset = 0
   ##  - \p ordering = CURAND_ORDERING_QUASI_DEFAULT
-  ## 
-  ##  The default values for \p rng_type = CURAND_RNG_QUASI_SCRAMBLED_SOBOL32 are:
+  ##
+  ##  The default values for \p rng_type = CURAND_RNG_QUASI_SCRAMBBLED_SOBOL32 are:
   ##  - \p dimensions = 1
   ##  - \p offset = 0
   ##  - \p ordering = CURAND_ORDERING_QUASI_DEFAULT
-  ## 
+  ##
   ##  The default values for \p rng_type = CURAND_RNG_QUASI_SCRAMBLED_SOBOL64 are:
   ##  - \p dimensions = 1
   ##  - \p offset = 0
   ##  - \p ordering = CURAND_ORDERING_QUASI_DEFAULT
-  ## 
+  ##
   ##  \param generator - Pointer to generator
   ##  \param rng_type - Type of generator to create
-  ## 
+  ##
+  ##  \return
+  ##  - CURAND_STATUS_ALLOCATION_FAILED, if memory could not be allocated \n
+  ##  - CURAND_STATUS_INITIALIZATION_FAILED if there was a problem setting up the GPU \n
+  ##  - CURAND_STATUS_VERSION_MISMATCH if the header file version does not match the
+  ##    dynamically linked library version \n
+  ##  - CURAND_STATUS_TYPE_ERROR if the value for \p rng_type is invalid \n
+  ##  - CURAND_STATUS_SUCCESS if generator was created successfully \n
+  ##
+  ##
+  proc curandCreateGenerator*(generator: ptr curandGenerator_t;
+                             rng_type: curandRngType_t): curandStatus_t {.cdecl,
+      importc: "curandCreateGenerator", dyn.}
+  ## *
+  ##  \brief Create new host CPU random number generator.
+  ##
+  ##  Creates a new host CPU random number generator of type \p rng_type
+  ##  `and returns it in \p *generator.`
+  ##
+  ##  Legal values for \p rng_type are:
+  ##  - CURAND_RNG_PSEUDO_DEFAULT
+  ##  - CURAND_RNG_PSEUDO_XORWOW
+  ##  - CURAND_RNG_PSEUDO_MRG32K3A
+  ##  - CURAND_RNG_PSEUDO_MTGP32
+  ##  - CURAND_RNG_PSEUDO_MT19937
+  ##  - CURAND_RNG_PSEUDO_PHILOX4_32_10
+  ##  - CURAND_RNG_QUASI_DEFAULT
+  ##  - CURAND_RNG_QUASI_SOBOL32
+  ##
+  ##  When \p rng_type is CURAND_RNG_PSEUDO_DEFAULT, the type chosen
+  ##  is CURAND_RNG_PSEUDO_XORWOW.  \n
+  ##  When \p rng_type is CURAND_RNG_QUASI_DEFAULT,
+  ##  the type chosen is CURAND_RNG_QUASI_SOBOL32.
+  ##
+  ##  The default values for \p rng_type = CURAND_RNG_PSEUDO_XORWOW are:
+  ##  - \p seed = 0
+  ##  - \p offset = 0
+  ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
+  ##
+  ##  The default values for \p rng_type = CURAND_RNG_PSEUDO_MRG32K3A are:
+  ##  - \p seed = 0
+  ##  - \p offset = 0
+  ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
+  ##
+  ##  The default values for \p rng_type = CURAND_RNG_PSEUDO_MTGP32 are:
+  ##  - \p seed = 0
+  ##  - \p offset = 0
+  ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
+  ##
+  ##  The default values for \p rng_type = CURAND_RNG_PSEUDO_MT19937 are:
+  ##  - \p seed = 0
+  ##  - \p offset = 0
+  ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
+  ##
+  ##  `* The default values for \p rng_type = CURAND_RNG_PSEUDO_PHILOX4_32_10 are:`
+  ##  - \p seed = 0
+  ##  - \p offset = 0
+  ##  - \p ordering = CURAND_ORDERING_PSEUDO_DEFAULT
+  ##
+  ##  The default values for \p rng_type = CURAND_RNG_QUASI_SOBOL32 are:
+  ##  - \p dimensions = 1
+  ##  - \p offset = 0
+  ##  - \p ordering = CURAND_ORDERING_QUASI_DEFAULT
+  ##
+  ##  The default values for \p rng_type = CURAND_RNG_QUASI_SOBOL64 are:
+  ##  - \p dimensions = 1
+  ##  - \p offset = 0
+  ##  - \p ordering = CURAND_ORDERING_QUASI_DEFAULT
+  ##
+  ##  The default values for \p rng_type = CURAND_RNG_QUASI_SCRAMBLED_SOBOL32 are:
+  ##  - \p dimensions = 1
+  ##  - \p offset = 0
+  ##  - \p ordering = CURAND_ORDERING_QUASI_DEFAULT
+  ##
+  ##  The default values for \p rng_type = CURAND_RNG_QUASI_SCRAMBLED_SOBOL64 are:
+  ##  - \p dimensions = 1
+  ##  - \p offset = 0
+  ##  - \p ordering = CURAND_ORDERING_QUASI_DEFAULT
+  ##
+  ##  \param generator - Pointer to generator
+  ##  \param rng_type - Type of generator to create
+  ##
   ##  \return
   ##  - CURAND_STATUS_ALLOCATION_FAILED if memory could not be allocated \n
   ##  - CURAND_STATUS_INITIALIZATION_FAILED if there was a problem setting up the GPU \n
@@ -390,166 +390,166 @@ when not defined(CURAND_H):
   ##    dynamically linked library version \n
   ##  - CURAND_STATUS_TYPE_ERROR if the value for \p rng_type is invalid \n
   ##  - CURAND_STATUS_SUCCESS if generator was created successfully \n
-  ## 
+  ##
   proc curandCreateGeneratorHost*(generator: ptr curandGenerator_t;
                                  rng_type: curandRngType_t): curandStatus_t {.
       cdecl, importc: "curandCreateGeneratorHost", dyn.}
   ## *
   ##  \brief Destroy an existing generator.
-  ## 
+  ##
   ##  Destroy an existing generator and free all memory associated with its state.
-  ## 
+  ##
   ##  \param generator - Generator to destroy
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
   ##  - CURAND_STATUS_SUCCESS if generator was destroyed successfully \n
-  ## 
+  ##
   proc curandDestroyGenerator*(generator: curandGenerator_t): curandStatus_t {.
       cdecl, importc: "curandDestroyGenerator", dyn.}
   ## *
   ##  \brief Return the version number of the library.
-  ## 
-  ##  Return in \p *version the version number of the dynamically linked CURAND
+  ##
+  ##  `Return in \p *version the version number of the dynamically linked CURAND`
   ##  library.  The format is the same as CUDART_VERSION from the CUDA Runtime.
   ##  The only supported configuration is CURAND version equal to CUDA Runtime
   ##  version.
-  ## 
+  ##
   ##  \param version - CURAND library version
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_SUCCESS if the version number was successfully returned \n
-  ## 
+  ##
   proc curandGetVersion*(version: ptr cint): curandStatus_t {.cdecl,
       importc: "curandGetVersion", dyn.}
   ## *
   ##  \brief Return the value of the curand property.
-  ## 
-  ##  Return in \p *value the number for the property described by \p type of the
+  ##
+  ##  `Return in \p *value the number for the property described by \p type of the`
   ##  dynamically linked CURAND library.
-  ## 
+  ##
   ##  \param type - CUDA library property
   ##  \param value - integer value for the requested property
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_SUCCESS if the property value was successfully returned \n
   ##  - CURAND_STATUS_OUT_OF_RANGE if the property type is not recognized \n
-  ## 
+  ##
   proc curandGetProperty*(`type`: libraryPropertyType; value: ptr cint): curandStatus_t {.
       cdecl, importc: "curandGetProperty", dyn.}
   ## *
   ##  \brief Set the current stream for CURAND kernel launches.
-  ## 
+  ##
   ##  Set the current stream for CURAND kernel launches.  All library functions
   ##  will use this stream until set again.
-  ## 
+  ##
   ##  \param generator - Generator to modify
   ##  \param stream - Stream to use or ::NULL for null stream
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
   ##  - CURAND_STATUS_SUCCESS if stream was set successfully \n
-  ## 
+  ##
   proc curandSetStream*(generator: curandGenerator_t; stream: cudaStream_t): curandStatus_t {.
       cdecl, importc: "curandSetStream", dyn.}
   ## *
-  ##  \brief Set the seed value of the pseudo-random number generator.  
-  ##  
+  ##  \brief Set the seed value of the pseudo-random number generator.
+  ##
   ##  Set the seed value of the pseudorandom number generator.
   ##  All values of seed are valid.  Different seeds will produce different sequences.
   ##  Different seeds will often not be statistically correlated with each other,
   ##  but some pairs of seed values may generate sequences which are statistically correlated.
-  ## 
+  ##
   ##  \param generator - Generator to modify
   ##  \param seed - Seed value
-  ##  
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
   ##  - CURAND_STATUS_TYPE_ERROR if the generator is not a pseudorandom number generator \n
   ##  - CURAND_STATUS_SUCCESS if generator seed was set successfully \n
-  ## 
+  ##
   proc curandSetPseudoRandomGeneratorSeed*(generator: curandGenerator_t;
       seed: culonglong): curandStatus_t {.cdecl, importc: "curandSetPseudoRandomGeneratorSeed",
                                        dyn.}
   ## *
   ##  \brief Set the absolute offset of the pseudo or quasirandom number generator.
-  ## 
+  ##
   ##  Set the absolute offset of the pseudo or quasirandom number generator.
-  ## 
-  ##  All values of offset are valid.  The offset position is absolute, not 
+  ##
+  ##  All values of offset are valid.  The offset position is absolute, not
   ##  relative to the current position in the sequence.
-  ## 
+  ##
   ##  \param generator - Generator to modify
   ##  \param offset - Absolute offset position
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
   ##  - CURAND_STATUS_SUCCESS if generator offset was set successfully \n
-  ## 
+  ##
   proc curandSetGeneratorOffset*(generator: curandGenerator_t; offset: culonglong): curandStatus_t {.
       cdecl, importc: "curandSetGeneratorOffset", dyn.}
   ## *
   ##  \brief Set the ordering of results of the pseudo or quasirandom number generator.
-  ## 
+  ##
   ##  Set the ordering of results of the pseudo or quasirandom number generator.
-  ## 
+  ##
   ##  Legal values of \p order for pseudorandom generators are:
   ##  - CURAND_ORDERING_PSEUDO_DEFAULT
   ##  - CURAND_ORDERING_PSEUDO_BEST
   ##  - CURAND_ORDERING_PSEUDO_SEEDED
-  ## 
+  ##
   ##  Legal values of \p order for quasirandom generators are:
   ##  - CURAND_ORDERING_QUASI_DEFAULT
-  ## 
+  ##
   ##  \param generator - Generator to modify
   ##  \param order - Ordering of results
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
   ##  - CURAND_STATUS_OUT_OF_RANGE if the ordering is not valid \n
   ##  - CURAND_STATUS_SUCCESS if generator ordering was set successfully \n
-  ## 
+  ##
   proc curandSetGeneratorOrdering*(generator: curandGenerator_t;
                                   order: curandOrdering_t): curandStatus_t {.cdecl,
       importc: "curandSetGeneratorOrdering", dyn.}
   ## *
   ##  \brief Set the number of dimensions.
-  ## 
+  ##
   ##  Set the number of dimensions to be generated by the quasirandom number
   ##  generator.
-  ##  
+  ##
   ##  Legal values for \p num_dimensions are 1 to 20000.
-  ##  
+  ##
   ##  \param generator - Generator to modify
   ##  \param num_dimensions - Number of dimensions
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
   ##  - CURAND_STATUS_OUT_OF_RANGE if num_dimensions is not valid \n
   ##  - CURAND_STATUS_TYPE_ERROR if the generator is not a quasirandom number generator \n
   ##  - CURAND_STATUS_SUCCESS if generator ordering was set successfully \n
-  ## 
+  ##
   proc curandSetQuasiRandomGeneratorDimensions*(generator: curandGenerator_t;
       num_dimensions: cuint): curandStatus_t {.cdecl,
       importc: "curandSetQuasiRandomGeneratorDimensions", dyn.}
   ## *
   ##  \brief Generate 32-bit pseudo or quasirandom numbers.
-  ## 
+  ##
   ##  Use \p generator to generate \p num 32-bit results into the device memory at
   ##  \p outputPtr.  The device memory must have been previously allocated and be
   ##  large enough to hold all the results.  Launches are done with the stream
   ##  set using ::curandSetStream(), or the null stream if no stream has been set.
-  ## 
+  ##
   ##  Results are 32-bit values with every bit random.
-  ## 
+  ##
   ##  \param generator - Generator to use
   ##  \param outputPtr - Pointer to device memory to store CUDA-generated results, or
   ##                  Pointer to host memory to store CPU-generated results
   ##  \param num - Number of random 32-bit values to generate
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
-  ##  - CURAND_STATUS_PREEXISTING_FAILURE if there was an existing error from 
+  ##  - CURAND_STATUS_PREEXISTING_FAILURE if there was an existing error from
   ##      a previous kernel launch \n
   ##  - CURAND_STATUS_LENGTH_NOT_MULTIPLE if the number of output samples is
   ##     not a multiple of the quasirandom dimension \n
@@ -557,53 +557,53 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_TYPE_ERROR if the generator is a 64 bit quasirandom generator.
   ##  (use ::curandGenerateLongLong() with 64 bit quasirandom generators)
   ##  - CURAND_STATUS_SUCCESS if the results were generated successfully \n
-  ## 
+  ##
   proc curandGenerate*(generator: curandGenerator_t; outputPtr: ptr cuint; num: csize): curandStatus_t {.
       cdecl, importc: "curandGenerate", dyn.}
   ## *
   ##  \brief Generate 64-bit quasirandom numbers.
-  ## 
+  ##
   ##  Use \p generator to generate \p num 64-bit results into the device memory at
   ##  \p outputPtr.  The device memory must have been previously allocated and be
   ##  large enough to hold all the results.  Launches are done with the stream
   ##  set using ::curandSetStream(), or the null stream if no stream has been set.
-  ## 
+  ##
   ##  Results are 64-bit values with every bit random.
-  ## 
+  ##
   ##  \param generator - Generator to use
   ##  \param outputPtr - Pointer to device memory to store CUDA-generated results, or
   ##                  Pointer to host memory to store CPU-generated results
   ##  \param num - Number of random 64-bit values to generate
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
-  ##  - CURAND_STATUS_PREEXISTING_FAILURE if there was an existing error from 
+  ##  - CURAND_STATUS_PREEXISTING_FAILURE if there was an existing error from
   ##      a previous kernel launch \n
   ##  - CURAND_STATUS_LENGTH_NOT_MULTIPLE if the number of output samples is
   ##     not a multiple of the quasirandom dimension \n
   ##  - CURAND_STATUS_LAUNCH_FAILURE if the kernel launch failed for any reason \n
   ##  - CURAND_STATUS_TYPE_ERROR if the generator is not a 64 bit quasirandom generator\n
   ##  - CURAND_STATUS_SUCCESS if the results were generated successfully \n
-  ## 
+  ##
   proc curandGenerateLongLong*(generator: curandGenerator_t;
                               outputPtr: ptr culonglong; num: csize): curandStatus_t {.
       cdecl, importc: "curandGenerateLongLong", dyn.}
   ## *
   ##  \brief Generate uniformly distributed floats.
-  ## 
+  ##
   ##  Use \p generator to generate \p num float results into the device memory at
   ##  \p outputPtr.  The device memory must have been previously allocated and be
   ##  large enough to hold all the results.  Launches are done with the stream
   ##  set using ::curandSetStream(), or the null stream if no stream has been set.
-  ## 
+  ##
   ##  Results are 32-bit floating point values between \p 0.0f and \p 1.0f,
   ##  excluding \p 0.0f and including \p 1.0f.
-  ## 
+  ##
   ##  \param generator - Generator to use
   ##  \param outputPtr - Pointer to device memory to store CUDA-generated results, or
   ##                  Pointer to host memory to store CPU-generated results
   ##  \param num - Number of floats to generate
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
   ##  - CURAND_STATUS_PREEXISTING_FAILURE if there was an existing error from
@@ -612,26 +612,26 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_LENGTH_NOT_MULTIPLE if the number of output samples is
   ##     not a multiple of the quasirandom dimension \n
   ##  - CURAND_STATUS_SUCCESS if the results were generated successfully \n
-  ## 
+  ##
   proc curandGenerateUniform*(generator: curandGenerator_t; outputPtr: ptr cfloat;
                              num: csize): curandStatus_t {.cdecl,
       importc: "curandGenerateUniform", dyn.}
   ## *
   ##  \brief Generate uniformly distributed doubles.
-  ## 
+  ##
   ##  Use \p generator to generate \p num double results into the device memory at
   ##  \p outputPtr.  The device memory must have been previously allocated and be
   ##  large enough to hold all the results.  Launches are done with the stream
   ##  set using ::curandSetStream(), or the null stream if no stream has been set.
-  ## 
-  ##  Results are 64-bit double precision floating point values between 
+  ##
+  ##  Results are 64-bit double precision floating point values between
   ##  \p 0.0 and \p 1.0, excluding \p 0.0 and including \p 1.0.
-  ## 
+  ##
   ##  \param generator - Generator to use
   ##  \param outputPtr - Pointer to device memory to store CUDA-generated results, or
   ##                  Pointer to host memory to store CPU-generated results
   ##  \param num - Number of doubles to generate
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
   ##  - CURAND_STATUS_PREEXISTING_FAILURE if there was an existing error from
@@ -641,26 +641,26 @@ when not defined(CURAND_H):
   ##     not a multiple of the quasirandom dimension \n
   ##  - CURAND_STATUS_DOUBLE_PRECISION_REQUIRED if the GPU does not support double precision \n
   ##  - CURAND_STATUS_SUCCESS if the results were generated successfully \n
-  ## 
+  ##
   proc curandGenerateUniformDouble*(generator: curandGenerator_t;
                                    outputPtr: ptr cdouble; num: csize): curandStatus_t {.
       cdecl, importc: "curandGenerateUniformDouble", dyn.}
   ## *
   ##  \brief Generate normally distributed doubles.
-  ## 
+  ##
   ##  Use \p generator to generate \p n float results into the device memory at
   ##  \p outputPtr.  The device memory must have been previously allocated and be
   ##  large enough to hold all the results.  Launches are done with the stream
   ##  set using ::curandSetStream(), or the null stream if no stream has been set.
-  ## 
+  ##
   ##  Results are 32-bit floating point values with mean \p mean and standard
   ##  deviation \p stddev.
-  ## 
+  ##
   ##  Normally distributed results are generated from pseudorandom generators
   ##  with a Box-Muller transform, and so require \p n to be even.
-  ##  Quasirandom generators use an inverse cumulative distribution 
+  ##  Quasirandom generators use an inverse cumulative distribution
   ##  function to preserve dimensionality.
-  ## 
+  ##
   ##  There may be slight numerical differences between results generated
   ##  on the GPU with generators created with ::curandCreateGenerator()
   ##  and results calculated on the CPU with generators created with
@@ -669,14 +669,14 @@ when not defined(CURAND_H):
   ##  future versions of CURAND may use newer versions of the CUDA math
   ##  library, so different versions of CURAND may give slightly different
   ##  numerical values.
-  ## 
+  ##
   ##  \param generator - Generator to use
   ##  \param outputPtr - Pointer to device memory to store CUDA-generated results, or
   ##                  Pointer to host memory to store CPU-generated results
   ##  \param n - Number of floats to generate
   ##  \param mean - Mean of normal distribution
   ##  \param stddev - Standard deviation of normal distribution
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
   ##  - CURAND_STATUS_PREEXISTING_FAILURE if there was an existing error from
@@ -686,26 +686,26 @@ when not defined(CURAND_H):
   ##     not a multiple of the quasirandom dimension, or is not a multiple
   ##     of two for pseudorandom generators \n
   ##  - CURAND_STATUS_SUCCESS if the results were generated successfully \n
-  ## 
+  ##
   proc curandGenerateNormal*(generator: curandGenerator_t; outputPtr: ptr cfloat;
                             n: csize; mean: cfloat; stddev: cfloat): curandStatus_t {.
       cdecl, importc: "curandGenerateNormal", dyn.}
   ## *
   ##  \brief Generate normally distributed doubles.
-  ## 
+  ##
   ##  Use \p generator to generate \p n double results into the device memory at
   ##  \p outputPtr.  The device memory must have been previously allocated and be
   ##  large enough to hold all the results.  Launches are done with the stream
   ##  set using ::curandSetStream(), or the null stream if no stream has been set.
-  ## 
+  ##
   ##  Results are 64-bit floating point values with mean \p mean and standard
   ##  deviation \p stddev.
-  ## 
+  ##
   ##  Normally distributed results are generated from pseudorandom generators
   ##  with a Box-Muller transform, and so require \p n to be even.
-  ##  Quasirandom generators use an inverse cumulative distribution 
+  ##  Quasirandom generators use an inverse cumulative distribution
   ##  function to preserve dimensionality.
-  ## 
+  ##
   ##  There may be slight numerical differences between results generated
   ##  on the GPU with generators created with ::curandCreateGenerator()
   ##  and results calculated on the CPU with generators created with
@@ -714,14 +714,14 @@ when not defined(CURAND_H):
   ##  future versions of CURAND may use newer versions of the CUDA math
   ##  library, so different versions of CURAND may give slightly different
   ##  numerical values.
-  ## 
+  ##
   ##  \param generator - Generator to use
   ##  \param outputPtr - Pointer to device memory to store CUDA-generated results, or
   ##                  Pointer to host memory to store CPU-generated results
   ##  \param n - Number of doubles to generate
   ##  \param mean - Mean of normal distribution
   ##  \param stddev - Standard deviation of normal distribution
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
   ##  - CURAND_STATUS_PREEXISTING_FAILURE if there was an existing error from
@@ -732,28 +732,28 @@ when not defined(CURAND_H):
   ##     of two for pseudorandom generators \n
   ##  - CURAND_STATUS_DOUBLE_PRECISION_REQUIRED if the GPU does not support double precision \n
   ##  - CURAND_STATUS_SUCCESS if the results were generated successfully \n
-  ## 
+  ##
   proc curandGenerateNormalDouble*(generator: curandGenerator_t;
                                   outputPtr: ptr cdouble; n: csize; mean: cdouble;
                                   stddev: cdouble): curandStatus_t {.cdecl,
       importc: "curandGenerateNormalDouble", dyn.}
   ## *
   ##  \brief Generate log-normally distributed floats.
-  ## 
+  ##
   ##  Use \p generator to generate \p n float results into the device memory at
   ##  \p outputPtr.  The device memory must have been previously allocated and be
   ##  large enough to hold all the results.  Launches are done with the stream
   ##  set using ::curandSetStream(), or the null stream if no stream has been set.
-  ## 
+  ##
   ##  Results are 32-bit floating point values with log-normal distribution based on
   ##  an associated normal distribution with mean \p mean and standard deviation \p stddev.
-  ## 
+  ##
   ##  Normally distributed results are generated from pseudorandom generators
   ##  with a Box-Muller transform, and so require \p n to be even.
-  ##  Quasirandom generators use an inverse cumulative distribution 
-  ##  function to preserve dimensionality. 
+  ##  Quasirandom generators use an inverse cumulative distribution
+  ##  function to preserve dimensionality.
   ##  The normally distributed results are transformed into log-normal distribution.
-  ## 
+  ##
   ##  There may be slight numerical differences between results generated
   ##  on the GPU with generators created with ::curandCreateGenerator()
   ##  and results calculated on the CPU with generators created with
@@ -762,14 +762,14 @@ when not defined(CURAND_H):
   ##  future versions of CURAND may use newer versions of the CUDA math
   ##  library, so different versions of CURAND may give slightly different
   ##  numerical values.
-  ## 
+  ##
   ##  \param generator - Generator to use
   ##  \param outputPtr - Pointer to device memory to store CUDA-generated results, or
   ##                  Pointer to host memory to store CPU-generated results
   ##  \param n - Number of floats to generate
   ##  \param mean - Mean of associated normal distribution
   ##  \param stddev - Standard deviation of associated normal distribution
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
   ##  - CURAND_STATUS_PREEXISTING_FAILURE if there was an existing error from
@@ -779,28 +779,28 @@ when not defined(CURAND_H):
   ##     not a multiple of the quasirandom dimension, or is not a multiple
   ##     of two for pseudorandom generators \n
   ##  - CURAND_STATUS_SUCCESS if the results were generated successfully \n
-  ## 
+  ##
   proc curandGenerateLogNormal*(generator: curandGenerator_t;
                                outputPtr: ptr cfloat; n: csize; mean: cfloat;
                                stddev: cfloat): curandStatus_t {.cdecl,
       importc: "curandGenerateLogNormal", dyn.}
   ## *
   ##  \brief Generate log-normally distributed doubles.
-  ## 
+  ##
   ##  Use \p generator to generate \p n double results into the device memory at
   ##  \p outputPtr.  The device memory must have been previously allocated and be
   ##  large enough to hold all the results.  Launches are done with the stream
   ##  set using ::curandSetStream(), or the null stream if no stream has been set.
-  ## 
+  ##
   ##  Results are 64-bit floating point values with log-normal distribution based on
   ##  an associated normal distribution with mean \p mean and standard deviation \p stddev.
-  ## 
+  ##
   ##  Normally distributed results are generated from pseudorandom generators
   ##  with a Box-Muller transform, and so require \p n to be even.
-  ##  Quasirandom generators use an inverse cumulative distribution 
+  ##  Quasirandom generators use an inverse cumulative distribution
   ##  function to preserve dimensionality.
   ##  The normally distributed results are transformed into log-normal distribution.
-  ## 
+  ##
   ##  There may be slight numerical differences between results generated
   ##  on the GPU with generators created with ::curandCreateGenerator()
   ##  and results calculated on the CPU with generators created with
@@ -809,14 +809,14 @@ when not defined(CURAND_H):
   ##  future versions of CURAND may use newer versions of the CUDA math
   ##  library, so different versions of CURAND may give slightly different
   ##  numerical values.
-  ## 
+  ##
   ##  \param generator - Generator to use
   ##  \param outputPtr - Pointer to device memory to store CUDA-generated results, or
   ##                  Pointer to host memory to store CPU-generated results
   ##  \param n - Number of doubles to generate
   ##  \param mean - Mean of normal distribution
   ##  \param stddev - Standard deviation of normal distribution
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
   ##  - CURAND_STATUS_PREEXISTING_FAILURE if there was an existing error from
@@ -827,22 +827,22 @@ when not defined(CURAND_H):
   ##     of two for pseudorandom generators \n
   ##  - CURAND_STATUS_DOUBLE_PRECISION_REQUIRED if the GPU does not support double precision \n
   ##  - CURAND_STATUS_SUCCESS if the results were generated successfully \n
-  ## 
+  ##
   proc curandGenerateLogNormalDouble*(generator: curandGenerator_t;
                                      outputPtr: ptr cdouble; n: csize; mean: cdouble;
                                      stddev: cdouble): curandStatus_t {.cdecl,
       importc: "curandGenerateLogNormalDouble", dyn.}
   ## *
   ##  \brief Construct the histogram array for a Poisson distribution.
-  ## 
+  ##
   ##  Construct the histogram array for the Poisson distribution with lambda \p lambda.
   ##  For lambda greater than 2000, an approximation with a normal distribution is used.
-  ## 
+  ##
   ##  \param lambda - lambda for the Poisson distribution
-  ## 
-  ## 
+  ##
+  ##
   ##  \param discrete_distribution - pointer to the histogram in device memory
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_ALLOCATION_FAILED if memory could not be allocated \n
   ##  - CURAND_STATUS_DOUBLE_PRECISION_REQUIRED if the GPU does not support double precision \n
@@ -852,38 +852,38 @@ when not defined(CURAND_H):
   ##     a previous kernel launch \n
   ##  - CURAND_STATUS_OUT_OF_RANGE if lambda is non-positive or greater than 400,000 \n
   ##  - CURAND_STATUS_SUCCESS if the histogram was generated successfully \n
-  ## 
+  ##
   proc curandCreatePoissonDistribution*(lambda: cdouble; discrete_distribution: ptr curandDiscreteDistribution_t): curandStatus_t {.
       cdecl, importc: "curandCreatePoissonDistribution", dyn.}
   ## *
   ##  \brief Destroy the histogram array for a discrete distribution (e.g. Poisson).
-  ## 
+  ##
   ##  Destroy the histogram array for a discrete distribution created by curandCreatePoissonDistribution.
-  ## 
+  ##
   ##  \param discrete_distribution - pointer to device memory where the histogram is stored
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the histogram was never created \n
   ##  - CURAND_STATUS_SUCCESS if the histogram was destroyed successfully \n
-  ## 
+  ##
   proc curandDestroyDistribution*(discrete_distribution: curandDiscreteDistribution_t): curandStatus_t {.
       cdecl, importc: "curandDestroyDistribution", dyn.}
   ## *
   ##  \brief Generate Poisson-distributed unsigned ints.
-  ## 
+  ##
   ##  Use \p generator to generate \p n unsigned int results into device memory at
   ##  \p outputPtr.  The device memory must have been previously allocated and must be
   ##  large enough to hold all the results.  Launches are done with the stream
   ##  set using ::curandSetStream(), or the null stream if no stream has been set.
-  ## 
+  ##
   ##  Results are 32-bit unsigned int point values with Poisson distribution, with lambda \p lambda.
-  ## 
+  ##
   ##  \param generator - Generator to use
   ##  \param outputPtr - Pointer to device memory to store CUDA-generated results, or
   ##                  Pointer to host memory to store CPU-generated results
   ##  \param n - Number of unsigned ints to generate
   ##  \param lambda - lambda for the Poisson distribution
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
   ##  - CURAND_STATUS_PREEXISTING_FAILURE if there was an existing error from
@@ -894,7 +894,7 @@ when not defined(CURAND_H):
   ##  - CURAND_STATUS_DOUBLE_PRECISION_REQUIRED if the GPU or sm does not support double precision \n
   ##  - CURAND_STATUS_OUT_OF_RANGE if lambda is non-positive or greater than 400,000 \n
   ##  - CURAND_STATUS_SUCCESS if the results were generated successfully \n
-  ## 
+  ##
   proc curandGeneratePoisson*(generator: curandGenerator_t; outputPtr: ptr cuint;
                              n: csize; lambda: cdouble): curandStatus_t {.cdecl,
       importc: "curandGeneratePoisson", dyn.}
@@ -913,104 +913,104 @@ when not defined(CURAND_H):
       cdecl, importc: "curandGenerateBinomialMethod", dyn.}
   ## *
   ##  \brief Setup starting states.
-  ## 
+  ##
   ##  Generate the starting state of the generator.  This function is
   ##  automatically called by generation functions such as
   ##  ::curandGenerate() and ::curandGenerateUniform().
   ##  It can be called manually for performance testing reasons to separate
   ##  timings for starting state generation and random number generation.
-  ## 
+  ##
   ##  \param generator - Generator to update
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_NOT_INITIALIZED if the generator was never created \n
-  ##  - CURAND_STATUS_PREEXISTING_FAILURE if there was an existing error from 
+  ##  - CURAND_STATUS_PREEXISTING_FAILURE if there was an existing error from
   ##      a previous kernel launch \n
   ##  - CURAND_STATUS_LAUNCH_FAILURE if the kernel launch failed for any reason \n
   ##  - CURAND_STATUS_SUCCESS if the seeds were generated successfully \n
-  ## 
+  ##
   proc curandGenerateSeeds*(generator: curandGenerator_t): curandStatus_t {.cdecl,
       importc: "curandGenerateSeeds", dyn.}
   ## *
   ##  \brief Get direction vectors for 32-bit quasirandom number generation.
-  ## 
+  ##
   ##  Get a pointer to an array of direction vectors that can be used
   ##  for quasirandom number generation.  The resulting pointer will
   ##  reference an array of direction vectors in host memory.
-  ## 
+  ##
   ##  The array contains vectors for many dimensions.  Each dimension
   ##  has 32 vectors.  Each individual vector is an unsigned int.
-  ## 
+  ##
   ##  Legal values for \p set are:
   ##  - CURAND_DIRECTION_VECTORS_32_JOEKUO6 (20,000 dimensions)
   ##  - CURAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6 (20,000 dimensions)
-  ## 
+  ##
   ##  \param vectors - Address of pointer in which to return direction vectors
   ##  \param set - Which set of direction vectors to use
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_OUT_OF_RANGE if the choice of set is invalid \n
   ##  - CURAND_STATUS_SUCCESS if the pointer was set successfully \n
-  ## 
+  ##
   proc curandGetDirectionVectors32*(vectors: ptr ptr curandDirectionVectors32_t;
                                    set: curandDirectionVectorSet_t): curandStatus_t {.
       cdecl, importc: "curandGetDirectionVectors32", dyn.}
   ## *
   ##  \brief Get scramble constants for 32-bit scrambled Sobol' .
-  ## 
+  ##
   ##  Get a pointer to an array of scramble constants that can be used
   ##  for quasirandom number generation.  The resulting pointer will
   ##  reference an array of unsinged ints in host memory.
-  ## 
+  ##
   ##  The array contains constants for many dimensions.  Each dimension
   ##  has a single unsigned int constant.
-  ## 
+  ##
   ##  \param constants - Address of pointer in which to return scramble constants
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_SUCCESS if the pointer was set successfully \n
-  ## 
+  ##
   proc curandGetScrambleConstants32*(constants: ptr ptr cuint): curandStatus_t {.
       cdecl, importc: "curandGetScrambleConstants32", dyn.}
   ## *
   ##  \brief Get direction vectors for 64-bit quasirandom number generation.
-  ## 
+  ##
   ##  Get a pointer to an array of direction vectors that can be used
   ##  for quasirandom number generation.  The resulting pointer will
   ##  reference an array of direction vectors in host memory.
-  ## 
+  ##
   ##  The array contains vectors for many dimensions.  Each dimension
   ##  has 64 vectors.  Each individual vector is an unsigned long long.
-  ## 
+  ##
   ##  Legal values for \p set are:
   ##  - CURAND_DIRECTION_VECTORS_64_JOEKUO6 (20,000 dimensions)
   ##  - CURAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6 (20,000 dimensions)
-  ## 
+  ##
   ##  \param vectors - Address of pointer in which to return direction vectors
   ##  \param set - Which set of direction vectors to use
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_OUT_OF_RANGE if the choice of set is invalid \n
   ##  - CURAND_STATUS_SUCCESS if the pointer was set successfully \n
-  ## 
+  ##
   proc curandGetDirectionVectors64*(vectors: ptr ptr curandDirectionVectors64_t;
                                    set: curandDirectionVectorSet_t): curandStatus_t {.
       cdecl, importc: "curandGetDirectionVectors64", dyn.}
   ## *
   ##  \brief Get scramble constants for 64-bit scrambled Sobol' .
-  ## 
+  ##
   ##  Get a pointer to an array of scramble constants that can be used
   ##  for quasirandom number generation.  The resulting pointer will
   ##  reference an array of unsinged long longs in host memory.
-  ## 
+  ##
   ##  The array contains constants for many dimensions.  Each dimension
   ##  has a single unsigned long long constant.
-  ## 
+  ##
   ##  \param constants - Address of pointer in which to return scramble constants
-  ## 
+  ##
   ##  \return
   ##  - CURAND_STATUS_SUCCESS if the pointer was set successfully \n
-  ## 
+  ##
   proc curandGetScrambleConstants64*(constants: ptr ptr culonglong): curandStatus_t {.
       cdecl, importc: "curandGetScrambleConstants64", dyn.}
   ## * @}

--- a/nimcuda/cusolverSp.nim
+++ b/nimcuda/cusolverSp.nim
@@ -14,15 +14,15 @@ else:
 import
   cuComplex
 
-## 
+##
 ##  Copyright 2014 NVIDIA Corporation.  All rights reserved.
-## 
+##
 ##  NOTICE TO LICENSEE:
-## 
+##
 ##  This source code and/or documentation ("Licensed Deliverables") are
 ##  subject to NVIDIA intellectual property rights under U.S. and
 ##  international Copyright laws.
-## 
+##
 ##  These Licensed Deliverables contained herein is PROPRIETARY and
 ##  CONFIDENTIAL to NVIDIA and is being provided under the terms and
 ##  conditions of a form of NVIDIA software license agreement by and
@@ -31,7 +31,7 @@ import
 ##  the contrary in the License Agreement, reproduction or disclosure
 ##  of the Licensed Deliverables to any third party without the express
 ##  written consent of NVIDIA is prohibited.
-## 
+##
 ##  NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
 ##  LICENSE AGREEMENT, NVIDIA MAKES NO REPRESENTATION ABOUT THE
 ##  SUITABILITY OF THESE LICENSED DELIVERABLES FOR ANY PURPOSE.  IT IS
@@ -46,7 +46,7 @@ import
 ##  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 ##  ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
 ##  OF THESE LICENSED DELIVERABLES.
-## 
+##
 ##  U.S. Government End Users.  These Licensed Deliverables are a
 ##  "commercial item" as that term is defined at 48 C.F.R. 2.101 (OCT
 ##  1995), consisting of "commercial computer software" and "commercial
@@ -56,12 +56,12 @@ import
 ##  48 C.F.R. 227.7202-1 through 227.7202-4 (JUNE 1995), all
 ##  U.S. Government End Users acquire the Licensed Deliverables with
 ##  only those rights set forth herein.
-## 
+##
 ##  Any use of the Licensed Deliverables in individual and commercial
 ##  software must include, in the user documentation and internal
 ##  comments to the code, the above Disclaimer and U.S. Government End
 ##  Users Notice.
-## 
+##
 
 when not defined(CUSOLVERSP_H):
   const
@@ -71,12 +71,12 @@ when not defined(CUSOLVERSP_H):
 
   type
     cusolverSpContext* = object
-    
+
   type
     cusolverSpHandle_t* = ptr cusolverSpContext
   type
     csrqrInfo* = object
-    
+
   type
     csrqrInfo_t* = ptr csrqrInfo
   proc cusolverSpCreate*(handle: ptr cusolverSpHandle_t): cusolverStatus_t {.cdecl,
@@ -92,12 +92,12 @@ when not defined(CUSOLVERSP_H):
                                csrEndPtrA: ptr cint; csrColIndA: ptr cint;
                                issym: ptr cint): cusolverStatus_t {.cdecl,
       importc: "cusolverSpXcsrissymHost", dyn.}
-  ##  -------- GPU linear solver based on LU factorization
-  ##        solve A*x = b, A can be singular 
+  ##  GPU linear solver based on LU factorization
+  ##  `      solve A*x = b, A can be singular `
   ##  [ls] stands for linear solve
   ##  [v] stands for vector
   ##  [lu] stands for LU factorization
-  ## 
+
   proc cusolverSpScsrlsvluHost*(handle: cusolverSpHandle_t; n: cint; nnzA: cint;
                                descrA: cusparseMatDescr_t; csrValA: ptr cfloat;
                                csrRowPtrA: ptr cint; csrColIndA: ptr cint;
@@ -123,12 +123,12 @@ when not defined(CUSOLVERSP_H):
                                tol: cdouble; reorder: cint; x: ptr cuDoubleComplex;
                                singularity: ptr cint): cusolverStatus_t {.cdecl,
       importc: "cusolverSpZcsrlsvluHost", dyn.}
-  ##  -------- GPU linear solver based on QR factorization
-  ##        solve A*x = b, A can be singular 
+  ##  GPU linear solver based on QR factorization
+  ##        solve A*x = b, A can be singular
   ##  [ls] stands for linear solve
   ##  [v] stands for vector
   ##  [qr] stands for QR factorization
-  ## 
+  ##
   proc cusolverSpScsrlsvqr*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                            descrA: cusparseMatDescr_t; csrVal: ptr cfloat;
                            csrRowPtr: ptr cint; csrColInd: ptr cint; b: ptr cfloat;
@@ -154,12 +154,12 @@ when not defined(CUSOLVERSP_H):
                            reorder: cint; x: ptr cuDoubleComplex;
                            singularity: ptr cint): cusolverStatus_t {.cdecl,
       importc: "cusolverSpZcsrlsvqr", dyn.}
-  ##  -------- CPU linear solver based on QR factorization
-  ##        solve A*x = b, A can be singular 
+  ##  CPU linear solver based on QR factorization
+  ##        solve A*x = b, A can be singular
   ##  [ls] stands for linear solve
   ##  [v] stands for vector
   ##  [qr] stands for QR factorization
-  ## 
+  ##
   proc cusolverSpScsrlsvqrHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                                descrA: cusparseMatDescr_t; csrValA: ptr cfloat;
                                csrRowPtrA: ptr cint; csrColIndA: ptr cint;
@@ -185,15 +185,15 @@ when not defined(CUSOLVERSP_H):
                                tol: cdouble; reorder: cint; x: ptr cuDoubleComplex;
                                singularity: ptr cint): cusolverStatus_t {.cdecl,
       importc: "cusolverSpZcsrlsvqrHost", dyn.}
-  ##  -------- CPU linear solver based on Cholesky factorization
-  ##        solve A*x = b, A can be singular 
+  ##  CPU linear solver based on Cholesky factorization
+  ##        solve A*x = b, A can be singular
   ##  [ls] stands for linear solve
   ##  [v] stands for vector
   ##  [chol] stands for Cholesky factorization
-  ## 
+  ##
   ##  Only works for symmetric positive definite matrix.
   ##  The upper part of A is ignored.
-  ## 
+  ##
   proc cusolverSpScsrlsvcholHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                                  descrA: cusparseMatDescr_t; csrVal: ptr cfloat;
                                  csrRowPtr: ptr cint; csrColInd: ptr cint;
@@ -220,15 +220,15 @@ when not defined(CUSOLVERSP_H):
                                  tol: cdouble; reorder: cint;
                                  x: ptr cuDoubleComplex; singularity: ptr cint): cusolverStatus_t {.
       cdecl, importc: "cusolverSpZcsrlsvcholHost", dyn.}
-  ##  -------- GPU linear solver based on Cholesky factorization
-  ##        solve A*x = b, A can be singular 
+  ##  GPU linear solver based on Cholesky factorization
+  ##        solve A*x = b, A can be singular
   ##  [ls] stands for linear solve
   ##  [v] stands for vector
   ##  [chol] stands for Cholesky factorization
-  ## 
+  ##
   ##  Only works for symmetric positive definite matrix.
   ##  The upper part of A is ignored.
-  ## 
+  ##
   proc cusolverSpScsrlsvchol*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                              descrA: cusparseMatDescr_t; csrVal: ptr cfloat;
                              csrRowPtr: ptr cint; csrColInd: ptr cint; b: ptr cfloat;
@@ -258,12 +258,12 @@ when not defined(CUSOLVERSP_H):
                              singularity: ptr cint): cusolverStatus_t {.cdecl,
       importc: "cusolverSpZcsrlsvchol", dyn.}
     ##  output
-  ##  ----------- CPU least square solver based on QR factorization
-  ##        solve min|b - A*x| 
+  ##  CPU least square solver based on QR factorization
+  ##        solve min|b - A*x|
   ##  [lsq] stands for least square
   ##  [v] stands for vector
   ##  [qr] stands for QR factorization
-  ## 
+  ##
   proc cusolverSpScsrlsqvqrHost*(handle: cusolverSpHandle_t; m: cint; n: cint;
                                 nnz: cint; descrA: cusparseMatDescr_t;
                                 csrValA: ptr cfloat; csrRowPtrA: ptr cint;
@@ -293,12 +293,12 @@ when not defined(CUSOLVERSP_H):
                                 x: ptr cuDoubleComplex; p: ptr cint;
                                 min_norm: ptr cdouble): cusolverStatus_t {.cdecl,
       importc: "cusolverSpZcsrlsqvqrHost", dyn.}
-  ##  --------- CPU eigenvalue solver based on shift inverse
-  ##       solve A*x = lambda * x 
+  ##  CPU eigenvalue solver based on shift inverse
+  ##       solve A*x = lambda * x
   ##    where lambda is the eigenvalue nearest mu0.
   ##  [eig] stands for eigenvalue solver
   ##  [si] stands for shift-inverse
-  ## 
+  ##
   proc cusolverSpScsreigvsiHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                                 descrA: cusparseMatDescr_t; csrValA: ptr cfloat;
                                 csrRowPtrA: ptr cint; csrColIndA: ptr cint;
@@ -325,12 +325,12 @@ when not defined(CUSOLVERSP_H):
                                 x0: ptr cuDoubleComplex; maxite: cint; tol: cdouble;
                                 mu: ptr cuDoubleComplex; x: ptr cuDoubleComplex): cusolverStatus_t {.
       cdecl, importc: "cusolverSpZcsreigvsiHost", dyn.}
-  ##  --------- GPU eigenvalue solver based on shift inverse
-  ##       solve A*x = lambda * x 
+  ##  GPU eigenvalue solver based on shift inverse
+  ##       solve A*x = lambda * x
   ##    where lambda is the eigenvalue nearest mu0.
   ##  [eig] stands for eigenvalue solver
   ##  [si] stands for shift-inverse
-  ## 
+  ##
   proc cusolverSpScsreigvsi*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                             descrA: cusparseMatDescr_t; csrValA: ptr cfloat;
                             csrRowPtrA: ptr cint; csrColIndA: ptr cint; mu0: cfloat;
@@ -356,7 +356,7 @@ when not defined(CUSOLVERSP_H):
                             x0: ptr cuDoubleComplex; maxite: cint; eps: cdouble;
                             mu: ptr cuDoubleComplex; x: ptr cuDoubleComplex): cusolverStatus_t {.
       cdecl, importc: "cusolverSpZcsreigvsi", dyn.}
-  ##  ----------- enclosed eigenvalues
+  ##  enclosed eigenvalues
   proc cusolverSpScsreigsHost*(handle: cusolverSpHandle_t; m: cint; nnz: cint;
                               descrA: cusparseMatDescr_t; csrValA: ptr cfloat;
                               csrRowPtrA: ptr cint; csrColIndA: ptr cint;
@@ -384,34 +384,34 @@ when not defined(CUSOLVERSP_H):
                               right_upper_corner: cuDoubleComplex;
                               num_eigs: ptr cint): cusolverStatus_t {.cdecl,
       importc: "cusolverSpZcsreigsHost", dyn.}
-  ##  --------- CPU symrcm
-  ##    Symmetric reverse Cuthill McKee permutation         
-  ## 
-  ## 
+  ##  CPU symrcm
+  ##    Symmetric reverse Cuthill McKee permutation
+  ##
+  ##
   proc cusolverSpXcsrsymrcmHost*(handle: cusolverSpHandle_t; n: cint; nnzA: cint;
                                 descrA: cusparseMatDescr_t; csrRowPtrA: ptr cint;
                                 csrColIndA: ptr cint; p: ptr cint): cusolverStatus_t {.
       cdecl, importc: "cusolverSpXcsrsymrcmHost", dyn.}
-  ##  --------- CPU symmdq 
+  ##  CPU symmdq
   ##    Symmetric minimum degree algorithm based on quotient graph
-  ## 
-  ## 
+  ##
+  ##
   proc cusolverSpXcsrsymmdqHost*(handle: cusolverSpHandle_t; n: cint; nnzA: cint;
                                 descrA: cusparseMatDescr_t; csrRowPtrA: ptr cint;
                                 csrColIndA: ptr cint; p: ptr cint): cusolverStatus_t {.
       cdecl, importc: "cusolverSpXcsrsymmdqHost", dyn.}
-  ##  --------- CPU symmdq 
+  ##  CPU symmdq
   ##    Symmetric Approximate minimum degree algorithm based on quotient graph
-  ## 
-  ## 
+  ##
+  ##
   proc cusolverSpXcsrsymamdHost*(handle: cusolverSpHandle_t; n: cint; nnzA: cint;
                                 descrA: cusparseMatDescr_t; csrRowPtrA: ptr cint;
                                 csrColIndA: ptr cint; p: ptr cint): cusolverStatus_t {.
       cdecl, importc: "cusolverSpXcsrsymamdHost", dyn.}
-  ##  --------- CPU permuation
-  ##    P*A*Q^T        
-  ## 
-  ## 
+  ##  CPU permuation
+  ##    P*A*Q^T
+  ##
+  ##
   proc cusolverSpXcsrperm_bufferSizeHost*(handle: cusolverSpHandle_t; m: cint;
       n: cint; nnzA: cint; descrA: cusparseMatDescr_t; csrRowPtrA: ptr cint;
       csrColIndA: ptr cint; p: ptr cint; q: ptr cint; bufferSizeInBytes: ptr csize): cusolverStatus_t {.
@@ -421,10 +421,10 @@ when not defined(CUSOLVERSP_H):
                               csrRowPtrA: ptr cint; csrColIndA: ptr cint; p: ptr cint;
                               q: ptr cint; map: ptr cint; pBuffer: pointer): cusolverStatus_t {.
       cdecl, importc: "cusolverSpXcsrpermHost", dyn.}
-  ## 
+  ##
   ##   Low-level API: Batched QR
-  ## 
-  ## 
+  ##
+  ##
   proc cusolverSpCreateCsrqrInfo*(info: ptr csrqrInfo_t): cusolverStatus_t {.cdecl,
       importc: "cusolverSpCreateCsrqrInfo", dyn.}
   proc cusolverSpDestroyCsrqrInfo*(info: csrqrInfo_t): cusolverStatus_t {.cdecl,

--- a/nimcuda/driver_types.nim
+++ b/nimcuda/driver_types.nim
@@ -121,8 +121,8 @@ when not defined(DRIVER_TYPES_H):
       cudaMemAttachSingle* = 0x00000004
       cudaOccupancyDefault* = 0x00000000
       cudaOccupancyDisableCachingOverride* = 0x00000001
-      cudaCpuDeviceId* = cint(-1) ## *< Device id that represents the CPU
-      cudaInvalidDeviceId* = cint(-2) ## *< Device id that represents an invalid device
+      cudaCpuDeviceId* = cint(-1) ## < Device id that represents the CPU
+      cudaInvalidDeviceId* = cint(-2) ## < Device id that represents an invalid device
   ## ******************************************************************************
   ##                                                                               *
   ##                                                                               *

--- a/nimcuda/nvgraph.nim
+++ b/nimcuda/nvgraph.nim
@@ -17,16 +17,16 @@ else:
 import
   library_types
 
-## 
+##
 ##  Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
-## 
+##
 ##  NVIDIA CORPORATION and its licensors retain all intellectual property
 ##  and proprietary rights in and to this software, related documentation
 ##  and any modifications thereto.  Any use, reproduction, disclosure or
 ##  distribution of this software and related documentation without an express
 ##  license agreement from NVIDIA CORPORATION is strictly prohibited.
-## 
-## 
+##
+##
 
 ##  nvGRAPH status type returns
 
@@ -45,14 +45,14 @@ proc nvgraphStatusGetString*(status: nvgraphStatus_t): cstring {.cdecl,
 
 type
   nvgraphContext* = object
-  
+
   nvgraphHandle_t* = ptr nvgraphContext
 
 ##  Opaque structure holding the graph descriptor
 
 type
   nvgraphGraphDescr* = object
-  
+
   nvgraphGraphDescr_t* = ptr nvgraphGraphDescr
 
 ##  Semi-ring types
@@ -70,7 +70,7 @@ type
     NVGRAPH_CSR_32 = 0, NVGRAPH_CSC_32 = 1, NVGRAPH_COO_32 = 2
   nvgraphTag_t* {.size: sizeof(cint).} = enum
     NVGRAPH_DEFAULT = 0,        ##  Default is unsorted.
-    NVGRAPH_UNSORTED = 1,       ## 
+    NVGRAPH_UNSORTED = 1,       ##
     NVGRAPH_SORTED_BY_SOURCE = 2, ##  CSR
     NVGRAPH_SORTED_BY_DESTINATION = 3
 
@@ -82,14 +82,14 @@ type
     nedges*: cint              ##  nnz
     source_offsets*: ptr cint   ##  rowPtr
     destination_indices*: ptr cint ##  colInd
-  
+
   nvgraphCSRTopology32I_t* = ptr nvgraphCSRTopology32I_st
   nvgraphCSCTopology32I_st* = object
     nvertices*: cint           ##  n+1
     nedges*: cint              ##  nnz
     destination_offsets*: ptr cint ##  colPtr
     source_indices*: ptr cint   ##  rowInd
-  
+
   nvgraphCSCTopology32I_t* = ptr nvgraphCSCTopology32I_st
   nvgraphCOOTopology32I_st* = object
     nvertices*: cint           ##  n+1
@@ -142,20 +142,20 @@ proc nvgraphAllocateVertexData*(handle: nvgraphHandle_t;
 proc nvgraphAllocateEdgeData*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                              numsets: csize; settypes: ptr cudaDataType): nvgraphStatus_t {.
     cdecl, importc: "nvgraphAllocateEdgeData", dyn.}
-##  Update the vertex set #setnum with the data in *vertexData, sets have 0-based index
+##  `Update the vertex set #setnum with the data in *vertexData, sets have 0-based index`
 ##   Conversions are not sopported so nvgraphTopologyType_t should match the graph structure
 
 proc nvgraphSetVertexData*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                           vertexData: pointer; setnum: csize): nvgraphStatus_t {.
     cdecl, importc: "nvgraphSetVertexData", dyn.}
-##  Copy the edge set #setnum in *edgeData, sets have 0-based index
+##  `Copy the edge set #setnum in *edgeData, sets have 0-based index`
 ##   Conversions are not sopported so nvgraphTopologyType_t should match the graph structure
 
 proc nvgraphGetVertexData*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                           vertexData: pointer; setnum: csize): nvgraphStatus_t {.
     cdecl, importc: "nvgraphGetVertexData", dyn.}
 ##  Convert the edge data to another topology
-## 
+##
 
 proc nvgraphConvertTopology*(handle: nvgraphHandle_t;
                             srcTType: nvgraphTopologyType_t; srcTopology: pointer;
@@ -164,26 +164,26 @@ proc nvgraphConvertTopology*(handle: nvgraphHandle_t;
                             dstEdgeData: pointer): nvgraphStatus_t {.cdecl,
     importc: "nvgraphConvertTopology", dyn.}
 ##  Convert graph to another structure
-## 
+##
 
 proc nvgraphConvertGraph*(handle: nvgraphHandle_t; srcDescrG: nvgraphGraphDescr_t;
                          dstDescrG: nvgraphGraphDescr_t;
                          dstTType: nvgraphTopologyType_t): nvgraphStatus_t {.cdecl,
     importc: "nvgraphConvertGraph", dyn.}
-##  Update the edge set #setnum with the data in *edgeData, sets have 0-based index
+##  `Update the edge set #setnum with the data in *edgeData, sets have 0-based index`
 ##   Conversions are not sopported so nvgraphTopologyType_t should match the graph structure
 
 proc nvgraphSetEdgeData*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                         edgeData: pointer; setnum: csize): nvgraphStatus_t {.cdecl,
     importc: "nvgraphSetEdgeData", dyn.}
-##  Copy the edge set #setnum in *edgeData, sets have 0-based index
+##  `Copy the edge set #setnum in *edgeData, sets have 0-based index`
 ##  Conversions are not sopported so nvgraphTopologyType_t should match the graph structure
 
 proc nvgraphGetEdgeData*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                         edgeData: pointer; setnum: csize): nvgraphStatus_t {.cdecl,
     importc: "nvgraphGetEdgeData", dyn.}
 ##  create a new graph by extracting a subgraph given a list of vertices
-## 
+##
 
 proc nvgraphExtractSubgraphByVertex*(handle: nvgraphHandle_t;
                                     descrG: nvgraphGraphDescr_t;
@@ -191,7 +191,7 @@ proc nvgraphExtractSubgraphByVertex*(handle: nvgraphHandle_t;
                                     subvertices: ptr cint; numvertices: csize): nvgraphStatus_t {.
     cdecl, importc: "nvgraphExtractSubgraphByVertex", dyn.}
 ##  create a new graph by extracting a subgraph given a list of edges
-## 
+##
 
 proc nvgraphExtractSubgraphByEdge*(handle: nvgraphHandle_t;
                                   descrG: nvgraphGraphDescr_t;
@@ -199,7 +199,7 @@ proc nvgraphExtractSubgraphByEdge*(handle: nvgraphHandle_t;
                                   subedges: ptr cint; numedges: csize): nvgraphStatus_t {.
     cdecl, importc: "nvgraphExtractSubgraphByEdge", dyn.}
 ##  nvGRAPH Semi-ring sparse matrix vector multiplication
-## 
+##
 
 proc nvgraphSrSpmv*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                    weight_index: csize; alpha: pointer; x_index: csize; beta: pointer;
@@ -207,14 +207,14 @@ proc nvgraphSrSpmv*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
     importc: "nvgraphSrSpmv", dyn.}
 ##  nvGRAPH Single Source Shortest Path (SSSP)
 ##  Calculate the shortest path distance from a single vertex in the graph to all other vertices.
-## 
+##
 
 proc nvgraphSssp*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                  weight_index: csize; source_vert: ptr cint; sssp_index: csize): nvgraphStatus_t {.
     cdecl, importc: "nvgraphSssp", dyn.}
 ##  nvGRAPH WidestPath
 ##  Find widest path potential from source_index to every other vertices.
-## 
+##
 
 proc nvgraphWidestPath*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                        weight_index: csize; source_vert: ptr cint;
@@ -222,7 +222,7 @@ proc nvgraphWidestPath*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
     importc: "nvgraphWidestPath", dyn.}
 ##  nvGRAPH PageRank
 ##  Find PageRank for each vertex of a graph with a given transition probabilities, a bookmark vector of dangling vertices, and the damping factor.
-## 
+##
 
 proc nvgraphPagerank*(handle: nvgraphHandle_t; descrG: nvgraphGraphDescr_t;
                      weight_index: csize; alpha: pointer; bookmark_index: csize;


### PR DESCRIPTION
So this is mostly a pretty hacky emacs macro job. I just escaped all lines that contain a `*` in accented quotes and fixed a couple of other small things that `nim doc` complained about.

This means the docs are now created successfully, although they are rather ugly. 