### PR TITLE
Update nimcuda.nimble

### DIFF
--- a/nimcuda.nimble
+++ b/nimcuda.nimble
@@ -10,7 +10,7 @@ skipDirs      = @["headers", "include", "c2nim", "examples", "htmldocs"]
 
 requires "nim >= 0.16.0"
 
-import ospaths, strutils
+import os, strutils
 
 proc patch(libName: string): string =
   when defined(windows):


### PR DESCRIPTION
I am working on removing old deprecated stuff from Nim, like pre- `1.0` or so,
your package is on important packages list and still uses Deprecated `ospaths`.
:)
